### PR TITLE
fixed expiry date

### DIFF
--- a/server/src/content/student/useCases/OnlineStore.ts
+++ b/server/src/content/student/useCases/OnlineStore.ts
@@ -6,8 +6,13 @@ import { StepType } from '../../types'
 
 const URL = '/public/student/useCases/store'
 
-const date = new Date()
-const todayDate = Number(date.toISOString().split('T')[0].replace(/-/g, ''))
+
+// need to limit the scope of `date` so that is it destroyed and 
+// re-created whenever we send a proof request
+function getDate() {
+  const date = new Date()
+  return Number(date.toISOString().split('T')[0].replace(/-/g, ''))
+}
 
 export const OnlineStore: UseCase = {
   slug: 'store',
@@ -59,7 +64,7 @@ export const OnlineStore: UseCase = {
           name: 'Student Card',
           icon: '/public/student/icon-student.svg',
           // properties: ['expiry_date'],
-          predicates: { name: 'expiry_date', value: todayDate, type: '>' },
+          predicates: { name: 'expiry_date', value: getDate(), type: '>=' },
         },
       ],
       issueCredentials: [],


### PR DESCRIPTION
expiry date was not being updated on proof request due to the date object being in a high scope. This meant that the date object was created once when the demo is started, but it was not updated for each proof request.

Resolves: #37 