### PR TITLE
updated the expiry date attribute and predicate

### DIFF
--- a/client/src/slices/types.ts
+++ b/client/src/slices/types.ts
@@ -51,7 +51,7 @@ export interface RequestedCredential {
   name: string
   icon: string
   properties?: string[]
-  predicates?: { name: string; value: string | number; type: string }
+  predicates?: { name: string; value?: string | number | (() => string | number); type: string }
   credentialDefinitionId?: string
 }
 

--- a/server/src/content/student/Student.ts
+++ b/server/src/content/student/Student.ts
@@ -21,11 +21,11 @@ export const Student: Character = {
         { name: 'student_last_name', value: 'Smith' },
         {
           name: 'expiry_date',
-          value: (function () {
+          value() {
             const expiry = new Date()
             expiry.setFullYear(expiry.getFullYear() + 4)
             return expiry.toISOString().split('T')[0].replace(/-/g, '')
-          })(),
+          },
         },
       ],
     },

--- a/server/src/content/student/useCases/OnlineStore.ts
+++ b/server/src/content/student/useCases/OnlineStore.ts
@@ -6,14 +6,6 @@ import { StepType } from '../../types'
 
 const URL = '/public/student/useCases/store'
 
-
-// need to limit the scope of `date` so that is it destroyed and 
-// re-created whenever we send a proof request
-function getDate() {
-  const date = new Date()
-  return Number(date.toISOString().split('T')[0].replace(/-/g, ''))
-}
-
 export const OnlineStore: UseCase = {
   slug: 'store',
   card: {
@@ -64,7 +56,12 @@ export const OnlineStore: UseCase = {
           name: 'Student Card',
           icon: '/public/student/icon-student.svg',
           // properties: ['expiry_date'],
-          predicates: { name: 'expiry_date', value: getDate(), type: '>=' },
+          predicates: {
+            name: 'expiry_date', value() {
+              const date = new Date()
+              return Number(date.toISOString().split('T')[0].replace(/-/g, ''))
+            }, type: '>='
+          },
         },
       ],
       issueCredentials: [],

--- a/server/src/content/types.ts
+++ b/server/src/content/types.ts
@@ -50,7 +50,7 @@ export interface RequestedCredential {
   name: string
   icon: string
   properties?: string[]
-  predicates?: { name: string; value: string | number; type: string }
+  predicates?: { name: string; value?: string | number | (() => string | number); type: string }
   credentialDefinitionId?: string
 }
 
@@ -74,7 +74,7 @@ export interface IssueCredential {
 
 export interface Attribute {
   name: string
-  value: string | number
+  value: string | number | (() => string | number)
 }
 
 export interface StepperItem {


### PR DESCRIPTION
Patched the issue with the expiry date on the proof request predicate and credential attribute.  
Previously the function to get the date was only being called once when the app started up so the date would only be updated once.  
I changed the value of the expiry_date attribute to be a computed value so that it is updated whenever it is used

Resolves: #37 