### PR TITLE
added the ability to label onboarding conn

### DIFF
--- a/client/src/pages/onboarding/steps/SetupConnection.tsx
+++ b/client/src/pages/onboarding/steps/SetupConnection.tsx
@@ -62,7 +62,7 @@ export const SetupConnection: React.FC<Props> = ({
   const isCompleted = connectionState === 'responded' || connectionState === 'complete'
 
   useEffect(() => {
-    if (!isCompleted) dispatch(createInvitation())
+    if (!isCompleted) dispatch(createInvitation(currentCharacter?.onboardingEntity))
   }, [])
 
   useEffect(() => {

--- a/client/src/slices/types.ts
+++ b/client/src/slices/types.ts
@@ -23,6 +23,7 @@ export interface Character {
   backgroundImage?: string
   onboardingText?: string
   starterCredentials: CredentialData[]
+  onboardingEntity?: Entity
 }
 
 export interface UseCase {

--- a/server/src/content/businessWoman/BusinessWoman.ts
+++ b/server/src/content/businessWoman/BusinessWoman.ts
@@ -41,4 +41,8 @@ export const BusinessWoman: Character = {
       ],
     },
   ],
+  onboardingEntity:{
+    name:"Law Society BC",
+    icon:"#"
+  }
 }

--- a/server/src/content/student/Student.ts
+++ b/server/src/content/student/Student.ts
@@ -48,4 +48,8 @@ export const Student: Character = {
       ],
     },
   ],
+  onboardingEntity:{
+    name:"BestBC College",
+    icon:"#"
+  }
 }

--- a/server/src/content/types.ts
+++ b/server/src/content/types.ts
@@ -8,6 +8,7 @@ export interface Character {
   backgroundImage?: string
   onboardingText?: string
   starterCredentials: StarterCredential[]
+  onboardingEntity?: Entity
 }
 
 export interface UseCase {


### PR DESCRIPTION
Added `BestBC College` and `Law Society BC` labels to onboarding connection invitations. This allows BC Wallet to properly display the connection labels from the demo:

![bestbc](https://user-images.githubusercontent.com/36937407/185240419-b187138e-ac81-4edb-b3e0-2812c8cc0198.png)
![lsbc](https://user-images.githubusercontent.com/36937407/185240422-db2b2d62-7bae-4da2-b586-664ccaf69f2b.png)
