### PR TITLE
fix: retry credential and proof requests on timeout

### DIFF
--- a/client/src/slices/credentials/credentialsThunks.ts
+++ b/client/src/slices/credentials/credentialsThunks.ts
@@ -20,8 +20,17 @@ export const issueCredential = createAsyncThunk(
 export const issueDeepCredential = createAsyncThunk(
   'credentials/issueCredential',
   async (data: { connectionId: string; cred: CredentialData }) => {
-    const response = await Api.issueDeepCredential(data.connectionId, data.cred)
-    return response.data
+    let success = false
+    let response = undefined
+    while (!success) {
+      try {
+        response = await Api.issueDeepCredential(data.connectionId, data.cred)
+        success = true
+      } catch {
+        // pass
+      }
+    }
+    return response?.data
   }
 )
 

--- a/client/src/slices/proof/proofThunks.ts
+++ b/client/src/slices/proof/proofThunks.ts
@@ -10,8 +10,17 @@ export const createProof = createAsyncThunk('proof/createProof', async (data: Pr
 })
 
 export const createDeepProof = createAsyncThunk('proof/createProof', async (data: ProofRequestData) => {
-  const response = await Api.createDeepProofRequest(data)
-  return response.data
+  let success = false
+  let response = undefined
+  while (!success) {
+    try {
+      response = await await Api.createDeepProofRequest(data)
+      success = true
+    } catch {
+      // pass
+    }
+  }
+  return response?.data
 })
 
 export const createProofOOB = createAsyncThunk('proof/createProofOOB', async (data: ProofRequestData) => {


### PR DESCRIPTION
Signed-off-by: wadeking98 <wkingnumber2@gmail.com>

Support for this PR: https://github.com/hyperledger/aries-mobile-agent-react-native
Allows deeplinking to work from locked wallet state. Previously the credential offer or proof request connection would timeout and fail due to the amount of time required to unlock bcwallet. These changes make the showcase retry connection request when they timeout.