### PR TITLE
feat: added support for photo attribute proof

### DIFF
--- a/client/src/pages/useCase/components/ProofAttributesCard.tsx
+++ b/client/src/pages/useCase/components/ProofAttributesCard.tsx
@@ -5,6 +5,7 @@ import React, { useEffect, useState } from 'react'
 
 import { CheckMark } from '../../../components/Checkmark'
 import { Loader } from '../../../components/Loader'
+import { isDataUrl } from '../../../utils/Helpers'
 import { getAttributesFromProof } from '../../../utils/ProofUtils'
 import { prependApiUrl } from '../../../utils/Url'
 
@@ -50,12 +51,21 @@ export const ProofAttributesCard: React.FC<Props> = ({ entityName, requestedCred
             const value = values.find((x) => x.name === prop)?.value
             return (
               <div key={prop} className="flex flex-row">
-                <p className="flex-1-1 text-sm bg-bcgov-lightgrey dark:bg-bcgov-darkgrey p-1 px-2 rounded-lg my-1 md:m-2">
-                  {prop.charAt(0).toUpperCase() + prop.slice(1)}
-                </p>
-                <p className="flex-1 text-sm bg-white dark:bg-grey p-1 px-2 rounded-lg m-2 truncate">
-                  {value && prop.includes('Date') ? formatDate(value) : value}
-                </p>
+                <div
+                  style={{ justifySelf: 'center', alignSelf: 'center' }}
+                  className="flex-1-1 text-sm bg-bcgov-lightgrey dark:bg-bcgov-darkgrey p-1 px-2 rounded-lg my-1 md:m-2"
+                >
+                  <p>{prop.charAt(0).toUpperCase() + prop.slice(1)}</p>
+                </div>
+                {isDataUrl(value) ? (
+                  <div className="text-sm bg-white dark:bg-grey p-1 px-2 rounded-lg m-2 truncate">
+                    <img src={value} style={{ height: 100 }} />
+                  </div>
+                ) : (
+                  <p className="flex-1 text-sm bg-white dark:bg-grey p-1 px-2 rounded-lg m-2 truncate">
+                    {value && prop.includes('Date') ? formatDate(value) : value}
+                  </p>
+                )}
               </div>
             )
           })}

--- a/client/src/utils/Helpers.ts
+++ b/client/src/utils/Helpers.ts
@@ -2,6 +2,10 @@ export const isConnected = (state: string) => {
   return state === 'complete' || state === 'response' || state === 'active'
 }
 
+export const isDataUrl = (value?: string) => {
+  return value && value.startsWith('data:image/')
+}
+
 export const isCredIssued = (state: string) => {
   return state === 'credential_issued' || state === 'done' || state === 'credential_acked'
 }

--- a/server/config/lawyerCustom.ts
+++ b/server/config/lawyerCustom.ts
@@ -1,4 +1,5 @@
 import type { CustomCharacter } from '../src/content/types'
+
 import { getDateInt } from '../src/utils/dateint'
 export const lawyerCustom: CustomCharacter = {
   name: 'Joyce',
@@ -232,6 +233,52 @@ export const lawyerCustom: CustomCharacter = {
           screenId: 'STEP_END',
           title: "You're done!",
           text: 'You’ve proved to Court Services Branch that you’re a practising lawyer from B.C. and your identity using your Person credential. You can now access court materials online from the comfort of your own home. It only took a few seconds and you revealed minimal information that Court Services Branch could easily and automatically trust.',
+          image: '/public/lawyer2/onboarding/lawyer2Success.svg',
+        },
+      ],
+    },
+    {
+      id: 'courtLibrary',
+      name: 'Court Library',
+      screens: [
+        {
+          screenId: 'START',
+          title: 'Gain access to the Court Library in person',
+          text: 'Joyce wants to gain access to the court library using her digital credentials. The court library requires that joyce provides photo identification.',
+          image: '/public/lawyer2/useCases/courtServices/bothCreds.svg',
+        },
+        {
+          screenId: 'CONNECTION',
+          title: 'Start proving you’re a lawyer',
+          text: 'As Joyce you’re now ready to prove you’re a practising lawyer in B.C. to the court library. Scan the QR code.',
+          image: '/public/lawyer2/useCases/courtServices/courtServicesOverlay.png',
+          verifier: { name: 'Court Library', icon: '/public/lawyer2/connection/lsbc-logo.png' },
+        },
+        {
+          screenId: 'PROOF',
+          title: 'Confirm the information to send',
+          text: 'BC Wallet will now ask you to confirm what to send. Notice how you’re not sharing your entire credential. The Court Library is requesting that you prove only what is needed.',
+          requestOptions: {
+            title: 'Court Library (DEMO) Request',
+            text: 'Court Library (DEMO) would like some of your personal information.',
+            requestedCredentials: [
+              {
+                icon: '/public/lawyer2/connection/lsbc-logo.png',
+                name: 'member_card',
+                properties: ['Given Name', 'Surname', 'PPID'],
+              },
+              {
+                icon: '/public/lawyer2/connection/bc-logo.png',
+                name: 'Person',
+                properties: ['given_names', 'family_name', 'picture'],
+              },
+            ],
+          },
+        },
+        {
+          screenId: 'STEP_END',
+          title: "You're done!",
+          text: 'You’ve proved to the Court Library that you’re a practising lawyer from B.C. and your identity using your Person credential. You can now access court materials online from the comfort of your own home. It only took a few seconds and you revealed minimal information that Court Services Branch could easily and automatically trust.',
           image: '/public/lawyer2/onboarding/lawyer2Success.svg',
         },
       ],

--- a/server/config/studentCustom.ts
+++ b/server/config/studentCustom.ts
@@ -1,4 +1,5 @@
 import type { CustomCharacter } from '../src/content/types'
+
 import { getDateInt } from '../src/utils/dateint'
 export const studentCustom: CustomCharacter = {
   name: 'Alice',

--- a/server/src/utils/dateint.ts
+++ b/server/src/utils/dateint.ts
@@ -1,5 +1,5 @@
 export const getDateInt = (offsetYear?: number) => {
-        const pastDate = new Date()
-        pastDate.setFullYear(pastDate.getFullYear() + (offsetYear ?? 0))
-        return parseInt(pastDate.toISOString().split('T')[0].replace(/-/g, ''))
+  const pastDate = new Date()
+  pastDate.setFullYear(pastDate.getFullYear() + (offsetYear ?? 0))
+  return parseInt(pastDate.toISOString().split('T')[0].replace(/-/g, ''))
 }


### PR DESCRIPTION
Added support for photo attribute proof in bc wallet demo lawyer showcase.
photo attribute is in the court library scenario.

<img width="911" alt="image" src="https://github.com/bcgov/BC-Wallet-Demo/assets/36937407/922660c8-0a6d-4949-a722-44653e45ed25">
