### PR TITLE
feat: added schema id to proofs for oca branding

### DIFF
--- a/client/src/pages/useCase/steps/StepProof.tsx
+++ b/client/src/pages/useCase/steps/StepProof.tsx
@@ -50,24 +50,31 @@ export const StepProof: React.FC<Props> = ({
     const predicates: any = []
 
     requestedCredentials?.forEach((item) => {
+      const restrictions: any[] = [
+        {
+          schema_name: item.name,
+        },
+      ]
+      if (item.schema_id) {
+        restrictions.push({
+          schema_id: item.schema_id,
+        })
+      }
+      if (item.cred_def_id) {
+        restrictions.push({
+          cred_def_id: item.cred_def_id,
+        })
+      }
       if (item.properties) {
         proofs[item.name] = {
-          restrictions: [
-            {
-              schema_name: item.name,
-            },
-          ],
+          restrictions,
           names: item.properties,
           non_revoked: item.nonRevoked,
         }
       }
       if (item.predicates) {
         predicates[item.name] = {
-          restrictions: [
-            {
-              schema_name: item.name,
-            },
-          ],
+          restrictions,
           name: item.predicates?.name,
           p_value: item.predicates?.value,
           p_type: item.predicates?.type,

--- a/client/src/slices/types.ts
+++ b/client/src/slices/types.ts
@@ -45,6 +45,8 @@ export interface OnboardingStep {
 export interface CredentialRequest {
   name: string
   icon?: string
+  schema_id?: string
+  cred_def_id?: string
   predicates?: { name: string; value?: string | number | (() => string | number); type: string }
   properties?: string[]
   nonRevoked?: { to: number; from?: number }

--- a/server/config/lawyerCustom.ts
+++ b/server/config/lawyerCustom.ts
@@ -222,11 +222,13 @@ export const lawyerCustom: CustomCharacter = {
               {
                 icon: '/public/lawyer2/connection/lsbc-logo.png',
                 name: 'member_card',
+                schema_id: 'QEquAHkM35w4XVT3Ku5yat:2:member_card:1.54',
                 properties: ['Given Name', 'Surname', 'PPID'],
               },
               {
                 icon: '/public/lawyer2/connection/bc-logo.png',
                 name: 'Person',
+                schema_id: 'QEquAHkM35w4XVT3Ku5yat:2:Person:1.3',
                 properties: ['given_names', 'family_name'],
               },
             ],
@@ -269,12 +271,14 @@ export const lawyerCustom: CustomCharacter = {
               {
                 icon: '/public/lawyer2/connection/lsbc-logo.png',
                 name: 'member_card',
+                schema_id: 'QEquAHkM35w4XVT3Ku5yat:2:member_card:1.54',
                 properties: ['Given Name', 'Surname', 'PPID'],
                 nonRevoked: { to: now() },
               },
               {
                 icon: '/public/lawyer2/connection/bc-logo.png',
                 name: 'Person',
+                schema_id: 'QEquAHkM35w4XVT3Ku5yat:2:Person:1.3',
                 properties: ['given_names', 'family_name', 'picture'],
                 nonRevoked: { to: now() },
               },

--- a/server/config/studentCustom.ts
+++ b/server/config/studentCustom.ts
@@ -134,6 +134,7 @@ export const studentCustom: CustomCharacter = {
               {
                 icon: '/public/student/useCases/school/icon-university-card.png',
                 name: 'student_card',
+                schema_id: 'QEquAHkM35w4XVT3Ku5yat:2:student_card:1.6',
                 predicates: {
                   name: 'expiry_date',
                   type: '>=',
@@ -179,6 +180,7 @@ export const studentCustom: CustomCharacter = {
               {
                 icon: '/public/student/useCases/school/icon-university-card.png',
                 name: 'student_card',
+                schema_id: 'QEquAHkM35w4XVT3Ku5yat:2:student_card:1.6',
                 properties: ['student_first_name'],
               },
             ],

--- a/server/src/content/types.ts
+++ b/server/src/content/types.ts
@@ -20,6 +20,8 @@ export interface OnboardingStep {
 export interface CredentialRequest {
   name: string
   icon?: string
+  schema_id?: string
+  cred_def_id?: string
   predicates?: { name: string; value?: string | number | (() => string | number); type: string }
   properties?: string[]
   nonRevoked?: { to: number; from?: number }


### PR DESCRIPTION
added schema_id to restriction in an OR clause so bc wallet can use it to look up the OCA information when the holder doesn't have it in their wallet during a proof request