### PR TITLE
Feat: Add helm charts and templates to deploy in openshift environment

### DIFF
--- a/charts/bc-wallet/Chart.yaml
+++ b/charts/bc-wallet/Chart.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+name: bc-wallet
+description: BC Wallet Showcase Builder services with PostgreSQL and RabbitMQ
+version: 0.1.0
+dependencies:
+  - name: postgresql
+    version: "16.6.3"
+    repository: "https://charts.bitnami.com/bitnami"
+    condition: postgresql.enabled
+  - name: rabbitmq
+    version: "15.5.1"
+    repository: "https://charts.bitnami.com/bitnami"
+    condition: rabbitmq.enabled

--- a/charts/bc-wallet/templates/_helpers.tpl
+++ b/charts/bc-wallet/templates/_helpers.tpl
@@ -1,0 +1,187 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "bc-wallet.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "bc-wallet.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "bc-wallet.chart" -}}
+{{- if .Chart }}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" "bc-wallet" "0.1.0" | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "bc-wallet.labels" -}}
+helm.sh/chart: {{ include "bc-wallet.chart" . }}
+{{- if .Release }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "bc-wallet.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "bc-wallet.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Returns a secret if it already exists in Kubernetes, otherwise creates
+it randomly.
+*/}}
+{{- define "getOrGeneratePass" -}}
+{{- $len := (default 16 .Length) | int -}}
+{{- $obj := (lookup "v1" .Kind .Namespace .Name).data -}}
+{{- if $obj }}
+{{- index $obj .Key -}}
+{{- else if (eq (lower .Kind) "secret") -}}
+{{- randAlphaNum $len | b64enc -}}
+{{- else -}}
+{{- randAlphaNum $len -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Define database secret name - used to reference PostgreSQL generated secret
+*/}}
+{{- define "bc-wallet.database.secret.name" -}}
+{{- if .Values.postgresql.auth.existingSecret -}}
+    {{- .Values.postgresql.auth.existingSecret -}}
+{{- else -}}
+    {{- printf "%s-postgresql" .Release.Name -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Define database user password key - used to reference PostgreSQL generated secret
+*/}}
+{{- define "bc-wallet.database.userPasswordKey" -}}
+{{- if .Values.postgresql.auth.secretKeys.userPasswordKey -}}
+{{- printf "%s" .Values.postgresql.auth.secretKeys.userPasswordKey -}}
+{{- else -}}
+password
+{{- end -}}
+{{- end -}}
+
+{{/*
+Define rabbitmq secret name - used to reference RabbitMQ generated secret
+*/}}
+{{- define "bc-wallet.rabbitmq.secret.name" -}}
+{{- if .Values.rabbitmq.auth.existingPasswordSecret -}}
+    {{- .Values.rabbitmq.auth.existingPasswordSecret -}}
+{{- else -}}
+    {{- printf "%s-rabbitmq" .Release.Name -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the RabbitMQ password key
+*/}}
+{{- define "bc-wallet.rabbitmq.passwordKey" -}}
+{{- if .Values.rabbitmq.auth.existingSecretKey -}}
+{{- .Values.rabbitmq.auth.existingSecretKey -}}
+{{- else -}}
+{{- "rabbitmq-password" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Get the rabbitmq erlang cookie key.
+*/}}
+{{- define "bc-wallet.rabbitmq.erlangCookieKey" -}}
+{{- if .Values.rabbitmq.auth.secretKeys.erlangCookieKey -}}
+{{- printf "%s" .Values.rabbitmq.auth.secretKeys.erlangCookieKey -}}
+{{- else -}}
+rabbitmq-erlang-cookie
+{{- end -}}
+{{- end -}}
+
+{{/*
+Define a FIXED auth token secret name that can be shared between frontend and backend
+*/}}
+{{- define "bc-wallet.authtoken.secret.name" -}}
+bc-wallet-authtoken
+{{- end -}}
+
+{{/*
+Generate API Server host if not overridden
+*/}}
+{{- define "bc-wallet.api-server.host" -}}
+{{- if (and (hasKey .Values.api_server "openshift") (hasKey .Values.api_server.openshift "route") (hasKey .Values.api_server.openshift.route "host")) -}}
+{{- .Values.api_server.openshift.route.host -}}
+{{- else -}}
+{{- printf "%s-%s%s" .Release.Name "api-server" .Values.ingressSuffix -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Generate Traction Adapter host if not overridden
+*/}}
+{{- define "bc-wallet.traction-adapter.host" -}}
+{{- if (and (hasKey .Values.traction_adapter "openshift") (hasKey .Values.traction_adapter.openshift "route") (hasKey .Values.traction_adapter.openshift.route "host")) -}}
+{{- .Values.traction_adapter.openshift.route.host -}}
+{{- else -}}
+{{- printf "%s-%s%s" .Release.Name "traction-adapter" .Values.ingressSuffix -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Generate Demo Web host if not overridden
+*/}}
+{{- define "bc-wallet.demo-web.host" -}}
+{{- if (and (hasKey .Values.demo_web "openshift") (hasKey .Values.demo_web.openshift "route") (hasKey .Values.demo_web.openshift.route "host")) -}}
+{{- .Values.demo_web.openshift.route.host -}}
+{{- else -}}
+{{- printf "%s-%s%s" .Release.Name "demo-web" .Values.ingressSuffix -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Generate Showcase Creator host if not overridden
+*/}}
+{{- define "bc-wallet.showcase-creator.host" -}}
+{{- if (and (hasKey .Values.showcase_creator "openshift") (hasKey .Values.showcase_creator.openshift "route") (hasKey .Values.showcase_creator.openshift.route "host")) -}}
+{{- .Values.showcase_creator.openshift.route.host -}}
+{{- else -}}
+{{- printf "%s-%s%s" .Release.Name "showcase-creator" .Values.ingressSuffix -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Generate Demo Server host if not overridden
+*/}}
+{{- define "bc-wallet.demo-server.host" -}}
+{{- if (and (hasKey .Values.demo_server "openshift") (hasKey .Values.demo_server.openshift "route") (hasKey .Values.demo_server.openshift.route "host")) -}}
+{{- .Values.demo_server.openshift.route.host -}}
+{{- else -}}
+{{- printf "%s-%s%s" .Release.Name "demo-server" .Values.ingressSuffix -}}
+{{- end -}}
+{{- end -}}

--- a/charts/bc-wallet/templates/_networkpolicy_helpers.tpl
+++ b/charts/bc-wallet/templates/_networkpolicy_helpers.tpl
@@ -1,0 +1,28 @@
+{{/*
+Define a common template for allowing intra-release communication with namespace support
+*/}}
+{{- define "bc-wallet.intra-release-network-policy" -}}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ .Release.Name }}-{{ .componentName }}-allow-internal
+  namespace: {{ .Values.global.namespaceOverride | default .Release.Namespace }}
+  labels:
+    app.kubernetes.io/component: {{ .componentLabel }}
+    app.kubernetes.io/part-of: bc-wallet
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  podSelector:
+    matchLabels:
+      app: {{ .Release.Name }}-{{ .componentName }}
+  ingress:
+  - from:
+    - podSelector:
+        matchLabels:
+          app.kubernetes.io/part-of: bc-wallet
+          app.kubernetes.io/instance: {{ .Release.Name }}
+    ports:
+    - protocol: TCP
+      port: {{ .servicePort }}
+{{- end -}} 

--- a/charts/bc-wallet/templates/api-server/deployment.yaml
+++ b/charts/bc-wallet/templates/api-server/deployment.yaml
@@ -1,0 +1,82 @@
+{{- if .Values.api_server.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "bc-wallet.fullname" . }}-api-server
+  namespace: {{ .Values.global.namespaceOverride | default .Release.Namespace }}
+  labels:
+    app.kubernetes.io/component: api
+    app.kubernetes.io/part-of: bc-wallet
+    {{- include "bc-wallet.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.api_server.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ include "bc-wallet.fullname" . }}-api-server
+  template:
+    metadata:
+      labels:
+        app: {{ include "bc-wallet.fullname" . }}-api-server
+        app.kubernetes.io/component: api
+        app.kubernetes.io/part-of: bc-wallet
+        {{- include "bc-wallet.labels" . | nindent 8 }}
+      {{- with .Values.api_server.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- with .Values.api_server.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+      - name: api-server
+        image: "{{ .Values.api_server.image.repository }}:{{ .Values.api_server.image.tag }}"
+        imagePullPolicy: {{ .Values.api_server.image.pullPolicy }}
+        {{- with .Values.api_server.containerSecurityContext }}
+        securityContext:
+          {{- toYaml . | nindent 12 }}
+        {{- end }}
+        ports:
+        - containerPort: {{ .Values.api_server.port }}
+          name: http
+        env:
+        - name: AMQ_HOST
+          value: {{.Release.Name}}-rabbitmq
+        - name: AMQ_PORT
+          value: {{ .Values.rabbitmq.port | quote }}
+        - name: AMQ_TRANSPORT
+          value: tcp
+        - name: AMQ_USER
+          value: {{ .Values.rabbitmq.auth.username | quote }}
+        - name: AMQ_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "bc-wallet.rabbitmq.secret.name" . }}
+              key: {{ include "bc-wallet.rabbitmq.passwordKey" . }}
+        - name: DB_HOST
+          value: {{ .Release.Name }}-postgresql
+        {{- range $key, $value := .Values.api_server.env }}
+        {{- if and (ne $key "DB_HOST") (kindIs "map" $value) }}
+        - name: {{ $key }}
+          valueFrom:
+            {{- toYaml $value | nindent 12 }}
+        {{- else if ne $key "DB_HOST" }}
+        - name: {{ $key }}
+          value: {{ $value | quote }}
+        {{- end }}
+        {{- end }}
+        - name: DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "bc-wallet.database.secret.name" . }}
+              key: {{ include "bc-wallet.database.userPasswordKey" . }}
+        - name: AUTH_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "bc-wallet.authtoken.secret.name" . }}
+              key: token
+        resources:
+          {{- toYaml .Values.api_server.resources | nindent 12 }}
+      serviceAccountName: {{ if .Values.api_server.serviceAccount.create }}{{ if .Values.api_server.serviceAccount.name }}{{ .Values.api_server.serviceAccount.name }}{{ else }}{{ include "bc-wallet.fullname" . }}-api-server{{ end }}{{ end }}
+{{- end }}

--- a/charts/bc-wallet/templates/api-server/hpa.yaml
+++ b/charts/bc-wallet/templates/api-server/hpa.yaml
@@ -1,0 +1,37 @@
+{{- if .Values.api_server.enabled }}
+{{- if .Values.api_server.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "bc-wallet.fullname" . }}-api-server
+  namespace: {{ .Values.global.namespaceOverride | default .Release.Namespace }}
+  labels:
+    app.kubernetes.io/component: api
+    app.kubernetes.io/part-of: bc-wallet
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "bc-wallet.fullname" . }}-api-server
+  minReplicas: {{ .Values.api_server.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.api_server.autoscaling.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.api_server.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.api_server.autoscaling.targetMemoryUtilizationPercentage }}
+  behavior:
+    scaleDown:
+      stabilizationWindowSeconds: {{ .Values.api_server.autoscaling.stabilizationWindowSeconds }}
+{{- end }}
+{{- end }}

--- a/charts/bc-wallet/templates/api-server/networkpolicy.yaml
+++ b/charts/bc-wallet/templates/api-server/networkpolicy.yaml
@@ -1,0 +1,67 @@
+{{- if and .Values.api_server.enabled .Values.api_server.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "bc-wallet.fullname" . }}-api-server-allow-external
+  namespace: {{ .Values.global.namespaceOverride | default .Release.Namespace }}
+  labels:
+    app.kubernetes.io/component: api
+    app.kubernetes.io/part-of: bc-wallet
+    {{- include "bc-wallet.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      app: {{ include "bc-wallet.fullname" . }}-api-server
+  ingress:
+  - {}  # Allow all ingress traffic
+---
+# Network policy for API server to database
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ .Release.Name }}-postgres-allow-api
+  namespace: {{ .Values.global.namespaceOverride | default .Release.Namespace }}
+  labels:
+    app.kubernetes.io/component: database
+    app.kubernetes.io/part-of: bc-wallet
+    {{- include "bc-wallet.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: postgresql
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  ingress:
+  - from:
+    - podSelector:
+        matchLabels:
+          app: {{ include "bc-wallet.fullname" . }}-api-server
+    ports:
+    - protocol: TCP
+      port: {{ .Values.postgresql.primary.service.ports.postgresql }}
+---
+# Network policy for UI to API
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "bc-wallet.fullname" . }}-api-allow-ui
+  namespace: {{ .Values.global.namespaceOverride | default .Release.Namespace }}
+  labels:
+    app.kubernetes.io/component: api
+    app.kubernetes.io/part-of: bc-wallet
+    {{- include "bc-wallet.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      app: {{ include "bc-wallet.fullname" . }}-api-server
+  ingress:
+  - from:
+    - podSelector:
+        matchLabels:
+          app.kubernetes.io/component: creator
+    ports:
+    - protocol: TCP
+      port: {{ .Values.api_server.service.port }}
+---
+{{- $context := dict "componentName" "api-server" "componentLabel" "api" "servicePort" .Values.api_server.service.port "Values" .Values "Release" .Release }}
+{{- include "bc-wallet.intra-release-network-policy" $context }}
+{{- end }}

--- a/charts/bc-wallet/templates/api-server/service.yaml
+++ b/charts/bc-wallet/templates/api-server/service.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.api_server.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "bc-wallet.fullname" . }}-api-server
+  namespace: {{ .Values.global.namespaceOverride | default .Release.Namespace }}
+  labels:
+    app.kubernetes.io/component: api
+    app.kubernetes.io/part-of: bc-wallet
+    {{- include "bc-wallet.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.api_server.service.type }}
+  ports:
+    - port: {{ .Values.api_server.service.port }}
+      targetPort: {{ .Values.api_server.port }}
+      protocol: TCP
+      name: http
+  selector:
+    app: {{ include "bc-wallet.fullname" . }}-api-server
+{{- end }}

--- a/charts/bc-wallet/templates/api-server/serviceaccount.yaml
+++ b/charts/bc-wallet/templates/api-server/serviceaccount.yaml
@@ -1,0 +1,15 @@
+{{- if and .Values.api_server.serviceAccount (eq .Values.api_server.serviceAccount.create true) }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ if .Values.api_server.serviceAccount.name }}{{ .Values.api_server.serviceAccount.name }}{{ else }}{{ include "bc-wallet.fullname" . }}-api-server{{ end }}
+  namespace: {{ .Values.global.namespaceOverride | default .Release.Namespace }}
+  labels:
+    app.kubernetes.io/component: api
+    app.kubernetes.io/part-of: bc-wallet
+    {{- include "bc-wallet.labels" . | nindent 4 }}
+  {{- with .Values.api_server.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/bc-wallet/templates/common/authtoken-secret.yaml
+++ b/charts/bc-wallet/templates/common/authtoken-secret.yaml
@@ -1,0 +1,18 @@
+{{- $authtokenSecretName := include "bc-wallet.authtoken.secret.name" . -}}
+{{- $authtokenSecret := (lookup "v1" "Secret" .Release.Namespace $authtokenSecretName) -}}
+{{- if not $authtokenSecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "bc-wallet.authtoken.secret.name" . }}
+  namespace: {{ .Values.global.namespaceOverride | default .Release.Namespace }}
+  annotations:
+    "helm.sh/resource-policy": keep
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+type: Opaque
+data:
+  token: {{ include "getOrGeneratePass" (dict "Namespace" .Release.Namespace "Kind" "Secret" "Name" (include "bc-wallet.authtoken.secret.name" .) "Key" "token" "Length" 32) }}
+{{- end }}

--- a/charts/bc-wallet/templates/common/configmap.yaml
+++ b/charts/bc-wallet/templates/common/configmap.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.postgresql.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "bc-wallet.fullname" . }}-postgresql-config
+  namespace: {{ .Values.global.namespaceOverride | default .Release.Namespace }}
+  labels:
+    {{- include "bc-wallet.labels" . | nindent 4 }}
+data:
+  postgresql.conf: |
+    {{- .Values.postgresql.primary.extendedConfiguration | nindent 4 }}
+---
+{{- end }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "bc-wallet.fullname" . }}
+  namespace: {{ .Values.global.namespaceOverride | default .Release.Namespace }}
+  labels:
+    {{- include "bc-wallet.labels" . | nindent 4 }}
+data:
+  {{- if .Values.postgresql.enabled }}
+  DB_HOST: {{ .Release.Name }}-postgresql
+  DB_PORT: "{{ .Values.postgresql.primary.service.ports.postgresql }}"
+  {{- end }}
+  {{- if .Values.rabbitmq.enabled }}
+  RABBITMQ_HOST: {{ .Release.Name }}-rabbitmq
+  RABBITMQ_PORT: "{{ .Values.rabbitmq.service.port }}"
+  RABBITMQ_MANAGEMENT_PORT: "{{ .Values.rabbitmq.service.managerPort }}"
+  {{- end }}
+  {{- if .Values.configMapData }}
+  {{- toYaml .Values.configMapData | nindent 2 }}
+  {{- end }}

--- a/charts/bc-wallet/templates/demo-server/deployment.yaml
+++ b/charts/bc-wallet/templates/demo-server/deployment.yaml
@@ -1,0 +1,69 @@
+{{- if .Values.demo_server.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "bc-wallet.fullname" . }}-demo-server
+  namespace: {{ .Values.global.namespaceOverride | default .Release.Namespace }}
+  labels:
+    app.kubernetes.io/component: server
+    app.kubernetes.io/part-of: bc-wallet
+    {{- include "bc-wallet.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.demo_server.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ include "bc-wallet.fullname" . }}-demo-server
+  template:
+    metadata:
+      labels:
+        app: {{ include "bc-wallet.fullname" . }}-demo-server
+        app.kubernetes.io/component: server
+        app.kubernetes.io/part-of: bc-wallet
+        {{- include "bc-wallet.labels" . | nindent 8 }}
+      {{- with .Values.demo_server.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- with .Values.demo_server.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+      - name: demo-server
+        image: "{{ .Values.demo_server.image.repository }}:{{ .Values.demo_server.image.tag }}"
+        imagePullPolicy: {{ .Values.demo_server.image.pullPolicy }}
+        {{- with .Values.demo_server.containerSecurityContext }}
+        securityContext:
+          {{- toYaml . | nindent 12 }}
+        {{- end }}
+        ports:
+        - containerPort: {{ .Values.demo_server.port }}
+          name: http
+        env:
+        - name: DB_HOST
+          value: {{ .Release.Name }}-postgresql
+        {{- range $key, $value := .Values.demo_server.env }}
+        {{- if and (ne $key "DB_HOST") (kindIs "map" $value) }}
+        - name: {{ $key }}
+          valueFrom:
+            {{- toYaml $value | nindent 12 }}
+        {{- else if ne $key "DB_HOST" }}
+        - name: {{ $key }}
+          value: {{ $value | quote }}
+        {{- end }}
+        {{- end }}
+        - name: DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "bc-wallet.database.secret.name" . }}
+              key: {{ include "bc-wallet.database.userPasswordKey" . }}
+        - name: AUTH_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "bc-wallet.authtoken.secret.name" . }}
+              key: token
+        resources:
+          {{- toYaml .Values.demo_server.resources | nindent 12 }}
+      serviceAccountName: {{ if .Values.demo_server.serviceAccount.create }}{{ if .Values.demo_server.serviceAccount.name }}{{ .Values.demo_server.serviceAccount.name }}{{ else }}{{ include "bc-wallet.fullname" . }}-demo-server{{ end }}{{ end }}
+{{- end }} 

--- a/charts/bc-wallet/templates/demo-server/hpa.yaml
+++ b/charts/bc-wallet/templates/demo-server/hpa.yaml
@@ -1,0 +1,36 @@
+{{- if .Values.demo_server.enabled }}
+{{- if .Values.demo_server.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "bc-wallet.fullname" . }}-demo-server
+  namespace: {{ .Values.global.namespaceOverride | default .Release.Namespace }}
+  labels:
+    app.kubernetes.io/component: server
+    app.kubernetes.io/part-of: bc-wallet
+    {{- include "bc-wallet.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "bc-wallet.fullname" . }}-demo-server
+  minReplicas: {{ .Values.demo_server.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.demo_server.autoscaling.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.demo_server.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.demo_server.autoscaling.targetMemoryUtilizationPercentage }}
+  behavior:
+    scaleDown:
+      stabilizationWindowSeconds: {{ .Values.demo_server.autoscaling.stabilizationWindowSeconds }}
+{{- end }}
+{{- end }} 

--- a/charts/bc-wallet/templates/demo-server/networkpolicy.yaml
+++ b/charts/bc-wallet/templates/demo-server/networkpolicy.yaml
@@ -1,0 +1,57 @@
+{{- if and .Values.demo_server.enabled .Values.demo_server.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "bc-wallet.fullname" . }}-demo-server-allow-external
+  namespace: {{ .Values.global.namespaceOverride | default .Release.Namespace }}
+  labels:
+    app.kubernetes.io/component: server
+    app.kubernetes.io/part-of: bc-wallet
+    {{- include "bc-wallet.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      app: {{ include "bc-wallet.fullname" . }}-demo-server
+  ingress:
+  - from:
+    {{- if .Values.demo_server.networkPolicy.ingress.namespaceSelector }}
+    - namespaceSelector:
+        matchLabels:
+          {{- if kindIs "map" .Values.demo_server.networkPolicy.ingress.namespaceSelector }}
+          {{- toYaml .Values.demo_server.networkPolicy.ingress.namespaceSelector | nindent 10 }}
+          {{- end }}
+      {{- if .Values.demo_server.networkPolicy.ingress.podSelector }}
+      podSelector:
+        {{- toYaml .Values.demo_server.networkPolicy.ingress.podSelector | nindent 10 }}
+      {{- end }}
+    {{- else }}
+    - {}  # Allow all ingress traffic if no selector specified
+    {{- end }}
+---
+# Network policy for Demo Server to database
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ .Release.Name }}-postgres-allow-demo-server
+  namespace: {{ .Values.global.namespaceOverride | default .Release.Namespace }}
+  labels:
+    app.kubernetes.io/component: database
+    app.kubernetes.io/part-of: bc-wallet
+    {{- include "bc-wallet.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: postgresql
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  ingress:
+  - from:
+    - podSelector:
+        matchLabels:
+          app: {{ include "bc-wallet.fullname" . }}-demo-server
+    ports:
+    - protocol: TCP
+      port: {{ .Values.postgresql.primary.service.ports.postgresql }}
+---
+{{- $context := dict "componentName" "demo-server" "componentLabel" "server" "servicePort" .Values.demo_server.service.port "Values" .Values "Release" .Release }}
+{{- include "bc-wallet.intra-release-network-policy" $context }}
+{{- end }} 

--- a/charts/bc-wallet/templates/demo-server/service.yaml
+++ b/charts/bc-wallet/templates/demo-server/service.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.demo_server.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "bc-wallet.fullname" . }}-demo-server
+  namespace: {{ .Values.global.namespaceOverride | default .Release.Namespace }}
+  labels:
+    app.kubernetes.io/component: server
+    app.kubernetes.io/part-of: bc-wallet
+    {{- include "bc-wallet.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.demo_server.service.type }}
+  ports:
+    - port: {{ .Values.demo_server.service.port }}
+      targetPort: {{ .Values.demo_server.port }}
+      protocol: TCP
+      name: http
+  selector:
+    app: {{ include "bc-wallet.fullname" . }}-demo-server
+{{- end }} 

--- a/charts/bc-wallet/templates/demo-server/serviceaccount.yaml
+++ b/charts/bc-wallet/templates/demo-server/serviceaccount.yaml
@@ -1,0 +1,15 @@
+{{- if and .Values.demo_server.serviceAccount (eq .Values.demo_server.serviceAccount.create true) }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ if .Values.demo_server.serviceAccount.name }}{{ .Values.demo_server.serviceAccount.name }}{{ else }}{{ include "bc-wallet.fullname" . }}-demo-server{{ end }}
+  namespace: {{ .Values.global.namespaceOverride | default .Release.Namespace }}
+  labels:
+    app.kubernetes.io/component: server
+    app.kubernetes.io/part-of: bc-wallet
+    {{- include "bc-wallet.labels" . | nindent 4 }}
+  {{- with .Values.demo_server.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }} 

--- a/charts/bc-wallet/templates/demo-web/deployment.yaml
+++ b/charts/bc-wallet/templates/demo-web/deployment.yaml
@@ -1,0 +1,59 @@
+{{- if .Values.demo_web.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "bc-wallet.fullname" . }}-demo-web
+  namespace: {{ .Values.global.namespaceOverride | default .Release.Namespace }}
+  labels:
+    app.kubernetes.io/component: web
+    app.kubernetes.io/part-of: bc-wallet
+    {{- include "bc-wallet.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.demo_web.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ include "bc-wallet.fullname" . }}-demo-web
+  template:
+    metadata:
+      labels:
+        app: {{ include "bc-wallet.fullname" . }}-demo-web
+        app.kubernetes.io/component: web
+        app.kubernetes.io/part-of: bc-wallet
+        {{- include "bc-wallet.labels" . | nindent 8 }}
+      {{- with .Values.demo_web.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- with .Values.demo_web.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+      - name: demo-web
+        image: "{{ .Values.demo_web.image.repository }}:{{ .Values.demo_web.image.tag }}"
+        imagePullPolicy: {{ .Values.demo_web.image.pullPolicy }}
+        {{- with .Values.demo_web.containerSecurityContext }}
+        securityContext:
+          {{- toYaml . | nindent 12 }}
+        {{- end }}
+        ports:
+        - containerPort: {{ .Values.demo_web.port }}
+          name: http
+        env:
+        {{- range $key, $value := .Values.demo_web.env }}
+        {{- if kindIs "map" $value }}
+        - name: {{ $key }}
+          valueFrom:
+            {{- toYaml $value | nindent 12 }}
+        {{- else }}
+        - name: {{ $key }}
+          value: {{ $value | quote }}
+        {{- end }}
+        {{- end }}
+        - name: API_URL
+          value: "http://{{ include "bc-wallet.fullname" . }}-api-server:{{ $.Values.api_server.service.port }}"
+        resources:
+          {{- toYaml .Values.demo_web.resources | nindent 12 }}
+      serviceAccountName: {{ if .Values.demo_web.serviceAccount.create }}{{ if .Values.demo_web.serviceAccount.name }}{{ .Values.demo_web.serviceAccount.name }}{{ else }}{{ include "bc-wallet.fullname" . }}-demo-web{{ end }}{{ end }}
+{{- end }} 

--- a/charts/bc-wallet/templates/demo-web/hpa.yaml
+++ b/charts/bc-wallet/templates/demo-web/hpa.yaml
@@ -1,0 +1,36 @@
+{{- if .Values.demo_web.enabled }}
+{{- if .Values.demo_web.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "bc-wallet.fullname" . }}-demo-web
+  namespace: {{ .Values.global.namespaceOverride | default .Release.Namespace }}
+  labels:
+    app.kubernetes.io/component: web
+    app.kubernetes.io/part-of: bc-wallet
+    {{- include "bc-wallet.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "bc-wallet.fullname" . }}-demo-web
+  minReplicas: {{ .Values.demo_web.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.demo_web.autoscaling.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.demo_web.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.demo_web.autoscaling.targetMemoryUtilizationPercentage }}
+  behavior:
+    scaleDown:
+      stabilizationWindowSeconds: {{ .Values.demo_web.autoscaling.stabilizationWindowSeconds }}
+{{- end }}
+{{- end }} 

--- a/charts/bc-wallet/templates/demo-web/networkpolicy.yaml
+++ b/charts/bc-wallet/templates/demo-web/networkpolicy.yaml
@@ -1,0 +1,60 @@
+{{- if and .Values.demo_web.enabled .Values.demo_web.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "bc-wallet.fullname" . }}-demo-web-allow-external
+  namespace: {{ .Values.global.namespaceOverride | default .Release.Namespace }}
+  labels:
+    app.kubernetes.io/component: web
+    app.kubernetes.io/part-of: bc-wallet
+    {{- include "bc-wallet.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      app: {{ include "bc-wallet.fullname" . }}-demo-web
+  ingress:
+  {{- if .Values.demo_web.networkPolicy.ingress.enabled }}
+  - from:
+    {{- if .Values.demo_web.networkPolicy.ingress.namespaceSelector }}
+    - namespaceSelector:
+        matchLabels:
+          {{- if kindIs "map" .Values.demo_web.networkPolicy.ingress.namespaceSelector }}
+          {{- toYaml .Values.demo_web.networkPolicy.ingress.namespaceSelector | nindent 10 }}
+          {{- end }}
+      {{- if .Values.demo_web.networkPolicy.ingress.podSelector }}
+      podSelector:
+        {{- toYaml .Values.demo_web.networkPolicy.ingress.podSelector | nindent 10 }}
+      {{- end }}
+    {{- else }}
+    - {}  # Allow all ingress traffic if no selector specified
+    {{- end }}
+  {{- else }}
+  - {}  # Allow all ingress traffic
+  {{- end }}
+---
+# Network policy for Web to API
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "bc-wallet.fullname" . }}-api-allow-web
+  namespace: {{ .Values.global.namespaceOverride | default .Release.Namespace }}
+  labels:
+    app.kubernetes.io/component: api
+    app.kubernetes.io/part-of: bc-wallet
+    {{- include "bc-wallet.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      app: {{ include "bc-wallet.fullname" . }}-api-server
+  ingress:
+  - from:
+    - podSelector:
+        matchLabels:
+          app: {{ include "bc-wallet.fullname" . }}-demo-web
+    ports:
+    - protocol: TCP
+      port: {{ .Values.api_server.service.port }}
+---
+{{- $context := dict "componentName" "demo-web" "componentLabel" "web" "servicePort" .Values.demo_web.service.port "Values" .Values "Release" .Release }}
+{{- include "bc-wallet.intra-release-network-policy" $context }}
+{{- end }} 

--- a/charts/bc-wallet/templates/demo-web/service.yaml
+++ b/charts/bc-wallet/templates/demo-web/service.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.demo_web.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "bc-wallet.fullname" . }}-demo-web
+  namespace: {{ .Values.global.namespaceOverride | default .Release.Namespace }}
+  labels:
+    app.kubernetes.io/component: web
+    app.kubernetes.io/part-of: bc-wallet
+    {{- include "bc-wallet.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.demo_web.service.type }}
+  ports:
+    - port: {{ .Values.demo_web.service.port }}
+      targetPort: {{ .Values.demo_web.port }}
+      protocol: TCP
+      name: http
+  selector:
+    app: {{ include "bc-wallet.fullname" . }}-demo-web
+{{- end }} 

--- a/charts/bc-wallet/templates/demo-web/serviceaccount.yaml
+++ b/charts/bc-wallet/templates/demo-web/serviceaccount.yaml
@@ -1,0 +1,15 @@
+{{- if and .Values.demo_web.serviceAccount (eq .Values.demo_web.serviceAccount.create true) }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ if .Values.demo_web.serviceAccount.name }}{{ .Values.demo_web.serviceAccount.name }}{{ else }}{{ include "bc-wallet.fullname" . }}-demo-web{{ end }}
+  namespace: {{ .Values.global.namespaceOverride | default .Release.Namespace }}
+  labels:
+    app.kubernetes.io/component: web
+    app.kubernetes.io/part-of: bc-wallet
+    {{- include "bc-wallet.labels" . | nindent 4 }}
+  {{- with .Values.demo_web.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }} 

--- a/charts/bc-wallet/templates/ingress.yaml
+++ b/charts/bc-wallet/templates/ingress.yaml
@@ -1,0 +1,73 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "bc-wallet.fullname" . }}-ingress
+  namespace: {{ .Values.global.namespaceOverride | default .Release.Namespace }}
+  labels:
+    app.kubernetes.io/part-of: bc-wallet
+    {{- include "bc-wallet.labels" . | nindent 4 }}
+  annotations:
+    {{- with .Values.ingress.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  rules:
+  - host: {{ include "bc-wallet.api-server.host" . | quote }}
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: {{ include "bc-wallet.fullname" . }}-api-server
+            port:
+              number: {{ $.Values.api_server.service.port }}
+  - host: {{ include "bc-wallet.traction-adapter.host" . | quote }}
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: {{ include "bc-wallet.fullname" . }}-traction-adapter
+            port:
+              number: {{ $.Values.traction_adapter.service.port }}
+  - host: {{ include "bc-wallet.demo-web.host" . | quote }}
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: {{ include "bc-wallet.fullname" . }}-demo-web
+            port:
+              number: {{ $.Values.demo_web.service.port }}
+  - host: {{ include "bc-wallet.showcase-creator.host" . | quote }}
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: {{ include "bc-wallet.fullname" . }}-showcase-creator
+            port:
+              number: {{ $.Values.showcase_creator.service.port }}
+  - host: {{ include "bc-wallet.demo-server.host" . | quote }}
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: {{ include "bc-wallet.fullname" . }}-demo-server
+            port:
+              number: {{ $.Values.demo_server.service.port }}
+  {{- with .Values.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/bc-wallet/templates/showcase-creator/deployment.yaml
+++ b/charts/bc-wallet/templates/showcase-creator/deployment.yaml
@@ -1,0 +1,69 @@
+{{- if .Values.showcase_creator.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "bc-wallet.fullname" . }}-showcase-creator
+  namespace: {{ .Values.global.namespaceOverride | default .Release.Namespace }}
+  labels:
+    app.kubernetes.io/component: creator
+    app.kubernetes.io/part-of: bc-wallet
+    {{- include "bc-wallet.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.showcase_creator.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ include "bc-wallet.fullname" . }}-showcase-creator
+  template:
+    metadata:
+      labels:
+        app: {{ include "bc-wallet.fullname" . }}-showcase-creator
+        app.kubernetes.io/component: creator
+        app.kubernetes.io/part-of: bc-wallet
+        {{- include "bc-wallet.labels" . | nindent 8 }}
+      {{- with .Values.showcase_creator.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- with .Values.showcase_creator.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+      - name: showcase-creator
+        image: "{{ .Values.showcase_creator.image.repository }}:{{ .Values.showcase_creator.image.tag }}"
+        imagePullPolicy: {{ .Values.showcase_creator.image.pullPolicy }}
+        {{- with .Values.showcase_creator.containerSecurityContext }}
+        securityContext:
+          {{- toYaml . | nindent 12 }}
+        {{- end }}
+        ports:
+        - containerPort: {{ .Values.showcase_creator.port }}
+          name: http
+        env:
+        - name: DB_HOST
+          value: {{ .Release.Name }}-postgresql
+        {{- range $key, $value := .Values.showcase_creator.env }}
+        {{- if and (ne $key "DB_HOST") (kindIs "map" $value) }}
+        - name: {{ $key }}
+          valueFrom:
+            {{- toYaml $value | nindent 12 }}
+        {{- else if ne $key "DB_HOST" }}
+        - name: {{ $key }}
+          value: {{ $value | quote }}
+        {{- end }}
+        {{- end }}
+        - name: DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "bc-wallet.database.secret.name" . }}
+              key: {{ include "bc-wallet.database.userPasswordKey" . }}
+        - name: AUTH_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "bc-wallet.authtoken.secret.name" . }}
+              key: token
+        resources:
+          {{- toYaml .Values.showcase_creator.resources | nindent 12 }}
+      serviceAccountName: {{ if .Values.showcase_creator.serviceAccount.create }}{{ if .Values.showcase_creator.serviceAccount.name }}{{ .Values.showcase_creator.serviceAccount.name }}{{ else }}{{ include "bc-wallet.fullname" . }}-showcase-creator{{ end }}{{ end }}
+{{- end }} 

--- a/charts/bc-wallet/templates/showcase-creator/hpa.yaml
+++ b/charts/bc-wallet/templates/showcase-creator/hpa.yaml
@@ -1,0 +1,36 @@
+{{- if .Values.showcase_creator.enabled }}
+{{- if .Values.showcase_creator.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "bc-wallet.fullname" . }}-showcase-creator
+  namespace: {{ .Values.global.namespaceOverride | default .Release.Namespace }}
+  labels:
+    app.kubernetes.io/component: creator
+    app.kubernetes.io/part-of: bc-wallet
+    {{- include "bc-wallet.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "bc-wallet.fullname" . }}-showcase-creator
+  minReplicas: {{ .Values.showcase_creator.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.showcase_creator.autoscaling.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.showcase_creator.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.showcase_creator.autoscaling.targetMemoryUtilizationPercentage }}
+  behavior:
+    scaleDown:
+      stabilizationWindowSeconds: {{ .Values.showcase_creator.autoscaling.stabilizationWindowSeconds }}
+{{- end }}
+{{- end }} 

--- a/charts/bc-wallet/templates/showcase-creator/networkpolicy.yaml
+++ b/charts/bc-wallet/templates/showcase-creator/networkpolicy.yaml
@@ -1,0 +1,61 @@
+{{- if and .Values.showcase_creator.enabled .Values.showcase_creator.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "bc-wallet.fullname" . }}-showcase-creator-allow-external
+  namespace: {{ .Values.global.namespaceOverride | default .Release.Namespace }}
+  labels:
+    app.kubernetes.io/component: creator
+    app.kubernetes.io/part-of: bc-wallet
+    {{- include "bc-wallet.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      app: {{ include "bc-wallet.fullname" . }}-showcase-creator
+  ingress:
+  {{- if .Values.showcase_creator.networkPolicy.ingress.enabled }}
+  - from:
+    {{- if .Values.showcase_creator.networkPolicy.ingress.namespaceSelector }}
+    - namespaceSelector:
+        matchLabels:
+          {{- if kindIs "map" .Values.showcase_creator.networkPolicy.ingress.namespaceSelector }}
+          {{- toYaml .Values.showcase_creator.networkPolicy.ingress.namespaceSelector | nindent 10 }}
+          {{- end }}
+      {{- if .Values.showcase_creator.networkPolicy.ingress.podSelector }}
+      podSelector:
+        {{- toYaml .Values.showcase_creator.networkPolicy.ingress.podSelector | nindent 10 }}
+      {{- end }}
+    {{- else }}
+    - {}  # Allow all ingress traffic if no selector specified
+    {{- end }}
+  {{- else }}
+  - {}  # Allow all ingress traffic
+  {{- end }}
+---
+# Network policy for Showcase Creator to database
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ .Release.Name }}-postgres-allow-creator
+  namespace: {{ .Values.global.namespaceOverride | default .Release.Namespace }}
+  labels:
+    app.kubernetes.io/component: database
+    app.kubernetes.io/part-of: bc-wallet
+    {{- include "bc-wallet.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: postgresql
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  ingress:
+  - from:
+    - podSelector:
+        matchLabels:
+          app: {{ include "bc-wallet.fullname" . }}-showcase-creator
+    ports:
+    - protocol: TCP
+      port: {{ .Values.postgresql.primary.service.ports.postgresql }}
+---
+{{- $context := dict "componentName" "showcase-creator" "componentLabel" "creator" "servicePort" .Values.showcase_creator.service.port "Values" .Values "Release" .Release }}
+{{- include "bc-wallet.intra-release-network-policy" $context }}
+{{- end }} 

--- a/charts/bc-wallet/templates/showcase-creator/service.yaml
+++ b/charts/bc-wallet/templates/showcase-creator/service.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.showcase_creator.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "bc-wallet.fullname" . }}-showcase-creator
+  namespace: {{ .Values.global.namespaceOverride | default .Release.Namespace }}
+  labels:
+    app.kubernetes.io/component: creator
+    app.kubernetes.io/part-of: bc-wallet
+    {{- include "bc-wallet.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.showcase_creator.service.type }}
+  ports:
+    - port: {{ .Values.showcase_creator.service.port }}
+      targetPort: {{ .Values.showcase_creator.port }}
+      protocol: TCP
+      name: http
+  selector:
+    app: {{ include "bc-wallet.fullname" . }}-showcase-creator
+{{- end }} 

--- a/charts/bc-wallet/templates/showcase-creator/serviceaccount.yaml
+++ b/charts/bc-wallet/templates/showcase-creator/serviceaccount.yaml
@@ -1,0 +1,15 @@
+{{- if and .Values.showcase_creator.serviceAccount (eq .Values.showcase_creator.serviceAccount.create true) }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ if .Values.showcase_creator.serviceAccount.name }}{{ .Values.showcase_creator.serviceAccount.name }}{{ else }}{{ include "bc-wallet.fullname" . }}-showcase-creator{{ end }}
+  namespace: {{ .Values.global.namespaceOverride | default .Release.Namespace }}
+  labels:
+    app.kubernetes.io/component: creator
+    app.kubernetes.io/part-of: bc-wallet
+    {{- include "bc-wallet.labels" . | nindent 4 }}
+  {{- with .Values.showcase_creator.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }} 

--- a/charts/bc-wallet/templates/traction-adapter/deployment.yaml
+++ b/charts/bc-wallet/templates/traction-adapter/deployment.yaml
@@ -1,0 +1,70 @@
+{{- if .Values.traction_adapter.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "bc-wallet.fullname" . }}-traction-adapter
+  namespace: {{ .Values.global.namespaceOverride | default .Release.Namespace }}
+  labels:
+    app.kubernetes.io/component: adapter
+    app.kubernetes.io/part-of: bc-wallet
+    {{- include "bc-wallet.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.traction_adapter.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ include "bc-wallet.fullname" . }}-traction-adapter
+  template:
+    metadata:
+      labels:
+        app: {{ include "bc-wallet.fullname" . }}-traction-adapter
+        app.kubernetes.io/component: adapter
+        app.kubernetes.io/part-of: bc-wallet
+        {{- include "bc-wallet.labels" . | nindent 8 }}
+      {{- with .Values.traction_adapter.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- with .Values.traction_adapter.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+      - name: traction-adapter
+        image: "{{ .Values.traction_adapter.image.repository }}:{{ .Values.traction_adapter.image.tag }}"
+        imagePullPolicy: {{ .Values.traction_adapter.image.pullPolicy }}
+        {{- with .Values.traction_adapter.containerSecurityContext }}
+        securityContext:
+          {{- toYaml . | nindent 12 }}
+        {{- end }}
+        ports:
+        - containerPort: {{ .Values.traction_adapter.port }}
+          name: http
+        env:
+        - name: AMQ_HOST
+          value: {{.Release.Name}}-rabbitmq
+        - name: AMQ_PORT
+          value: {{ .Values.rabbitmq.port | quote }}
+        - name: AMQ_TRANSPORT
+          value: tcp
+        - name: AMQ_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "bc-wallet.rabbitmq.secret.name" . }}
+              key: {{ include "bc-wallet.rabbitmq.passwordKey" . }}
+        - name: AMQ_USER
+          value: {{ .Values.rabbitmq.auth.username | quote }}
+        {{- range $key, $value := .Values.traction_adapter.env }}
+        {{- if and (ne $key "AMQ_HOST") (ne $key "AMQ_PORT") (ne $key "AMQ_TRANSPORT") (ne $key "AMQ_PASSWORD") (ne $key "AMQ_USER") (kindIs "map" $value) }}
+        - name: {{ $key }}
+          valueFrom:
+            {{- toYaml $value | nindent 14 }}
+        {{- else if and (ne $key "AMQ_HOST") (ne $key "AMQ_PORT") (ne $key "AMQ_TRANSPORT") (ne $key "AMQ_PASSWORD") (ne $key "AMQ_USER") }}
+        - name: {{ $key }}
+          value: {{ $value | quote }}
+        {{- end }}
+        {{- end }}
+        resources:
+          {{- toYaml .Values.traction_adapter.resources | nindent 12 }}
+      serviceAccountName: {{ if .Values.traction_adapter.serviceAccount.create }}{{ if .Values.traction_adapter.serviceAccount.name }}{{ .Values.traction_adapter.serviceAccount.name }}{{ else }}{{ include "bc-wallet.fullname" . }}-traction-adapter{{ end }}{{ end }}
+{{- end }}

--- a/charts/bc-wallet/templates/traction-adapter/hpa.yaml
+++ b/charts/bc-wallet/templates/traction-adapter/hpa.yaml
@@ -1,0 +1,36 @@
+{{- if .Values.traction_adapter.enabled }}
+{{- if .Values.traction_adapter.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "bc-wallet.fullname" . }}-traction-adapter
+  namespace: {{ .Values.global.namespaceOverride | default .Release.Namespace }}
+  labels:
+    app.kubernetes.io/component: adapter
+    app.kubernetes.io/part-of: bc-wallet
+    {{- include "bc-wallet.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "bc-wallet.fullname" . }}-traction-adapter
+  minReplicas: {{ .Values.traction_adapter.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.traction_adapter.autoscaling.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.traction_adapter.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.traction_adapter.autoscaling.targetMemoryUtilizationPercentage }}
+  behavior:
+    scaleDown:
+      stabilizationWindowSeconds: {{ .Values.traction_adapter.autoscaling.stabilizationWindowSeconds }}
+{{- end }}
+{{- end }}

--- a/charts/bc-wallet/templates/traction-adapter/networkpolicy.yaml
+++ b/charts/bc-wallet/templates/traction-adapter/networkpolicy.yaml
@@ -1,0 +1,61 @@
+{{- if and .Values.traction_adapter.enabled .Values.traction_adapter.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "bc-wallet.fullname" . }}-traction-adapter-allow-external
+  namespace: {{ .Values.global.namespaceOverride | default .Release.Namespace }}
+  labels:
+    app.kubernetes.io/component: adapter
+    app.kubernetes.io/part-of: bc-wallet
+    {{- include "bc-wallet.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      app: {{ include "bc-wallet.fullname" . }}-traction-adapter
+  ingress:
+  {{- if .Values.traction_adapter.networkPolicy.ingress.enabled }}
+  - from:
+    {{- if .Values.traction_adapter.networkPolicy.ingress.namespaceSelector }}
+    - namespaceSelector:
+        matchLabels:
+          {{- if kindIs "map" .Values.traction_adapter.networkPolicy.ingress.namespaceSelector }}
+          {{- toYaml .Values.traction_adapter.networkPolicy.ingress.namespaceSelector | nindent 10 }}
+          {{- end }}
+      {{- if .Values.traction_adapter.networkPolicy.ingress.podSelector }}
+      podSelector:
+        {{- toYaml .Values.traction_adapter.networkPolicy.ingress.podSelector | nindent 10 }}
+      {{- end }}
+    {{- else }}
+    - {}  # Allow all ingress traffic if no selector specified
+    {{- end }}
+  {{- else }}
+  - {}  # Allow all ingress traffic
+  {{- end }}
+---
+# Network policy for Traction Adapter to RabbitMQ
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ .Release.Name }}-rabbitmq-allow-adapter
+  namespace: {{ .Values.global.namespaceOverride | default .Release.Namespace }}
+  labels:
+    app.kubernetes.io/component: messagebroker
+    app.kubernetes.io/part-of: bc-wallet
+    {{- include "bc-wallet.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: rabbitmq
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  ingress:
+  - from:
+    - podSelector:
+        matchLabels:
+          app: {{ include "bc-wallet.fullname" . }}-traction-adapter
+    ports:
+    - protocol: TCP
+      port: {{ .Values.rabbitmq.service.ports.amqp }}
+---
+{{- $context := dict "componentName" "traction-adapter" "componentLabel" "adapter" "servicePort" .Values.traction_adapter.service.port "Values" .Values "Release" .Release }}
+{{- include "bc-wallet.intra-release-network-policy" $context }}
+{{- end }}

--- a/charts/bc-wallet/templates/traction-adapter/service.yaml
+++ b/charts/bc-wallet/templates/traction-adapter/service.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.traction_adapter.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "bc-wallet.fullname" . }}-traction-adapter
+  namespace: {{ .Values.global.namespaceOverride | default .Release.Namespace }}
+  labels:
+    app.kubernetes.io/component: adapter
+    app.kubernetes.io/part-of: bc-wallet
+    {{- include "bc-wallet.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.traction_adapter.service.type }}
+  ports:
+    - port: {{ .Values.traction_adapter.service.port }}
+      targetPort: {{ .Values.traction_adapter.port }}
+      protocol: TCP
+      name: http
+  selector:
+    app: {{ include "bc-wallet.fullname" . }}-traction-adapter
+{{- end }}

--- a/charts/bc-wallet/templates/traction-adapter/serviceaccount.yaml
+++ b/charts/bc-wallet/templates/traction-adapter/serviceaccount.yaml
@@ -1,0 +1,15 @@
+{{- if and .Values.traction_adapter.serviceAccount (eq .Values.traction_adapter.serviceAccount.create true) }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ if .Values.traction_adapter.serviceAccount.name }}{{ .Values.traction_adapter.serviceAccount.name }}{{ else }}{{ include "bc-wallet.fullname" . }}-traction-adapter{{ end }}
+  namespace: {{ .Values.global.namespaceOverride | default .Release.Namespace }}
+  labels:
+    app.kubernetes.io/component: adapter
+    app.kubernetes.io/part-of: bc-wallet
+    {{- include "bc-wallet.labels" . | nindent 4 }}
+  {{- with .Values.traction_adapter.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/bc-wallet/values.yaml
+++ b/charts/bc-wallet/values.yaml
@@ -1,0 +1,408 @@
+nameOverride: ""
+fullnameOverride: ""
+
+global:
+  namespaceOverride: ""
+
+# Add ingressSuffix for dynamic host generation
+ingressSuffix: "-dev.apps.silver.devops.gov.bc.ca"
+
+ingress:
+  enabled: true
+  className: ""
+  annotations:
+    kubernetes.io/ingress.class: openshift-default
+    route.openshift.io/termination: edge
+  hosts:
+    - host: ""  
+      paths:
+        - path: /
+          pathType: Prefix
+          service: api-server
+    - host: ""  
+      paths:
+        - path: /
+          pathType: Prefix
+          service: traction-adapter
+    - host: ""  
+      paths:
+        - path: /
+          pathType: Prefix
+          service: demo-web
+    - host: "" 
+      paths:
+        - path: /
+          pathType: Prefix
+          service: showcase-creator
+    - host: "" 
+      paths:
+        - path: /
+          pathType: Prefix
+          service: demo-server
+  tls: []
+
+api_server:
+  image:
+    repository: ghcr.io/bcgov/bc-wallet-api-server
+    pullPolicy: IfNotPresent
+    pullSecrets: []
+    tag: "latest"
+  replicaCount: 1
+  labelOverride: ""
+  port: 3000
+  path: /
+  env:
+    APP_NAME: bc-wallet-api
+    LOG_LEVEL: debug
+    DB_PORT: "5432"
+    DB_NAME: showcase-db
+    DB_USERNAME: showcase-user
+    CORS_DISABLED: true
+    ALLOW_ORIGINS: "*"
+    ALLOW_METHODS: "GET, POST, PUT, DELETE, OPTIONS"
+    ALLOW_HEADERS: "Content-Type, Authorization"
+    ALLOW_CREDENTIALS: "true"
+    API_KEY: SENSITIVE
+    ENCRYPTION_KEY: SENSITIVE
+  resources:
+    limits:
+      cpu: 200m
+      memory: 256Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi
+  podAnnotations: {}
+  podSecurityContext: {}
+  containerSecurityContext: {}
+  service:
+    type: ClusterIP
+    port: 3000
+  affinity: {}
+  nodeSelector: {}
+  tolerations: []
+  networkPolicy:
+    enabled: true
+    ingress:
+      enabled: true
+      namespaceSelector: 
+        network.openshift.io/policy-group: ingress
+      podSelector: {}
+  enabled: true
+  serviceAccount:
+    create: false
+    name: ""
+    annotations: {}
+    automountServiceAccountToken: true
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 3
+    targetCPUUtilizationPercentage: 80
+    targetMemoryUtilizationPercentage: 80
+    stabilizationWindowSeconds: 300
+
+traction_adapter:
+  image:
+    repository: ghcr.io/bcgov/bc-wallet-traction-adapter
+    pullPolicy: IfNotPresent
+    pullSecrets: []
+    tag: "latest"
+  replicaCount: 1
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 3
+    targetCPUUtilizationPercentage: 80
+    targetMemoryUtilizationPercentage: 80
+    stabilizationWindowSeconds: 300
+  labelOverride: ""
+  port: 3000
+  path: /traction
+  env:
+    APP_NAME: bc-wallet-traction-adapter
+    LOG_LEVEL: debug
+    NODE_PORT: 3000
+    RABBITMQ_PORT: 5672
+    RABBITMQ_USER: guest
+    RABBITMQ_VHOST: /
+    DEFAULT_API_BASE_PATH: SENSITIVE # ADD TRACTION API BASE PATH HERE
+    FIXED_SHOWCASE_BACKEND: SENSITIVE # ADD SHOWCASE BACKEND HERE
+    ENCRYPTION_KEY: SENSITIVE
+    FIXED_API_KEY: SENSITIVE
+    FIXED_WALLET_ID: SENSITIVE
+    FIXED_TENANT_ID: SENSITIVE
+  resources:
+    limits:
+      cpu: 200m
+      memory: 256Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi
+  podAnnotations: {}
+  podSecurityContext: {}
+  containerSecurityContext: {}
+  service:
+    type: ClusterIP
+    port: 3000
+  affinity: {}
+  nodeSelector: {}
+  tolerations: []
+  networkPolicy:
+    enabled: true
+    ingress:
+      enabled: true
+      namespaceSelector: 
+        network.openshift.io/policy-group: ingress
+      podSelector: {}
+  enabled: true
+  serviceAccount:
+    create: false
+    annotations: {}
+    automountServiceAccountToken: true
+    name: ""
+
+demo_web:
+  image:
+    repository: ghcr.io/bcgov/bc-wallet-demo-web
+    pullPolicy: IfNotPresent
+    pullSecrets: []
+    tag: "latest"
+  replicaCount: 1
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 3
+    targetCPUUtilizationPercentage: 80
+    targetMemoryUtilizationPercentage: 80
+    stabilizationWindowSeconds: 300
+  labelOverride: ""
+  port: 3000
+  path: /
+  env:
+    REACT_APP_INSIGHTS_PROJECT_ID: SENSITIVE
+    REACT_APP_DEFAULT_SLUG: REACT_APP_DEFAULT_SLUG 
+    REACT_APP_HOST_BACKEND: SENSITIVE # ADD DEMO BACKEND HERE
+    REACT_APP_BASE_ROUTE: /digital-trust/showcase
+    REACT_APP_SHOWCASE_BACKEND: SENSITIVE # ADD SHOWCASE BACKEND HERE
+    REACT_APP_SNOWPLOW_ENDPOINT: SENSITIVE
+  resources:
+    limits:
+      cpu: 200m
+      memory: 256Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi
+  podAnnotations: {}
+  podSecurityContext: {}
+  containerSecurityContext: {}
+  service:
+    type: ClusterIP
+    port: 3000
+  affinity: {}
+  nodeSelector: {}
+  tolerations: []
+  networkPolicy:
+    enabled: true
+    ingress:
+      enabled: true
+      namespaceSelector: 
+        network.openshift.io/policy-group: ingress
+      podSelector: {}
+  enabled: true
+  serviceAccount:
+    create: false
+    annotations: {}
+    automountServiceAccountToken: true
+    name: ""
+
+showcase_creator:
+  image:
+    repository: ghcr.io/bcgov/bc-wallet-showcase-creator
+    pullPolicy: IfNotPresent
+    pullSecrets: []
+    tag: "latest"
+  replicaCount: 1
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 3
+    targetCPUUtilizationPercentage: 80
+    targetMemoryUtilizationPercentage: 80
+    stabilizationWindowSeconds: 300
+  labelOverride: ""
+  port: 3050
+  path: /
+  env:
+    NEXT_PUBLIC_WALLET_URL: https://digital.gov.bc.ca/digital-trust/showcase
+    NEXT_PUBLIC_SHOWCASE_BACKEND: SENSITIVE # ADD SHOWCASE BACKEND HERE
+    AUTH_SECRET: SENSITIVE # ADD AUTH SECRET HERE
+    AUTH_KEYCLOAK_ID: SENSITIVE # ADD KEYCLOAK ID HERE
+    AUTH_KEYCLOAK_SECRET: SENSITIVE # ADD KEYCLOAK SECRET HERE
+    AUTH_KEYCLOAK_ISSUER: SENSITIVE # ADD KEYCLOAK ISSUER HERE
+    AUTH_TRUST_HOST: "true"
+    AUTH_REDIRECT_PROXY_URL: SENSITIVE # ADD REDIRECT PROXY URL HERE
+    AUTH_URL: SENSITIVE # ADD AUTH URL HERE
+  resources:
+    limits:
+      cpu: 200m
+      memory: 256Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi
+  podAnnotations: {}
+  podSecurityContext: {}
+  containerSecurityContext: {}
+  service:
+    type: ClusterIP
+    port: 3050
+  affinity: {}
+  nodeSelector: {}
+  tolerations: []
+  networkPolicy:
+    enabled: true
+    ingress:
+      enabled: true
+      namespaceSelector: 
+        network.openshift.io/policy-group: ingress
+      podSelector: {}
+  enabled: true
+  serviceAccount:
+    create: false
+    annotations: {}
+    automountServiceAccountToken: true
+    name: ""
+
+demo_server:
+  image:
+    repository: ghcr.io/bcgov/bc-wallet-demo-server
+    pullPolicy: IfNotPresent
+    pullSecrets: []
+    tag: "latest"
+  replicaCount: 1
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 3
+    targetCPUUtilizationPercentage: 80
+    targetMemoryUtilizationPercentage: 80
+    stabilizationWindowSeconds: 300
+  labelOverride: ""
+  port: 3000
+  path: /
+  env:
+    APP_NAME: bc-wallet-demo-server
+    TENANT_ID: SENSITIVE # ADD TENANT ID HERE
+    API_KEY: SENSITIVE # ADD API KEY HERE
+    BASE_ROUTE: /digital-trust/showcase
+    WEBHOOK_SECRET: SENSITIVE # ADD WEBHOOK SECRET HERE
+    TRACTION_URL: SENSITIVE # ADD TRACTION URL HERE
+  resources:
+    limits:
+      cpu: 200m
+      memory: 256Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi
+  podAnnotations: {}
+  podSecurityContext: {}
+  containerSecurityContext: {}
+  service:
+    type: ClusterIP
+    port: 3000
+  affinity: {}
+  nodeSelector: {}
+  tolerations: []
+  networkPolicy:
+    enabled: true
+    ingress:
+      enabled: true
+      namespaceSelector: 
+        network.openshift.io/policy-group: ingress
+      podSelector: {}
+  enabled: true
+  serviceAccount:
+    create: false
+    annotations: {}
+    automountServiceAccountToken: true
+    name: ""
+
+postgresql:
+  enabled: true
+  auth:
+    enablePostgresUser: true
+    username: "showcase-user"
+    database: "showcase-db"
+    secretKeys:
+      adminPasswordKey: "postgres-password"
+      userPasswordKey: "password"
+  primary:
+    service:
+      ports:
+        postgresql: 5432
+    persistence:
+      enabled: true
+      size: 1Gi
+    resources:
+      limits:
+        cpu: 200m
+        memory: 256Mi
+      requests:
+        cpu: 100m
+        memory: 128Mi
+    podSecurityContext:
+      enabled: false
+    containerSecurityContext:
+      enabled: false
+  networkPolicy:
+    enabled: true
+  fullnameOverride: ""
+
+rabbitmq:
+  enabled: true
+  auth:
+    username: "bc_user"
+    password: "some_password"
+    existingSecret: ""
+    existingSecretKey: "rabbitmq-password"
+    erlangCookie: ""
+    existingErlangSecret: ""
+    existingErlangSecretKey: "rabbitmq-erlang-cookie"
+  extraPlugins: "rabbitmq_management rabbitmq_amqp1_0"
+  configuration: |-
+    management.listener.port = 15672
+    management.listener.ssl = false
+    default_user = bc_user
+    default_pass = some_password
+  extraConfiguration: |-
+    default_user = bc_user
+    default_pass = some_password
+  service:
+    type: ClusterIP
+    ports:
+      amqp: 5672
+      manager: 15672
+  livenessProbe:
+    enabled: false
+  readinessProbe:
+    enabled: false
+  persistence:
+    enabled: true
+    size: 1Gi
+  resources:
+    limits:
+      cpu: 200m
+      memory: 256Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi
+  containerSecurityContext:
+    enabled: false
+  podSecurityContext:
+    enabled: false
+  replicaCount: 1
+  pdb:
+    create: true
+    minAvailable: 1
+  networkPolicy:
+    enabled: true
+  fullnameOverride: ""


### PR DESCRIPTION
This PR restructures the Helm chart for bc-wallet into a modular, multi-service architecture and introduces comprehensive documentation.

### Helm Chart Enhancements (by contributor):

- Each service is now organized within its own directory, including deployment, service, HPA, and related resources.
- Shared configurations have been centralized under `common/`, utilizing templating through `_helpers.tpl` and `_networkpolicy_helpers.tpl`.
- Integrated dependencies, including Bitnami PostgreSQL and RabbitMQ.
- Service-specific Ingress resources have been defined, with routing compatible with OpenShift.

### Documentation Improvements:

- Detailed explanation of ephemeral PR environments.
- Overview of the Helm chart structure and configuration options in `values.yaml`.
- In-depth breakdown of templates, helper functions, secret management, and route generation.
- Updated directory structure for improved clarity.

**These changes promote consistent, secure, and scalable Helm-based deployments, providing a clear reference for DevOps contributors.**