### PR TITLE
[Helm] Enable readiness probe for demo-web

### DIFF
--- a/charts/bc-wallet/values.yaml
+++ b/charts/bc-wallet/values.yaml
@@ -361,13 +361,12 @@ demoWeb:
   livenessProbe:
     {}
     # httpGet:
-    #   path: /
+    #   path: /health
     #   port: http
   readinessProbe:
-    {}
-    # httpGet:
-    #   path: /
-    #   port: http
+    httpGet:
+      path: /health
+      port: http
 
   # This section is for setting up autoscaling more information can be found here: https://kubernetes.io/docs/concepts/workloads/autoscaling/
   autoscaling:


### PR DESCRIPTION
`demo-web` service has a `/health` endpoint configured in `Caddyfile`
- Updating value files to enable a readiness probe for the service