### PR TITLE
Add MongoDB service to Docker Compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,20 @@
-version: "3.9"
 services:
+  mongodb:
+    image: mongo:7.0
+    restart: unless-stopped
+    volumes:
+      - mongo-data:/data/db
+    environment:
+      MONGO_INITDB_DATABASE: bcwallet_demo
+    expose:
+      - "27017"
+    healthcheck:
+      test: ["CMD", "mongosh", "--quiet", "--eval", "db.adminCommand('ping').ok"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 20s
+
   frontend:
     image: bc-wallet-demo-web
     build: 
@@ -24,6 +39,9 @@ services:
       - "5000:5000"
     env_file:
       - ./server/.env
+    depends_on:
+      mongodb:
+        condition: service_healthy
   dev:
     image: bc-wallet-demo-dev
     build:
@@ -34,4 +52,9 @@ services:
       - "5000:5000"
     volumes:
       - ./:/app
-  
+    depends_on:
+      mongodb:
+        condition: service_healthy
+
+volumes:
+  mongo-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   mongodb:
-    image: mongo:7.0
+    image: mongo:8
     restart: unless-stopped
     volumes:
       - mongo-data:/data/db

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,3 +1,6 @@
+# MongoDB (docker-compose service name `mongodb`; optional until the server uses it)
+# MONGODB_URI=mongodb://mongodb:27017/bcwallet_demo
+
 TENANT_ID=000000000000000000000000
 API_KEY=000000000000000000000000
 TRACTION_URL=https://traction-api.com


### PR DESCRIPTION
- Run mongo:7.0 with persistent volume and healthcheck
- Wait for healthy Mongo before starting backend and dev
- Document optional MONGODB_URI in server/.env.example
- Drop obsolete compose version key
