### PR TITLE
Only load the controllers into express

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -13,7 +13,7 @@ import { tractionApiKeyUpdaterInit, tractionRequest, tractionGarbageCollection }
 const baseRoute = process.env.BASE_ROUTE
 
 const app: Express = createExpressServer({
-  controllers: [__dirname + '/controllers/**/*.ts'],
+  controllers: [__dirname + '/controllers/*.ts'],
   cors: true,
   routePrefix: `${baseRoute}/demo`,
 })


### PR DESCRIPTION
There was a small error that was causing the test files to get loaded into express and caused issues with ts-node. It shouldn't match all subdirectories here.