### PR TITLE
Add Helm chart for showcase (web + API + MongoDB)

### DIFF
--- a/.github/actions/showcase-build-frontend/action.yml
+++ b/.github/actions/showcase-build-frontend/action.yml
@@ -1,0 +1,52 @@
+name: Showcase build frontend image
+description: Build and push bc-wallet-showcase-frontend to GHCR (Vite build-args, provenance + SBOM)
+inputs:
+  image:
+    description: Full image reference without tag (e.g. ghcr.io/bcgov/bc-wallet-showcase-frontend)
+    required: true
+  tag:
+    description: Image tag (e.g. main or pr-42)
+    required: true
+  react_app_host_backend:
+    description: Value for REACT_APP_HOST_BACKEND (Vite VITE_HOST_BACKEND at build time)
+    required: true
+  react_app_insights_project_id:
+    description: Optional REACT_APP_INSIGHTS_PROJECT_ID (may be empty)
+    required: false
+    default: ''
+  github_token:
+    description: Token with packages write (typically secrets.GITHUB_TOKEN)
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/checkout@v4
+
+    - uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ inputs.github_token }}
+
+    - uses: docker/setup-buildx-action@v3
+
+    - id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: ${{ inputs.image }}
+        tags: |
+          type=raw,value=${{ inputs.tag }}
+
+    - uses: docker/build-push-action@v7
+      with:
+        context: .
+        file: ./frontend/Dockerfile
+        push: true
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
+        provenance: mode=min
+        sbom: true
+        build-args: |
+          REACT_APP_INSIGHTS_PROJECT_ID=${{ inputs.react_app_insights_project_id }}
+          REACT_APP_HOST_BACKEND=${{ inputs.react_app_host_backend }}

--- a/.github/actions/showcase-build-server/action.yml
+++ b/.github/actions/showcase-build-server/action.yml
@@ -1,0 +1,42 @@
+name: Showcase build server image
+description: Build and push bc-wallet-showcase-server to GHCR (provenance + SBOM)
+inputs:
+  image:
+    description: Full image reference without tag (e.g. ghcr.io/bcgov/bc-wallet-showcase-server)
+    required: true
+  tag:
+    description: Image tag (e.g. main or pr-42)
+    required: true
+  github_token:
+    description: Token with packages write (typically secrets.GITHUB_TOKEN)
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/checkout@v4
+
+    - uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ inputs.github_token }}
+
+    - uses: docker/setup-buildx-action@v3
+
+    - id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: ${{ inputs.image }}
+        tags: |
+          type=raw,value=${{ inputs.tag }}
+
+    - uses: docker/build-push-action@v7
+      with:
+        context: .
+        file: ./server/Dockerfile
+        push: true
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
+        provenance: mode=min
+        sbom: true

--- a/.github/actions/showcase-helm-lint/action.yml
+++ b/.github/actions/showcase-helm-lint/action.yml
@@ -1,0 +1,71 @@
+name: Showcase Helm lint
+description: |
+  helm dependency update, helm lint (default + dev + PR overlays), and helm template smoke checks
+  for charts/showcase. Use before packaging or upgrading the chart in CI.
+
+inputs:
+  skip_checkout:
+    description: Set to the string `true` if this job already ran actions/checkout
+    required: false
+    default: 'false'
+  skip_helm_install:
+    description: Set to `true` if Helm is already on PATH (e.g. after showcase-setup-oc-helm)
+    required: false
+    default: 'false'
+  helm_version:
+    description: Helm CLI version for azure/setup-helm when skip_helm_install is false
+    required: false
+    default: 'v3.16.3'
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/checkout@v4
+      if: ${{ inputs.skip_checkout != 'true' }}
+
+    - uses: azure/setup-helm@v4
+      if: ${{ inputs.skip_helm_install != 'true' }}
+      with:
+        version: ${{ inputs.helm_version }}
+
+    - name: Helm dependency update
+      shell: bash
+      working-directory: charts/showcase
+      run: helm dependency update
+
+    - name: Helm lint
+      shell: bash
+      working-directory: charts/showcase
+      run: >
+        helm lint .
+        --set showcase.publicOrigin=https://example.com
+        --set mongodb.auth.rootPassword=helm-ci-lint-placeholder
+
+    - name: Helm lint (values-dev overlay)
+      shell: bash
+      working-directory: charts/showcase
+      run: helm lint . -f ../../deploy/showcase/values-dev.yaml
+
+    - name: Helm template (smoke)
+      shell: bash
+      working-directory: charts/showcase
+      run: >
+        helm template smoke .
+        --set showcase.publicOrigin=https://example.com
+        --set mongodb.auth.rootPassword=helm-ci-lint-placeholder
+        >/dev/null
+
+    - name: Helm template (values-dev overlay)
+      shell: bash
+      working-directory: charts/showcase
+      run: helm template smoke-dev . -f ../../deploy/showcase/values-dev.yaml >/dev/null
+
+    - name: Helm lint (PR overlay)
+      shell: bash
+      working-directory: charts/showcase
+      run: helm lint . -f ../../deploy/showcase/values-pr.yaml
+
+    - name: Helm template (PR overlay)
+      shell: bash
+      working-directory: charts/showcase
+      run: helm template smoke-pr . -f ../../deploy/showcase/values-pr.yaml >/dev/null

--- a/.github/actions/showcase-helm-lint/action.yml
+++ b/.github/actions/showcase-helm-lint/action.yml
@@ -2,6 +2,8 @@ name: Showcase Helm lint
 description: |
   helm dependency update, helm lint (default + dev + PR overlays), and helm template smoke checks
   for charts/showcase. Use before packaging or upgrading the chart in CI.
+  When invoked as a local action (`uses: ./.github/actions/showcase-helm-lint`), the workflow must
+  run `actions/checkout` first, then pass `skip_checkout: true` so checkout is not duplicated.
 
 inputs:
   skip_checkout:

--- a/.github/actions/showcase-setup-oc-helm/action.yml
+++ b/.github/actions/showcase-setup-oc-helm/action.yml
@@ -1,0 +1,12 @@
+name: Showcase OpenShift + Helm CLI
+description: Install pinned oc and Helm versions used by showcase deploy workflows
+runs:
+  using: composite
+  steps:
+    - uses: redhat-actions/openshift-tools-installer@v1
+      with:
+        oc: '4.15'
+
+    - uses: azure/setup-helm@v4
+      with:
+        version: v3.16.3

--- a/.github/workflows/deploy-showcase-dev.yaml
+++ b/.github/workflows/deploy-showcase-dev.yaml
@@ -1,16 +1,22 @@
-# Upgrades the showcase Helm release on OpenShift when relevant paths merge to `main`.
+# Builds and pushes showcase images (tag `main`), then upgrades the dev Helm release on OpenShift
+# when relevant paths merge to `main` (bcgov repo only for GHCR push + deploy).
 #
 # Configure the bcgov repository (Settings → Secrets and variables → Actions):
 #   Variables (not secret):
 #     SHOWCASE_DEV_OC_URL        — API URL, e.g. https://api.silver.devops.gov.bc.ca:6443
 #     SHOWCASE_DEV_NAMESPACE     — Target namespace (must already exist)
+#     SHOWCASE_DEV_PUBLIC_ORIGIN — Optional. Browser origin for Vite `VITE_HOST_BACKEND` in the
+#                                  frontend image (scheme + host, no path). Defaults to the URL
+#                                  in deploy/showcase/values-dev.yaml — set this if dev hostname changes.
 #   Optional variable:
 #     SHOWCASE_DEV_HELM_RELEASE  — Helm release name (default: showcase)
 #   Secret:
 #     SHOWCASE_DEV_OC_TOKEN      — Service account or user token with permission to
 #                                  helm upgrade/install resources in that namespace
 #
-# If any required variable or the token is missing, this job is skipped (forks stay green).
+# If OpenShift variables/token are missing, image build + push to GHCR still runs on bcgov (so
+# `ghcr.io/bcgov/bc-wallet-showcase-*:main` stays current); the Helm job is skipped. Forks skip
+# GHCR jobs entirely (stay green).
 
 name: Deploy showcase (dev)
 
@@ -32,15 +38,104 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  HUSKY: '0'
+  REGISTRY: ghcr.io
+  SHOWCASE_SERVER_IMAGE: ghcr.io/${{ github.repository_owner }}/bc-wallet-showcase-server
+  SHOWCASE_FRONTEND_IMAGE: ghcr.io/${{ github.repository_owner }}/bc-wallet-showcase-frontend
+
 jobs:
+  build-server:
+    name: Build and push server image (main)
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    if: github.repository_owner == 'bcgov'
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/setup-buildx-action@v3
+
+      - id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.SHOWCASE_SERVER_IMAGE }}
+          tags: |
+            type=raw,value=main
+
+      - uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./server/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          provenance: mode=min
+          sbom: true
+
+  build-frontend:
+    name: Build and push frontend image (main)
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    if: github.repository_owner == 'bcgov'
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/setup-buildx-action@v3
+
+      - id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.SHOWCASE_FRONTEND_IMAGE }}
+          tags: |
+            type=raw,value=main
+
+      - uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./frontend/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          provenance: mode=min
+          sbom: true
+          build-args: |
+            REACT_APP_INSIGHTS_PROJECT_ID=${{ vars.REACT_APP_INSIGHTS_PROJECT_ID || secrets.REACT_APP_INSIGHTS_PROJECT_ID }}
+            REACT_APP_HOST_BACKEND=${{ vars.SHOWCASE_DEV_PUBLIC_ORIGIN || 'https://bc-wallet-showcase-dev.apps.silver.devops.gov.bc.ca' }}
+
   helm-upgrade-dev:
     name: Helm upgrade (OpenShift dev)
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    needs: [build-server, build-frontend]
     if: >-
-      ${{ vars.SHOWCASE_DEV_OC_URL != '' &&
-          vars.SHOWCASE_DEV_NAMESPACE != '' &&
-          secrets.SHOWCASE_DEV_OC_TOKEN != '' }}
+      github.repository_owner == 'bcgov' &&
+      needs.build-server.result == 'success' &&
+      needs.build-frontend.result == 'success' &&
+      vars.SHOWCASE_DEV_OC_URL != '' &&
+      vars.SHOWCASE_DEV_NAMESPACE != '' &&
+      secrets.SHOWCASE_DEV_OC_TOKEN != ''
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -79,3 +174,24 @@ jobs:
             --wait \
             --timeout 15m \
             --atomic
+
+      # Same tag (`:main`) can point at a new digest; restart so workloads pull the image we just pushed.
+      - name: Rollout restart (pick up new main digest)
+        env:
+          SHOWCASE_DEV_NAMESPACE: ${{ vars.SHOWCASE_DEV_NAMESPACE }}
+          SHOWCASE_DEV_HELM_RELEASE: ${{ vars.SHOWCASE_DEV_HELM_RELEASE }}
+        run: |
+          set -euo pipefail
+          release="${SHOWCASE_DEV_HELM_RELEASE:-showcase}"
+          ns="${SHOWCASE_DEV_NAMESPACE}"
+          server_deploy="$(oc get deploy -n "${ns}" \
+            -l "app.kubernetes.io/instance=${release},app.kubernetes.io/component=server" \
+            -o jsonpath='{.items[0].metadata.name}')"
+          frontend_deploy="$(oc get deploy -n "${ns}" \
+            -l "app.kubernetes.io/instance=${release},app.kubernetes.io/component=frontend" \
+            -o jsonpath='{.items[0].metadata.name}')"
+          test -n "${server_deploy}" && test -n "${frontend_deploy}"
+          oc rollout restart "deployment/${server_deploy}" -n "${ns}"
+          oc rollout status "deployment/${server_deploy}" -n "${ns}" --timeout=15m
+          oc rollout restart "deployment/${frontend_deploy}" -n "${ns}"
+          oc rollout status "deployment/${frontend_deploy}" -n "${ns}" --timeout=15m

--- a/.github/workflows/deploy-showcase-dev.yaml
+++ b/.github/workflows/deploy-showcase-dev.yaml
@@ -1,0 +1,81 @@
+# Upgrades the showcase Helm release on OpenShift when relevant paths merge to `main`.
+#
+# Configure the bcgov repository (Settings → Secrets and variables → Actions):
+#   Variables (not secret):
+#     SHOWCASE_DEV_OC_URL        — API URL, e.g. https://api.silver.devops.gov.bc.ca:6443
+#     SHOWCASE_DEV_NAMESPACE     — Target namespace (must already exist)
+#   Optional variable:
+#     SHOWCASE_DEV_HELM_RELEASE  — Helm release name (default: showcase)
+#   Secret:
+#     SHOWCASE_DEV_OC_TOKEN      — Service account or user token with permission to
+#                                  helm upgrade/install resources in that namespace
+#
+# If any required variable or the token is missing, this job is skipped (forks stay green).
+
+name: Deploy showcase (dev)
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'charts/showcase/**'
+      - 'frontend/**'
+      - 'server/**'
+      - 'package.json'
+      - 'yarn.lock'
+      - '.github/workflows/deploy-showcase-dev.yaml'
+
+concurrency:
+  group: deploy-showcase-dev-${{ github.repository }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  helm-upgrade-dev:
+    name: Helm upgrade (OpenShift dev)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    if: >-
+      ${{ vars.SHOWCASE_DEV_OC_URL != '' &&
+          vars.SHOWCASE_DEV_NAMESPACE != '' &&
+          secrets.SHOWCASE_DEV_OC_TOKEN != '' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install OpenShift CLI
+        uses: redhat-actions/openshift-tools-installer@v1
+        with:
+          oc: '4.15'
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.16.3
+
+      - name: Log in to OpenShift
+        env:
+          SHOWCASE_DEV_OC_URL: ${{ vars.SHOWCASE_DEV_OC_URL }}
+          SHOWCASE_DEV_OC_TOKEN: ${{ secrets.SHOWCASE_DEV_OC_TOKEN }}
+        run: oc login "${SHOWCASE_DEV_OC_URL}" --token="${SHOWCASE_DEV_OC_TOKEN}"
+
+      - name: Helm dependency update
+        working-directory: charts/showcase
+        run: helm dependency update
+
+      - name: Helm upgrade --install
+        working-directory: charts/showcase
+        env:
+          SHOWCASE_DEV_NAMESPACE: ${{ vars.SHOWCASE_DEV_NAMESPACE }}
+          SHOWCASE_DEV_HELM_RELEASE: ${{ vars.SHOWCASE_DEV_HELM_RELEASE }}
+        run: |
+          set -euo pipefail
+          release="${SHOWCASE_DEV_HELM_RELEASE:-showcase}"
+          helm upgrade --install "${release}" . \
+            -f ../../deploy/showcase/values-dev.yaml \
+            --namespace "${SHOWCASE_DEV_NAMESPACE}" \
+            --wait \
+            --timeout 15m \
+            --atomic

--- a/.github/workflows/deploy-showcase-dev.yaml
+++ b/.github/workflows/deploy-showcase-dev.yaml
@@ -1,6 +1,8 @@
 # Builds and pushes showcase images (tag `main`), then upgrades the dev Helm release on OpenShift
 # when relevant paths merge to `main` (bcgov repo only for GHCR push + deploy).
 #
+# Shared Docker / CLI setup lives under `.github/actions/showcase-*` (same builders as deploy-showcase-pr).
+#
 # Configure the bcgov repository (Settings → Secrets and variables → Actions):
 #   Variables (not secret):
 #     SHOWCASE_DEV_OC_URL        — API URL, e.g. https://api.silver.devops.gov.bc.ca:6443
@@ -30,6 +32,9 @@ on:
       - 'package.json'
       - 'yarn.lock'
       - '.github/workflows/deploy-showcase-dev.yaml'
+      - '.github/actions/showcase-build-server/**'
+      - '.github/actions/showcase-build-frontend/**'
+      - '.github/actions/showcase-setup-oc-helm/**'
 
 concurrency:
   group: deploy-showcase-dev-${{ github.repository }}
@@ -55,32 +60,11 @@ jobs:
       packages: write
       id-token: write
     steps:
-      - uses: actions/checkout@v4
-
-      - uses: docker/login-action@v3
+      - uses: ./.github/actions/showcase-build-server
         with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - uses: docker/setup-buildx-action@v3
-
-      - id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.SHOWCASE_SERVER_IMAGE }}
-          tags: |
-            type=raw,value=main
-
-      - uses: docker/build-push-action@v7
-        with:
-          context: .
-          file: ./server/Dockerfile
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          provenance: mode=min
-          sbom: true
+          image: ${{ env.SHOWCASE_SERVER_IMAGE }}
+          tag: main
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
   build-frontend:
     name: Build and push frontend image (main)
@@ -92,35 +76,13 @@ jobs:
       packages: write
       id-token: write
     steps:
-      - uses: actions/checkout@v4
-
-      - uses: docker/login-action@v3
+      - uses: ./.github/actions/showcase-build-frontend
         with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - uses: docker/setup-buildx-action@v3
-
-      - id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.SHOWCASE_FRONTEND_IMAGE }}
-          tags: |
-            type=raw,value=main
-
-      - uses: docker/build-push-action@v7
-        with:
-          context: .
-          file: ./frontend/Dockerfile
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          provenance: mode=min
-          sbom: true
-          build-args: |
-            REACT_APP_INSIGHTS_PROJECT_ID=${{ vars.REACT_APP_INSIGHTS_PROJECT_ID || secrets.REACT_APP_INSIGHTS_PROJECT_ID }}
-            REACT_APP_HOST_BACKEND=${{ vars.SHOWCASE_DEV_PUBLIC_ORIGIN || 'https://bc-wallet-showcase-dev.apps.silver.devops.gov.bc.ca' }}
+          image: ${{ env.SHOWCASE_FRONTEND_IMAGE }}
+          tag: main
+          react_app_host_backend: ${{ vars.SHOWCASE_DEV_PUBLIC_ORIGIN || 'https://bc-wallet-showcase-dev.apps.silver.devops.gov.bc.ca' }}
+          react_app_insights_project_id: ${{ vars.REACT_APP_INSIGHTS_PROJECT_ID || secrets.REACT_APP_INSIGHTS_PROJECT_ID }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
   helm-upgrade-dev:
     name: Helm upgrade (OpenShift dev)
@@ -140,15 +102,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install OpenShift CLI
-        uses: redhat-actions/openshift-tools-installer@v1
-        with:
-          oc: '4.15'
-
-      - name: Set up Helm
-        uses: azure/setup-helm@v4
-        with:
-          version: v3.16.3
+      - uses: ./.github/actions/showcase-setup-oc-helm
 
       - name: Log in to OpenShift
         env:

--- a/.github/workflows/deploy-showcase-dev.yaml
+++ b/.github/workflows/deploy-showcase-dev.yaml
@@ -35,6 +35,7 @@ on:
       - '.github/actions/showcase-build-server/**'
       - '.github/actions/showcase-build-frontend/**'
       - '.github/actions/showcase-setup-oc-helm/**'
+      - '.github/actions/showcase-helm-lint/**'
 
 concurrency:
   group: deploy-showcase-dev-${{ github.repository }}
@@ -110,9 +111,10 @@ jobs:
           SHOWCASE_DEV_OC_TOKEN: ${{ secrets.SHOWCASE_DEV_OC_TOKEN }}
         run: oc login "${SHOWCASE_DEV_OC_URL}" --token="${SHOWCASE_DEV_OC_TOKEN}"
 
-      - name: Helm dependency update
-        working-directory: charts/showcase
-        run: helm dependency update
+      - uses: ./.github/actions/showcase-helm-lint
+        with:
+          skip_checkout: 'true'
+          skip_helm_install: 'true'
 
       - name: Helm upgrade --install
         working-directory: charts/showcase

--- a/.github/workflows/deploy-showcase-pr.yaml
+++ b/.github/workflows/deploy-showcase-pr.yaml
@@ -1,0 +1,221 @@
+# Build showcase images (tag pr-<number>), Helm install/upgrade per PR, optional URL comment.
+#
+# Configure on bcgov/BC-Wallet-Demo (same secret names as traction PR workflows):
+#   Secrets: OPENSHIFT_SERVER, OPENSHIFT_TOKEN, OPENSHIFT_NAMESPACE
+#   Variables: SHOWCASE_PR_HOST_SUFFIX — hostname without scheme, e.g.
+#     bc-wallet-showcase-dev.apps.silver.devops.gov.bc.ca
+#     Public URL becomes https://pr-<N>-<SHOWCASE_PR_HOST_SUFFIX>
+# Optional build-args (same as build_packages): REACT_APP_* via repo Variables or Secrets.
+#
+# Skips when not bcgov, when SHOWCASE_PR_HOST_SUFFIX is unset, on draft PRs (no deploy), or when
+# OpenShift secrets are missing (no deploy). Fork PRs do not receive org secrets on the runner.
+
+name: Showcase PR — build and deploy
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'charts/showcase/**'
+      - 'deploy/showcase/**'
+      - 'frontend/**'
+      - 'server/**'
+      - 'package.json'
+      - 'yarn.lock'
+      - '.github/workflows/deploy-showcase-pr.yaml'
+    types: [opened, synchronize, reopened, ready_for_review]
+
+concurrency:
+  group: showcase-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  packages: write
+  pull-requests: write
+
+env:
+  HUSKY: '0'
+  REGISTRY: ghcr.io
+  SHOWCASE_SERVER_IMAGE: ghcr.io/${{ github.repository_owner }}/bc-wallet-showcase-server
+  SHOWCASE_FRONTEND_IMAGE: ghcr.io/${{ github.repository_owner }}/bc-wallet-showcase-frontend
+
+jobs:
+  ready:
+    name: Ready gates
+    runs-on: ubuntu-latest
+    outputs:
+      deploy: ${{ github.repository_owner == 'bcgov' && github.event.pull_request.draft != true && vars.SHOWCASE_PR_HOST_SUFFIX != '' }}
+      build: ${{ github.repository_owner == 'bcgov' && vars.SHOWCASE_PR_HOST_SUFFIX != '' }}
+
+  build_server:
+    name: Build and push server image
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    needs: [ready]
+    if: needs.ready.outputs.build == 'true'
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/setup-buildx-action@v3
+
+      - id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.SHOWCASE_SERVER_IMAGE }}
+          tags: |
+            type=raw,value=pr-${{ github.event.pull_request.number }}
+
+      - uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./server/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          provenance: mode=min
+          sbom: true
+
+  build_frontend:
+    name: Build and push frontend image
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    needs: [ready]
+    if: needs.ready.outputs.build == 'true'
+    env:
+      PR_PUBLIC_ORIGIN: https://pr-${{ github.event.pull_request.number }}-${{ vars.SHOWCASE_PR_HOST_SUFFIX }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/setup-buildx-action@v3
+
+      - id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.SHOWCASE_FRONTEND_IMAGE }}
+          tags: |
+            type=raw,value=pr-${{ github.event.pull_request.number }}
+
+      - uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./frontend/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          provenance: mode=min
+          sbom: true
+          build-args: |
+            REACT_APP_INSIGHTS_PROJECT_ID=${{ vars.REACT_APP_INSIGHTS_PROJECT_ID || secrets.REACT_APP_INSIGHTS_PROJECT_ID }}
+            REACT_APP_HOST_BACKEND=${{ env.PR_PUBLIC_ORIGIN }}
+
+  deploy:
+    name: Helm upgrade (PR instance)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    needs: [ready, build_server, build_frontend]
+    if: ${{ always() && needs.ready.outputs.deploy == 'true' && needs.build_server.result == 'success' && needs.build_frontend.result == 'success' && secrets.OPENSHIFT_TOKEN != '' && secrets.OPENSHIFT_SERVER != '' && secrets.OPENSHIFT_NAMESPACE != '' }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: redhat-actions/openshift-tools-installer@v1
+        with:
+          oc: '4.15'
+
+      - uses: azure/setup-helm@v4
+        with:
+          version: v3.16.3
+
+      - uses: redhat-actions/oc-login@v1
+        with:
+          openshift_server_url: ${{ secrets.OPENSHIFT_SERVER }}
+          openshift_token: ${{ secrets.OPENSHIFT_TOKEN }}
+          namespace: ${{ secrets.OPENSHIFT_NAMESPACE }}
+
+      - name: Helm dependency update
+        working-directory: charts/showcase
+        run: helm dependency update
+
+      - name: Helm upgrade --install
+        working-directory: charts/showcase
+        env:
+          PR_NUM: ${{ github.event.pull_request.number }}
+          HOST_SUFFIX: ${{ vars.SHOWCASE_PR_HOST_SUFFIX }}
+          OWNER_LOWER: ${{ github.repository_owner }}
+        run: |
+          set -euo pipefail
+          origin="https://pr-${PR_NUM}-${HOST_SUFFIX}"
+          owner_lc="$(echo "${OWNER_LOWER}" | tr '[:upper:]' '[:lower:]')"
+          helm upgrade --install "pr-${PR_NUM}-showcase" . \
+            -f ../../deploy/showcase/values-pr.yaml \
+            --set-string "showcase.publicOrigin=${origin}" \
+            --set "showcase.server.image.repository=${owner_lc}/bc-wallet-showcase-server" \
+            --set "showcase.server.image.tag=pr-${PR_NUM}" \
+            --set "showcase.frontend.image.repository=${owner_lc}/bc-wallet-showcase-frontend" \
+            --set "showcase.frontend.image.tag=pr-${PR_NUM}" \
+            --wait \
+            --timeout 15m \
+            --atomic
+
+      # Same image tag (:pr-N) may point at a new digest; restart pulls new layers. Wait so the job does not succeed before pods are ready.
+      - name: Restart deployments and wait for rollouts
+        env:
+          PR_NUM: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          oc rollout restart "deployment/pr-${PR_NUM}-showcase-server"
+          oc rollout status "deployment/pr-${PR_NUM}-showcase-server" --timeout=15m
+          oc rollout restart "deployment/pr-${PR_NUM}-showcase-frontend"
+          oc rollout status "deployment/pr-${PR_NUM}-showcase-frontend" --timeout=15m
+
+  pr_urls_comment:
+    name: PR deployment comment
+    runs-on: ubuntu-latest
+    needs: [ready, deploy]
+    if: ${{ always() && needs.ready.outputs.deploy == 'true' && needs.deploy.result == 'success' }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: peter-evans/find-comment@v3
+        id: fc
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: Showcase PR deployment URL
+
+      - name: Create PR deployment comment
+        if: steps.fc.outputs.comment-id == ''
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            | Showcase PR | |
+            | --- | --- |
+            | UI (same host as API) | `https://pr-${{ github.event.pull_request.number }}-${{ vars.SHOWCASE_PR_HOST_SUFFIX }}/digital-trust/showcase` |
+
+            Showcase PR deployment URL (Helm release `pr-${{ github.event.pull_request.number }}-showcase`).
+
+      - name: Update PR deployment comment
+        if: steps.fc.outputs.comment-id != ''
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-id: ${{ steps.fc.outputs.comment-id }}
+          body: |
+            | Showcase PR | |
+            | --- | --- |
+            | UI (same host as API) | `https://pr-${{ github.event.pull_request.number }}-${{ vars.SHOWCASE_PR_HOST_SUFFIX }}/digital-trust/showcase` |
+
+            Showcase PR deployment URL (Helm release `pr-${{ github.event.pull_request.number }}-showcase`).

--- a/.github/workflows/deploy-showcase-pr.yaml
+++ b/.github/workflows/deploy-showcase-pr.yaml
@@ -28,6 +28,7 @@ on:
       - '.github/actions/showcase-build-server/**'
       - '.github/actions/showcase-build-frontend/**'
       - '.github/actions/showcase-setup-oc-helm/**'
+      - '.github/actions/showcase-helm-lint/**'
     types: [opened, synchronize, reopened, ready_for_review]
 
 concurrency:
@@ -106,9 +107,10 @@ jobs:
           openshift_token: ${{ secrets.OPENSHIFT_TOKEN }}
           namespace: ${{ secrets.OPENSHIFT_NAMESPACE }}
 
-      - name: Helm dependency update
-        working-directory: charts/showcase
-        run: helm dependency update
+      - uses: ./.github/actions/showcase-helm-lint
+        with:
+          skip_checkout: 'true'
+          skip_helm_install: 'true'
 
       - name: Helm upgrade --install
         working-directory: charts/showcase

--- a/.github/workflows/deploy-showcase-pr.yaml
+++ b/.github/workflows/deploy-showcase-pr.yaml
@@ -1,5 +1,7 @@
 # Build showcase images (tag pr-<number>), Helm install/upgrade per PR, optional URL comment.
 #
+# Shared Docker steps live under `.github/actions/showcase-build-*` (also used by deploy-showcase-dev).
+#
 # Configure on bcgov/BC-Wallet-Demo (same secret names as traction PR workflows):
 #   Secrets: OPENSHIFT_SERVER, OPENSHIFT_TOKEN, OPENSHIFT_NAMESPACE
 #   Variables: SHOWCASE_PR_HOST_SUFFIX — hostname without scheme, e.g.
@@ -23,6 +25,9 @@ on:
       - 'package.json'
       - 'yarn.lock'
       - '.github/workflows/deploy-showcase-pr.yaml'
+      - '.github/actions/showcase-build-server/**'
+      - '.github/actions/showcase-build-frontend/**'
+      - '.github/actions/showcase-setup-oc-helm/**'
     types: [opened, synchronize, reopened, ready_for_review]
 
 concurrency:
@@ -54,33 +59,16 @@ jobs:
     timeout-minutes: 45
     needs: [ready]
     if: needs.ready.outputs.build == 'true'
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
     steps:
-      - uses: actions/checkout@v4
-
-      - uses: docker/login-action@v3
+      - uses: ./.github/actions/showcase-build-server
         with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - uses: docker/setup-buildx-action@v3
-
-      - id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.SHOWCASE_SERVER_IMAGE }}
-          tags: |
-            type=raw,value=pr-${{ github.event.pull_request.number }}
-
-      - uses: docker/build-push-action@v7
-        with:
-          context: .
-          file: ./server/Dockerfile
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          provenance: mode=min
-          sbom: true
+          image: ${{ env.SHOWCASE_SERVER_IMAGE }}
+          tag: pr-${{ github.event.pull_request.number }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
   build_frontend:
     name: Build and push frontend image
@@ -88,38 +76,18 @@ jobs:
     timeout-minutes: 45
     needs: [ready]
     if: needs.ready.outputs.build == 'true'
-    env:
-      PR_PUBLIC_ORIGIN: https://pr-${{ github.event.pull_request.number }}-${{ vars.SHOWCASE_PR_HOST_SUFFIX }}
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
     steps:
-      - uses: actions/checkout@v4
-
-      - uses: docker/login-action@v3
+      - uses: ./.github/actions/showcase-build-frontend
         with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - uses: docker/setup-buildx-action@v3
-
-      - id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.SHOWCASE_FRONTEND_IMAGE }}
-          tags: |
-            type=raw,value=pr-${{ github.event.pull_request.number }}
-
-      - uses: docker/build-push-action@v7
-        with:
-          context: .
-          file: ./frontend/Dockerfile
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          provenance: mode=min
-          sbom: true
-          build-args: |
-            REACT_APP_INSIGHTS_PROJECT_ID=${{ vars.REACT_APP_INSIGHTS_PROJECT_ID || secrets.REACT_APP_INSIGHTS_PROJECT_ID }}
-            REACT_APP_HOST_BACKEND=${{ env.PR_PUBLIC_ORIGIN }}
+          image: ${{ env.SHOWCASE_FRONTEND_IMAGE }}
+          tag: pr-${{ github.event.pull_request.number }}
+          react_app_host_backend: https://pr-${{ github.event.pull_request.number }}-${{ vars.SHOWCASE_PR_HOST_SUFFIX }}
+          react_app_insights_project_id: ${{ vars.REACT_APP_INSIGHTS_PROJECT_ID || secrets.REACT_APP_INSIGHTS_PROJECT_ID }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
   deploy:
     name: Helm upgrade (PR instance)
@@ -130,13 +98,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: redhat-actions/openshift-tools-installer@v1
-        with:
-          oc: '4.15'
-
-      - uses: azure/setup-helm@v4
-        with:
-          version: v3.16.3
+      - uses: ./.github/actions/showcase-setup-oc-helm
 
       - uses: redhat-actions/oc-login@v1
         with:

--- a/.github/workflows/helm-lint-showcase.yaml
+++ b/.github/workflows/helm-lint-showcase.yaml
@@ -1,0 +1,69 @@
+name: Helm lint (showcase)
+
+on:
+  pull_request:
+    paths:
+      - 'charts/showcase/**'
+      - 'deploy/showcase/**'
+      - '.github/workflows/helm-lint-showcase.yaml'
+      - '.github/workflows/deploy-showcase-dev.yaml'
+      - '.github/workflows/deploy-showcase-pr.yaml'
+      - '.github/workflows/undeploy-showcase-pr.yaml'
+  push:
+    branches: [main]
+    paths:
+      - 'charts/showcase/**'
+      - 'deploy/showcase/**'
+      - '.github/workflows/helm-lint-showcase.yaml'
+      - '.github/workflows/deploy-showcase-dev.yaml'
+      - '.github/workflows/deploy-showcase-pr.yaml'
+      - '.github/workflows/undeploy-showcase-pr.yaml'
+
+permissions:
+  contents: read
+
+jobs:
+  helm-lint-showcase:
+    name: helm dependency update + lint + template
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: azure/setup-helm@v4
+        with:
+          version: v3.16.3
+
+      - name: Helm dependency update
+        working-directory: charts/showcase
+        run: helm dependency update
+
+      - name: Helm lint
+        working-directory: charts/showcase
+        run: >
+          helm lint .
+          --set showcase.publicOrigin=https://example.com
+          --set mongodb.auth.rootPassword=helm-ci-lint-placeholder
+
+      - name: Helm lint (values-dev overlay)
+        working-directory: charts/showcase
+        run: helm lint . -f ../../deploy/showcase/values-dev.yaml
+
+      - name: Helm template (smoke)
+        working-directory: charts/showcase
+        run: >
+          helm template smoke .
+          --set showcase.publicOrigin=https://example.com
+          --set mongodb.auth.rootPassword=helm-ci-lint-placeholder
+          >/dev/null
+
+      - name: Helm template (values-dev overlay)
+        working-directory: charts/showcase
+        run: helm template smoke-dev . -f ../../deploy/showcase/values-dev.yaml >/dev/null
+
+      - name: Helm lint (PR overlay)
+        working-directory: charts/showcase
+        run: helm lint . -f ../../deploy/showcase/values-pr.yaml
+
+      - name: Helm template (PR overlay)
+        working-directory: charts/showcase
+        run: helm template smoke-pr . -f ../../deploy/showcase/values-pr.yaml >/dev/null

--- a/.github/workflows/helm-lint-showcase.yaml
+++ b/.github/workflows/helm-lint-showcase.yaml
@@ -37,4 +37,9 @@ jobs:
     name: helm dependency update + lint + template
     runs-on: ubuntu-latest
     steps:
+      # Local composite actions require the repo on disk before `uses: ./.github/actions/...` resolves.
+      - uses: actions/checkout@v4
+
       - uses: ./.github/actions/showcase-helm-lint
+        with:
+          skip_checkout: 'true'

--- a/.github/workflows/helm-lint-showcase.yaml
+++ b/.github/workflows/helm-lint-showcase.yaml
@@ -9,6 +9,9 @@ on:
       - '.github/workflows/deploy-showcase-dev.yaml'
       - '.github/workflows/deploy-showcase-pr.yaml'
       - '.github/workflows/undeploy-showcase-pr.yaml'
+      - '.github/actions/showcase-build-server/**'
+      - '.github/actions/showcase-build-frontend/**'
+      - '.github/actions/showcase-setup-oc-helm/**'
   push:
     branches: [main]
     paths:
@@ -18,6 +21,9 @@ on:
       - '.github/workflows/deploy-showcase-dev.yaml'
       - '.github/workflows/deploy-showcase-pr.yaml'
       - '.github/workflows/undeploy-showcase-pr.yaml'
+      - '.github/actions/showcase-build-server/**'
+      - '.github/actions/showcase-build-frontend/**'
+      - '.github/actions/showcase-setup-oc-helm/**'
 
 permissions:
   contents: read

--- a/.github/workflows/helm-lint-showcase.yaml
+++ b/.github/workflows/helm-lint-showcase.yaml
@@ -9,9 +9,11 @@ on:
       - '.github/workflows/deploy-showcase-dev.yaml'
       - '.github/workflows/deploy-showcase-pr.yaml'
       - '.github/workflows/undeploy-showcase-pr.yaml'
+      - '.github/workflows/helm-publish-showcase.yaml'
       - '.github/actions/showcase-build-server/**'
       - '.github/actions/showcase-build-frontend/**'
       - '.github/actions/showcase-setup-oc-helm/**'
+      - '.github/actions/showcase-helm-lint/**'
   push:
     branches: [main]
     paths:
@@ -21,9 +23,11 @@ on:
       - '.github/workflows/deploy-showcase-dev.yaml'
       - '.github/workflows/deploy-showcase-pr.yaml'
       - '.github/workflows/undeploy-showcase-pr.yaml'
+      - '.github/workflows/helm-publish-showcase.yaml'
       - '.github/actions/showcase-build-server/**'
       - '.github/actions/showcase-build-frontend/**'
       - '.github/actions/showcase-setup-oc-helm/**'
+      - '.github/actions/showcase-helm-lint/**'
 
 permissions:
   contents: read
@@ -33,43 +37,4 @@ jobs:
     name: helm dependency update + lint + template
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-
-      - uses: azure/setup-helm@v4
-        with:
-          version: v3.16.3
-
-      - name: Helm dependency update
-        working-directory: charts/showcase
-        run: helm dependency update
-
-      - name: Helm lint
-        working-directory: charts/showcase
-        run: >
-          helm lint .
-          --set showcase.publicOrigin=https://example.com
-          --set mongodb.auth.rootPassword=helm-ci-lint-placeholder
-
-      - name: Helm lint (values-dev overlay)
-        working-directory: charts/showcase
-        run: helm lint . -f ../../deploy/showcase/values-dev.yaml
-
-      - name: Helm template (smoke)
-        working-directory: charts/showcase
-        run: >
-          helm template smoke .
-          --set showcase.publicOrigin=https://example.com
-          --set mongodb.auth.rootPassword=helm-ci-lint-placeholder
-          >/dev/null
-
-      - name: Helm template (values-dev overlay)
-        working-directory: charts/showcase
-        run: helm template smoke-dev . -f ../../deploy/showcase/values-dev.yaml >/dev/null
-
-      - name: Helm lint (PR overlay)
-        working-directory: charts/showcase
-        run: helm lint . -f ../../deploy/showcase/values-pr.yaml
-
-      - name: Helm template (PR overlay)
-        working-directory: charts/showcase
-        run: helm template smoke-pr . -f ../../deploy/showcase/values-pr.yaml >/dev/null
+      - uses: ./.github/actions/showcase-helm-lint

--- a/.github/workflows/helm-publish-showcase.yaml
+++ b/.github/workflows/helm-publish-showcase.yaml
@@ -8,6 +8,7 @@ on:
     paths:
       - 'charts/showcase/**'
       - '.github/workflows/helm-publish-showcase.yaml'
+      - '.github/actions/showcase-helm-lint/**'
 
 permissions:
   contents: read
@@ -24,19 +25,18 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: azure/setup-helm@v4
+      - uses: ./.github/actions/showcase-helm-lint
         with:
-          version: v3.16.3
+          skip_checkout: 'true'
 
       - name: Lowercase OCI repository path
         run: |
           echo "OCI_REPOSITORY=$(echo "${{ github.repository_owner }}/bc-wallet-showcase-chart" | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"
 
-      - name: Helm dependency update and package
+      - name: Helm package
         working-directory: charts/showcase
         run: |
           set -euo pipefail
-          helm dependency update
           mkdir -p "$GITHUB_WORKSPACE/dist"
           helm package . --destination "$GITHUB_WORKSPACE/dist"
 

--- a/.github/workflows/helm-publish-showcase.yaml
+++ b/.github/workflows/helm-publish-showcase.yaml
@@ -1,0 +1,73 @@
+name: Publish showcase Helm chart (GHCR OCI)
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - 'charts/showcase/**'
+      - '.github/workflows/helm-publish-showcase.yaml'
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: helm-publish-showcase-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Package and push to ghcr.io (OCI)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: azure/setup-helm@v4
+        with:
+          version: v3.16.3
+
+      - name: Lowercase OCI repository path
+        run: |
+          echo "OCI_REPOSITORY=$(echo "${{ github.repository_owner }}/bc-wallet-showcase-chart" | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"
+
+      - name: Helm dependency update and package
+        working-directory: charts/showcase
+        run: |
+          set -euo pipefail
+          helm dependency update
+          mkdir -p "$GITHUB_WORKSPACE/dist"
+          helm package . --destination "$GITHUB_WORKSPACE/dist"
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push chart (OCI)
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          charts=(dist/showcase-*.tgz)
+          if [[ ${#charts[@]} -ne 1 ]]; then
+            echo "Expected exactly one dist/showcase-*.tgz, got: ${charts[*]-none}"
+            exit 1
+          fi
+          echo "Pushing ${charts[0]} to oci://ghcr.io/${OCI_REPOSITORY}"
+          helm push "${charts[0]}" "oci://ghcr.io/${OCI_REPOSITORY}"
+
+      - name: Install summary
+        run: |
+          ver=$(basename dist/showcase-*.tgz .tgz | sed 's/^showcase-//')
+          echo "### Showcase chart published" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Version:** \`${ver}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "Install (Helm 3.8+):" >> "$GITHUB_STEP_SUMMARY"
+          echo '```bash' >> "$GITHUB_STEP_SUMMARY"
+          echo "helm install showcase oci://ghcr.io/${OCI_REPOSITORY} --version ${ver} \\" >> "$GITHUB_STEP_SUMMARY"
+          echo '  --set showcase.publicOrigin=https://your-api.example' >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/undeploy-showcase-pr.yaml
+++ b/.github/workflows/undeploy-showcase-pr.yaml
@@ -1,0 +1,56 @@
+# Remove Helm release and chart-scoped secrets/PVC when a PR is closed (traction-style cleanup).
+#
+# Requires bcgov repo + OPENSHIFT_SERVER, OPENSHIFT_TOKEN, OPENSHIFT_NAMESPACE (same as deploy-showcase-pr).
+
+name: Showcase PR — uninstall
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'charts/showcase/**'
+      - 'deploy/showcase/**'
+      - 'frontend/**'
+      - 'server/**'
+      - 'package.json'
+      - 'yarn.lock'
+      - '.github/workflows/deploy-showcase-pr.yaml'
+      - '.github/workflows/undeploy-showcase-pr.yaml'
+    types: [closed]
+
+permissions:
+  contents: read
+
+jobs:
+  uninstall:
+    name: Helm uninstall PR instance
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    if: ${{ github.repository_owner == 'bcgov' && secrets.OPENSHIFT_TOKEN != '' && secrets.OPENSHIFT_SERVER != '' && secrets.OPENSHIFT_NAMESPACE != '' }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: azure/setup-helm@v4
+        with:
+          version: v3.16.3
+
+      - uses: redhat-actions/oc-login@v1
+        with:
+          openshift_server_url: ${{ secrets.OPENSHIFT_SERVER }}
+          openshift_token: ${{ secrets.OPENSHIFT_TOKEN }}
+          namespace: ${{ secrets.OPENSHIFT_NAMESPACE }}
+
+      - name: Helm uninstall
+        continue-on-error: true
+        env:
+          PR_NUM: ${{ github.event.pull_request.number }}
+        run: helm uninstall "pr-${PR_NUM}-showcase"
+
+      - name: Delete leftover secrets and PVCs for this release
+        continue-on-error: true
+        env:
+          PR_NUM: ${{ github.event.pull_request.number }}
+        run: >
+          oc delete secret,pvc
+          -l "app.kubernetes.io/instance=pr-${PR_NUM}-showcase"
+          --ignore-not-found=true

--- a/.prettierignore
+++ b/.prettierignore
@@ -3,3 +3,8 @@ frontend/build
 server/build
 server/coverage
 coverage
+
+# Helm: Go templates are not valid YAML for Prettier; vendored packages are binary
+charts/showcase/templates/**
+charts/showcase/charts/**
+charts/showcase/.helmignore

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,6 @@
 {
   "printWidth": 120,
   "semi": false,
-  "singleQuote": true
+  "singleQuote": true,
+  "endOfLine": "lf"
 }

--- a/charts/showcase/.helmignore
+++ b/charts/showcase/.helmignore
@@ -1,0 +1,19 @@
+# Patterns to ignore when building packages.
+.DS_Store
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+.project
+.idea/
+*.tmproj
+.vscode/
+ci/*.*

--- a/charts/showcase/Chart.lock
+++ b/charts/showcase/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: mongodb
+  repository: oci://registry-1.docker.io/cloudpirates
+  version: 0.15.0
+digest: sha256:fb9dea5d3d2f1731a2a9f69fa742a1e0fad99143cf9a6d26b0fd44118a0750d2
+generated: "2026-04-14T19:57:14.228716195-04:00"

--- a/charts/showcase/Chart.yaml
+++ b/charts/showcase/Chart.yaml
@@ -1,0 +1,11 @@
+apiVersion: v2
+name: showcase
+description: Helm chart for the BC Wallet Demo showcase (frontend + server API + MongoDB by default)
+type: application
+version: 0.4.0
+appVersion: '1.0.0'
+dependencies:
+  - name: mongodb
+    version: 0.15.0
+    repository: oci://registry-1.docker.io/cloudpirates
+    condition: mongodb.enabled

--- a/charts/showcase/README.md
+++ b/charts/showcase/README.md
@@ -1,0 +1,112 @@
+# Showcase Helm chart
+
+Helm chart for the BC Wallet Demo **showcase**: **frontend** (Caddy + static SPA), **server** (Express API + Socket.IO), and **MongoDB** (CloudPirates subchart, on by default).
+
+- **MongoDB** is pulled from **CloudPirates** OCI (`oci://registry-1.docker.io/cloudpirates/mongodb`), not Bitnami. Set **`mongodb.enabled: false`** if you use an external database only.
+- This chart does **not** deploy ACA-Py.
+
+## Prerequisites
+
+- Helm 3.9+
+- From repo root, fetch subchart artifacts (ignored by git as `*.tgz`):
+
+```bash
+cd charts/showcase
+helm dependency update
+```
+
+## Install
+
+### OpenShift / BC Gov Silver (recommended overlay)
+
+Use **`deploy/showcase/values-dev.yaml`** for the shared **dev** overlay (ingress, route timeouts, optional auto-secrets, NetworkPolicy, public dev URL). Copy or override for other namespaces or hostnames.
+
+```bash
+cd charts/showcase
+helm dependency update
+helm upgrade --install my-showcase . \
+  -f ../../deploy/showcase/values-dev.yaml \
+  --namespace <namespace> \
+  --create-namespace
+```
+
+Set **`showcase.publicOrigin`** to the browser origin (HTTPS, no path). If **`ingress.enabled`** and **`ingress.frontend.hostname`** are empty, the Ingress host is taken from that URL.
+
+### Generic cluster (minimal example)
+
+```bash
+helm upgrade --install my-showcase . \
+  --namespace bc-wallet-demo --create-namespace \
+  --set showcase.server.existingSecret=bc-wallet-server-env \
+  --set showcase.publicOrigin='https://showcase.example.com'
+```
+
+Create the referenced **`Secret`** first (keys as env names; see **`server/.env.example`** in the app repo).
+
+Default images: **`ghcr.io/bcgov/bc-wallet-showcase-server:main`**, **`ghcr.io/bcgov/bc-wallet-showcase-frontend:main`**. Override **`showcase.server.image`** / **`showcase.frontend.image`** if needed.
+
+## Applying chart changes
+
+**`helm upgrade --install`** applies ConfigMaps, NetworkPolicies, Deployment `command`/`args`, and so on. **`kubectl`/`oc rollout restart` alone** only recreates pods from the manifests already on the cluster; it does **not** pick up edits from your Git checkout until you upgrade the release.
+
+## One hostname (UI + API)
+
+**`showcase.publicOrigin`** is the value passed to **`VITE_HOST_BACKEND`** (scheme + host + optional port, **no path**). With ingress enabled, the usual pattern is one public host: browser → Ingress → Caddy → static files and **`reverse_proxy`** to the API.
+
+**`showcase.baseRoute`** must match **`BASE_ROUTE`** on the server (the chart sets the latter from the same value). It must also match how the **frontend image** was built (Vite `import.meta.env`); changing only Helm without rebuilding the image can desync routes (including Socket.IO paths).
+
+## Caddy → API (in-cluster)
+
+- The frontend Deployment sets **`SHOWCASE_API_UPSTREAM`** using **Kubernetes service-link expansion** (for example **`http://$(SHOWCASE_SERVER_SERVICE_HOST):$(SHOWCASE_SERVER_SERVICE_PORT_HTTP)`** when the API Service is **`showcase-server`** and its port is named **`http`**). The kubelet substitutes the Service **ClusterIP** and port at pod start, so Caddy does not need working pod DNS to reach the API (avoids **`dial tcp: lookup … i/o timeout`** under strict NetworkPolicy / DNS paths).
+- The Caddyfile uses **`{$SHOWCASE_API_UPSTREAM}`** for **`reverse_proxy`** and still sets **`header_up Host`** to **`<api-service-name>:<port>`** (the in-cluster name the app expects), independent of the dial address.
+
+If **`helm upgrade`** was skipped, an older release may still run a previous Caddy/Deployment template (including older **`{$…_SERVICE_HOST}`**-style upstream wiring); **`helm upgrade`** applies the current manifests.
+
+## Networking (`showcase.networkPolicy`)
+
+When **`showcase.networkPolicy.enabled: true`** (default in **`deploy/showcase/values-dev.yaml`** for deny-by-default namespaces):
+
+- **Ingress** from OpenShift router namespaces to the frontend.
+- **Frontend egress**: API (**`showcase.server.containerPort`**, default **5000**) to **server pods** only. **DNS** (**UDP/TCP 53**) and **HTTPS** (**TCP 443**) are allowed to any destination (no **`to`** peers): OpenShift clusters differ in how CoreDNS is reached, and strict namespace/`ipBlock` selectors can block resolution even when port **53** is open.
+- **Server ingress** from the frontend only; **server egress**: Mongo (if enabled) to **Mongo pods** only (**TCP 27017**; `app.kubernetes.io/name: mongodb`, instance = release name), plus the same **DNS + HTTPS** rule as the frontend.
+- **MongoDB** ingress on **27017** from the server only (see **`templates/mongodb/networkpolicy.yaml`**).
+
+The **`wait-for-mongo-tcp`** init container uses the same host as chart-built **`MONGODB_URI`** (**`showcase.mongodb.uriHost`**: Service **ClusterIP** when **`helm install/upgrade`** can **`lookup`** the Service, otherwise the Mongo Service FQDN). That avoids relying on pod DNS for the TCP readiness probe under NetworkPolicy.
+
+**`showcase.networkPolicy.openshiftIngressNamespace`** defaults to **`openshift-ingress`**; override if your cluster uses a different router namespace label.
+
+## Secrets
+
+Prefer a pre-created **`Secret`** and **`showcase.server.existingSecret`**: the server uses **`envFrom`**, so every key becomes an env var (**`MONGODB_URI`**, **`TRACTION_URL`**, **`API_KEY`**, … — see **`server/.env.example`**).
+
+With **`mongodb.enabled: true`**, the chart creates/reuses **`{{ release }}-showcase-mongo-root`** and builds chart-managed **`MONGODB_URI`** from that password (Helm **`lookup`**). Keep **`mongodb.auth.existingSecret`** set to the tpl string in **`deploy/showcase/values-dev.yaml`** so the Mongo subchart and server URI use the same secret source. Use **`showcase.server.existingSecret`** when you want to supply your own full server env (including `MONGODB_URI`).
+
+### Mongo subchart
+
+All **`mongodb:`** keys pass through to CloudPirates. Inspect the packaged chart or:
+
+`helm show values oci://registry-1.docker.io/cloudpirates/mongodb --version 0.15.0`
+
+## Caddy: CSP and **`trusted_proxies`**
+
+- **`showcase.frontend.contentSecurityPolicy`** — default is permissive for the bundled React build; tighten **`connect-src`** / **`script-src`** for hardened environments.
+- **`showcase.frontend.trustedProxies`** — default **`private_ranges`** (trust RFC1918 / loopback for **`X-Forwarded-*`** on **`reverse_proxy`**). **`deploy/showcase/values-dev.yaml`** sets **`0.0.0.0/0`** to mirror the bcgov demo web Caddyfile when the edge forwards from public addresses; only use that when you understand the trade-off.
+
+## Upgrading from chart **0.2.x**
+
+**`showcase.web`** / **`ingress.web`** became **`showcase.frontend`** / **`ingress.frontend`**. Resource names use **`-frontend`** instead of **`-web`**. Plan as a breaking values + object rename.
+
+## Troubleshooting: 503 vs 502 (OpenShift)
+
+- **`503`** on the **public Route**: the router did not get a **successful, timely** response from the backend (readiness, no endpoints, timeout, reset). Check **`oc describe route`**, **`oc get endpoints`**, pod **readiness**, and **router** logs—not only Caddy.
+- **`502`** with **`Server: Caddy`**: **`reverse_proxy`** to the API failed (connect, timeout, **DNS lookup of the upstream hostname**, or NetworkPolicy). Check **frontend** logs for messages like **`lookup <api-service-name>: i/o timeout`** — that means the proxy could not resolve the upstream (this chart uses **service-link env expansion** in **`SHOWCASE_API_UPSTREAM`** so Caddy dials **ClusterIP** instead). From the **frontend** pod, **`wget http://127.0.0.1:3000/<baseRoute>/server/ready`** and **`wget`** to **`…/demo/socket/?EIO=4&transport=polling`** isolate Caddy vs the API path.
+
+**`oc run … curl …` to the frontend Service from inside the same namespace** can hang: the chart NetworkPolicy typically allows **ingress :3000** only from **OpenShift router** namespaces, not from arbitrary pods. Use **`oc exec`** into the **frontend** pod, **`oc port-forward`** to **3000**, or **`curl`** from your laptop to the **public HTTPS** URL.
+
+Quick **public** checks (replace host with yours): **`curl -i`** to **`…/server/ready`**, **`…/demo/socket/?EIO=4&transport=polling`**, and a **WebSocket upgrade** (`Connection: Upgrade`, `Upgrade: websocket`) on **`…/demo/socket/?EIO=4&transport=websocket`**—expect **200** / Engine.IO **`0{`** and **`101 Switching Protocols`** respectively when the path is healthy.
+
+## CI
+
+PRs touching **`charts/showcase/**`** or **`deploy/showcase/**`** run **`helm dependency update`**, **`helm lint`** (default values, **`deploy/showcase/values-dev.yaml`**, and **`deploy/showcase/values-pr.yaml`**), and **`helm template`** (see **`.github/workflows/helm-lint-showcase.yaml`**). Merges to **`main`** can run **`Deploy showcase (dev)`** when repository variables and a token secret are configured (see **`.github/workflows/deploy-showcase-dev.yaml`**).
+
+**PR environments** (bcgov repo only): **`.github/workflows/deploy-showcase-pr.yaml`** builds and pushes **`ghcr.io/bcgov/bc-wallet-showcase-{server,frontend}:pr-<N>`**, then **`helm upgrade --install pr-<N>-showcase`** with **`deploy/showcase/values-pr.yaml`**. Requires repository variable **`SHOWCASE_PR_HOST_SUFFIX`** (hostname only, e.g. `bc-wallet-showcase-dev.apps.silver.devops.gov.bc.ca`) and OpenShift secrets **`OPENSHIFT_SERVER`**, **`OPENSHIFT_TOKEN`**, **`OPENSHIFT_NAMESPACE`** (same names as [traction PR workflows](https://github.com/bcgov/traction/blob/main/.github/workflows/on_pr_opened.yaml)). **`.github/workflows/undeploy-showcase-pr.yaml`** runs on PR close to **`helm uninstall`** and delete labeled **`Secret`**/**`PVC`**.

--- a/charts/showcase/files/caddyfile.tpl
+++ b/charts/showcase/files/caddyfile.tpl
@@ -1,0 +1,61 @@
+:{{ .Values.showcase.frontend.containerPort }} {
+    header {
+        Content-Security-Policy {{ .Values.showcase.frontend.contentSecurityPolicy | quote }};
+        Strict-Transport-Security "max-age=86400; includeSubDomains";
+        X-Content-Type-Options "nosniff";
+        X-XSS-Protection 1;
+        X-Frame-Options DENY;
+    }
+    log {
+        output stdout
+    }
+    root * /srv
+    file_server
+    # baseRoute from Helm (not {$VITE_BASE_ROUTE}) so Caddy matches SPA + /demo/socket before upstream.
+    @encode_static {
+        not path {{ .Values.showcase.baseRoute }}/demo/* {{ .Values.showcase.baseRoute }}/server/* {{ .Values.showcase.baseRoute }}/agent/* {{ .Values.showcase.baseRoute }}/public/* {{ .Values.showcase.baseRoute }}/qr
+    }
+    encode @encode_static zstd gzip
+    # No global `templates` — Engine.IO polling bodies can break the templates handler.
+    vars * basePath {{ .Values.showcase.baseRoute }}
+    handle /health {
+        respond 200
+    }
+    # path_regexp so /demo does not swallow /demo/socket (Socket.IO polling).
+    @demo_root path_regexp demoRoot ^{{ .Values.showcase.baseRoute }}/demo/?$
+    handle @demo_root {
+        redir {vars.basePath}
+    }
+    @dashboard_root path_regexp dashboardRoot ^{{ .Values.showcase.baseRoute }}/dashboard/?$
+    handle @dashboard_root {
+        redir {vars.basePath}
+    }
+    handle {{ .Values.showcase.baseRoute }}* {
+        @websockets {
+            header Connection *Upgrade*
+            header Upgrade    websocket
+        }
+        reverse_proxy @websockets {$SHOWCASE_API_UPSTREAM} {
+            header_up Host {{ include "showcase.server.fullname" . }}:{{ .Values.showcase.server.containerPort }}
+        }
+        @spa_router {
+            not path {{ .Values.showcase.baseRoute }}/demo/* {{ .Values.showcase.baseRoute }}/server/* {{ .Values.showcase.baseRoute }}/agent/ready {{ .Values.showcase.baseRoute }}/public/* {{ .Values.showcase.baseRoute }}/qr
+            file {
+                try_files {path} /index.html
+            }
+        }
+        rewrite @spa_router {http.matchers.file.relative}
+        @pass {
+            path {{ .Values.showcase.baseRoute }}/demo/* {{ .Values.showcase.baseRoute }}/server/* {{ .Values.showcase.baseRoute }}/agent/ready {{ .Values.showcase.baseRoute }}/public/* {{ .Values.showcase.baseRoute }}/qr
+        }
+        reverse_proxy @pass {$SHOWCASE_API_UPSTREAM} {
+            trusted_proxies {{ .Values.showcase.frontend.trustedProxies }}
+            # Stable Host for API (TCP dial uses ClusterIP from SHOWCASE_API_UPSTREAM service-link expansion).
+            header_up Host {{ include "showcase.server.fullname" . }}:{{ .Values.showcase.server.containerPort }}
+            header_up X-Forwarded-Host {host}
+        }
+    }
+    handle {
+        redir {vars.basePath}
+    }
+}

--- a/charts/showcase/templates/NOTES.txt
+++ b/charts/showcase/templates/NOTES.txt
@@ -1,0 +1,28 @@
+1. Get the frontend UI URL (in-cluster or via ingress):
+{{- if .Values.ingress.enabled }}
+{{- $o := urlParse .Values.showcase.publicOrigin }}
+   {{ $o.scheme }}://{{ include "showcase.ingressFrontendHost" . }}{{ .Values.ingress.frontend.path | default "/" }}
+{{- else }}
+   kubectl --namespace {{ include "showcase.namespace" . }} port-forward svc/{{ include "showcase.frontend.fullname" . }} {{ .Values.showcase.frontend.containerPort }}:{{ .Values.showcase.frontend.containerPort }}
+   Then open http://127.0.0.1:{{ .Values.showcase.frontend.containerPort }}
+{{- end }}
+
+2. API service (ClusterIP):
+   {{ include "showcase.server.fullname" . }}:{{ .Values.showcase.server.containerPort }}
+
+{{- if .Values.showcase.server.existingSecret }}
+
+3. Server env comes from Secret `{{ .Values.showcase.server.existingSecret }}` (envFrom).
+{{- else if eq (include "showcase.server.chartServerSecretNeeded" . | trim) "1" }}
+
+3. Server env comes from chart Secret `{{ include "showcase.server.secretName" . }}`.
+{{- end }}
+
+{{- if .Values.mongodb.enabled }}
+
+4. MongoDB (CloudPirates) primary service: {{ include "showcase.mongodb.host" . }}:27017
+{{- end }}
+
+MongoDB subchart: oci://registry-1.docker.io/cloudpirates/mongodb
+
+To apply chart changes (ConfigMap, NetworkPolicy, commands, etc.), run helm upgrade; oc rollout restart alone is not enough.

--- a/charts/showcase/templates/_helpers.tpl
+++ b/charts/showcase/templates/_helpers.tpl
@@ -1,0 +1,229 @@
+{{/*
+Chart name and version for the `helm.sh/chart` label.
+*/}}
+{{- define "showcase.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Short app name (chart name or nameOverride).
+*/}}
+{{- define "showcase.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Fully qualified application name (release + chart, or fullnameOverride).
+*/}}
+{{- define "showcase.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Namespace for templated resources.
+*/}}
+{{- define "showcase.namespace" -}}
+{{- default .Release.Namespace .Values.namespaceOverride }}
+{{- end }}
+
+{{/*
+Selector labels (must match pod template labels used in matchLabels).
+*/}}
+{{- define "showcase.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "showcase.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Common labels on metadata (chart + optional commonLabels).
+*/}}
+{{- define "showcase.labels" -}}
+helm.sh/chart: {{ include "showcase.chart" . }}
+{{ include "showcase.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- range $k, $v := .Values.commonLabels }}
+{{ $k }}: {{ $v | quote }}
+{{- end }}
+{{- end }}
+
+{{/*
+Container image reference (registry + repository + tag or digest).
+*/}}
+{{- define "showcase.image" -}}
+{{- $img := .image -}}
+{{- $global := .global -}}
+{{- $reg := coalesce $img.registry $global.imageRegistry "" -}}
+{{- $repo := $img.repository -}}
+{{- $tag := default "latest" $img.tag -}}
+{{- $dig := $img.digest -}}
+{{- if $dig -}}
+{{- if $reg -}}
+{{- printf "%s/%s@%s" $reg $repo $dig -}}
+{{- else -}}
+{{- printf "%s@%s" $repo $dig -}}
+{{- end -}}
+{{- else -}}
+{{- if $reg -}}
+{{- printf "%s/%s:%s" $reg $repo $tag -}}
+{{- else -}}
+{{- printf "%s:%s" $repo $tag -}}
+{{- end -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+API (server) resource name prefix.
+*/}}
+{{- define "showcase.server.fullname" -}}
+{{- printf "%s-server" (include "showcase.fullname" .) }}
+{{- end }}
+
+{{/*
+Kubernetes service-link env prefix for the API Service `metadata.name` (uppercase, `-` → `_`).
+Used by the frontend `SHOWCASE_API_UPSTREAM` so Caddy dials ClusterIP without pod DNS.
+Must match the server Service port name `http` → `_SERVICE_PORT_HTTP`.
+*/}}
+{{- define "showcase.server.serviceEnvPrefix" -}}
+{{- upper (replace "-" "_" (include "showcase.server.fullname" .)) -}}
+{{- end }}
+
+{{/*
+Frontend (Caddy + static SPA) resource name prefix.
+*/}}
+{{- define "showcase.frontend.fullname" -}}
+{{- printf "%s-frontend" (include "showcase.fullname" .) }}
+{{- end }}
+
+{{/*
+Server container image.
+*/}}
+{{- define "showcase.server.image" -}}
+{{ include "showcase.image" (dict "image" .Values.showcase.server.image "global" .Values.global) }}
+{{- end }}
+
+{{/*
+Frontend container image.
+*/}}
+{{- define "showcase.frontend.image" -}}
+{{ include "showcase.image" (dict "image" .Values.showcase.frontend.image "global" .Values.global) }}
+{{- end }}
+
+{{/*
+MongoDB Service metadata.name / in-cluster short DNS host (must match CloudPirates `mongodb.fullname`).
+*/}}
+{{- define "showcase.mongodb.host" -}}
+{{- if .Values.mongodb.fullnameOverride }}
+{{- .Values.mongodb.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default "mongodb" .Values.mongodb.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Fully-qualified in-cluster DNS name for the MongoDB Service (fallback when Service ClusterIP is unavailable).
+*/}}
+{{- define "showcase.mongodb.serviceFqdn" -}}
+{{- $ns := include "showcase.namespace" . -}}
+{{- $domain := .Values.showcase.clusterDNSDomain | default "cluster.local" -}}
+{{- printf "%s.%s.svc.%s" (include "showcase.mongodb.host" .) $ns $domain }}
+{{- end }}
+
+{{/*
+Host for chart-built MONGODB_URI: Service ClusterIP when lookup succeeds (no DNS; same path as init nc), else FQDN.
+*/}}
+{{- define "showcase.mongodb.uriHost" -}}
+{{- $ns := include "showcase.namespace" . -}}
+{{- $svcName := include "showcase.mongodb.host" . -}}
+{{- $svc := lookup "v1" "Service" $ns $svcName -}}
+{{- if and $svc $svc.spec.clusterIP (ne $svc.spec.clusterIP "None") -}}
+{{- $svc.spec.clusterIP -}}
+{{- else -}}
+{{- include "showcase.mongodb.serviceFqdn" . -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Query fragment appended to chart-built MONGODB_URI after authSource. directConnection=true avoids the
+Node driver sitting in an Unknown topology when a single mongod advertises a different "me" host
+than the in-cluster Service DNS name (common with standalone StatefulSet + ClusterIP).
+*/}}
+{{- define "showcase.mongodb.uriDriverQuerySuffix" -}}
+&directConnection=true
+{{- end }}
+
+{{/*
+Server env Secret name.
+*/}}
+{{- define "showcase.server.secretName" -}}
+{{- printf "%s-server-env" (include "showcase.fullname" .) }}
+{{- end }}
+
+{{/*
+Frontend ConfigMap name (Caddyfile).
+*/}}
+{{- define "showcase.frontend.configmapName" -}}
+{{- printf "%s-frontend-caddy" (include "showcase.fullname" .) }}
+{{- end }}
+
+{{/*
+Fail when required public browser origin is missing.
+*/}}
+{{- define "showcase.validatePublicOrigin" -}}
+{{- if not .Values.showcase.publicOrigin }}
+{{- fail "showcase.publicOrigin must be set to the browser-reachable origin (scheme + host[:port], no path)." }}
+{{- end }}
+{{- end }}
+
+{{/*
+Ingress hostname for the frontend: use ingress.frontend.hostname when set; otherwise the host from
+showcase.publicOrigin (same browser origin for UI + API through Caddy on one hostname).
+*/}}
+{{- define "showcase.ingressFrontendHost" -}}
+{{- include "showcase.validatePublicOrigin" . -}}
+{{- $origin := .Values.showcase.publicOrigin -}}
+{{- $p := urlParse $origin -}}
+{{- coalesce .Values.ingress.frontend.hostname $p.hostname | required "ingress: set ingress.frontend.hostname or use showcase.publicOrigin with a valid host" -}}
+{{- end }}
+
+{{/*
+Secret name for chart-generated Mongo root password (used by mongodb.auth.existingSecret tpl).
+*/}}
+{{- define "showcase.autoMongoRootSecretName" -}}
+{{- printf "%s-showcase-mongo-root" .Release.Name }}
+{{- end }}
+
+{{/*
+True (string "1") when the chart should create *-showcase-server-env (no showcase.server.existingSecret,
+and bundled MongoDB is enabled).
+*/}}
+{{- define "showcase.server.chartServerSecretNeeded" -}}
+{{- if and (not .Values.showcase.server.existingSecret) .Values.mongodb.enabled }}1{{- end }}
+{{- end }}
+
+{{/*
+Fail when bundled MongoDB is on but chart cannot determine generated Mongo secret wiring.
+*/}}
+{{- define "showcase.validateMongoAuth" -}}
+{{- if and .Values.mongodb.enabled (not .Values.showcase.server.existingSecret) }}
+{{- if not (and .Values.mongodb.auth.existingSecret .Values.mongodb.auth.existingSecretPasswordKey) }}
+{{- fail "When mongodb.enabled is true: set mongodb.auth.existingSecret and mongodb.auth.existingSecretPasswordKey for chart-generated Mongo root password wiring." }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/showcase/templates/auto-provisioned-secrets.yaml
+++ b/charts/showcase/templates/auto-provisioned-secrets.yaml
@@ -1,0 +1,39 @@
+{{- if .Values.mongodb.enabled }}
+{{- $ns := include "showcase.namespace" . }}
+{{- $mongoRootSecret := include "showcase.autoMongoRootSecretName" . }}
+{{- $existing := lookup "v1" "Secret" $ns $mongoRootSecret }}
+{{- $pass := "" }}
+{{- if and $existing $existing.data (index $existing.data "password") }}
+{{- $pass = (index $existing.data "password" | b64dec) }}
+{{- else }}
+{{- $pass = randAlphaNum 32 }}
+{{- end }}
+{{- $host := include "showcase.mongodb.uriHost" . }}
+{{- $db := .Values.showcase.server.mongodbConnection.database | default "bcwallet_demo" }}
+{{- $authSource := .Values.showcase.server.mongodbConnection.authSource | default "admin" | urlquery }}
+{{- $user := .Values.mongodb.auth.rootUsername | default "admin" | urlquery }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $mongoRootSecret }}
+  namespace: {{ $ns | quote }}
+  labels: {{- include "showcase.labels" . | nindent 4 }}
+    app.kubernetes.io/component: mongodb
+type: Opaque
+stringData:
+  password: {{ $pass | quote }}
+{{- if not .Values.showcase.server.existingSecret }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "showcase.server.secretName" . }}
+  namespace: {{ $ns | quote }}
+  labels: {{- include "showcase.labels" . | nindent 4 }}
+    app.kubernetes.io/component: server
+type: Opaque
+stringData:
+  MONGODB_URI: {{ printf "mongodb://%s:%s@%s:27017/%s?authSource=%s%s" $user ($pass | urlquery) $host $db $authSource (include "showcase.mongodb.uriDriverQuerySuffix" .) | quote }}
+{{- end }}
+{{- end }}

--- a/charts/showcase/templates/frontend/configmap-caddy.yaml
+++ b/charts/showcase/templates/frontend/configmap-caddy.yaml
@@ -7,64 +7,8 @@ metadata:
     app.kubernetes.io/component: frontend
 data:
   Caddyfile: |
-    :{{ .Values.showcase.frontend.containerPort }} {
-        header {
-            Content-Security-Policy {{ .Values.showcase.frontend.contentSecurityPolicy | quote }};
-            Strict-Transport-Security "max-age=86400; includeSubDomains";
-            X-Content-Type-Options "nosniff";
-            X-XSS-Protection 1;
-            X-Frame-Options DENY;
-        }
-        log {
-            output stdout
-        }
-        root * /srv
-        file_server
-        # baseRoute from Helm (not {$VITE_BASE_ROUTE}) so Caddy matches SPA + /demo/socket before upstream.
-        @encode_static {
-            not path {{ .Values.showcase.baseRoute }}/demo/* {{ .Values.showcase.baseRoute }}/server/* {{ .Values.showcase.baseRoute }}/agent/* {{ .Values.showcase.baseRoute }}/public/* {{ .Values.showcase.baseRoute }}/qr
-        }
-        encode @encode_static zstd gzip
-        # No global `templates` — Engine.IO polling bodies can break the templates handler.
-        vars * basePath {{ .Values.showcase.baseRoute }}
-        handle /health {
-            respond 200
-        }
-        # path_regexp so /demo does not swallow /demo/socket (Socket.IO polling).
-        @demo_root path_regexp demoRoot ^{{ .Values.showcase.baseRoute }}/demo/?$
-        handle @demo_root {
-            redir {vars.basePath}
-        }
-        @dashboard_root path_regexp dashboardRoot ^{{ .Values.showcase.baseRoute }}/dashboard/?$
-        handle @dashboard_root {
-            redir {vars.basePath}
-        }
-        handle {{ .Values.showcase.baseRoute }}* {
-            @websockets {
-                header Connection *Upgrade*
-                header Upgrade    websocket
-            }
-            reverse_proxy @websockets {$SHOWCASE_API_UPSTREAM} {
-                header_up Host {{ include "showcase.server.fullname" . }}:{{ .Values.showcase.server.containerPort }}
-            }
-            @spa_router {
-                not path {{ .Values.showcase.baseRoute }}/demo/* {{ .Values.showcase.baseRoute }}/server/* {{ .Values.showcase.baseRoute }}/agent/ready {{ .Values.showcase.baseRoute }}/public/* {{ .Values.showcase.baseRoute }}/qr
-                file {
-                    try_files {path} /index.html
-                }
-            }
-            rewrite @spa_router {http.matchers.file.relative}
-            @pass {
-                path {{ .Values.showcase.baseRoute }}/demo/* {{ .Values.showcase.baseRoute }}/server/* {{ .Values.showcase.baseRoute }}/agent/ready {{ .Values.showcase.baseRoute }}/public/* {{ .Values.showcase.baseRoute }}/qr
-            }
-            reverse_proxy @pass {$SHOWCASE_API_UPSTREAM} {
-                trusted_proxies {{ .Values.showcase.frontend.trustedProxies }}
-                # Stable Host for API (TCP dial uses ClusterIP from SHOWCASE_API_UPSTREAM service-link expansion).
-                header_up Host {{ include "showcase.server.fullname" . }}:{{ .Values.showcase.server.containerPort }}
-                header_up X-Forwarded-Host {host}
-            }
-        }
-        handle {
-            redir {vars.basePath}
-        }
-    }
+{{- if .Values.showcase.frontend.caddyfile }}
+{{ tpl .Values.showcase.frontend.caddyfile . | nindent 4 }}
+{{- else }}
+{{ tpl (.Files.Get "files/caddyfile.tpl") . | nindent 4 }}
+{{- end }}

--- a/charts/showcase/templates/frontend/configmap-caddy.yaml
+++ b/charts/showcase/templates/frontend/configmap-caddy.yaml
@@ -1,0 +1,70 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "showcase.frontend.configmapName" . }}
+  namespace: {{ include "showcase.namespace" . | quote }}
+  labels: {{- include "showcase.labels" . | nindent 4 }}
+    app.kubernetes.io/component: frontend
+data:
+  Caddyfile: |
+    :{{ .Values.showcase.frontend.containerPort }} {
+        header {
+            Content-Security-Policy {{ .Values.showcase.frontend.contentSecurityPolicy | quote }};
+            Strict-Transport-Security "max-age=86400; includeSubDomains";
+            X-Content-Type-Options "nosniff";
+            X-XSS-Protection 1;
+            X-Frame-Options DENY;
+        }
+        log {
+            output stdout
+        }
+        root * /srv
+        file_server
+        # baseRoute from Helm (not {$VITE_BASE_ROUTE}) so Caddy matches SPA + /demo/socket before upstream.
+        @encode_static {
+            not path {{ .Values.showcase.baseRoute }}/demo/* {{ .Values.showcase.baseRoute }}/server/* {{ .Values.showcase.baseRoute }}/agent/* {{ .Values.showcase.baseRoute }}/public/* {{ .Values.showcase.baseRoute }}/qr
+        }
+        encode @encode_static zstd gzip
+        # No global `templates` — Engine.IO polling bodies can break the templates handler.
+        vars * basePath {{ .Values.showcase.baseRoute }}
+        handle /health {
+            respond 200
+        }
+        # path_regexp so /demo does not swallow /demo/socket (Socket.IO polling).
+        @demo_root path_regexp demoRoot ^{{ .Values.showcase.baseRoute }}/demo/?$
+        handle @demo_root {
+            redir {vars.basePath}
+        }
+        @dashboard_root path_regexp dashboardRoot ^{{ .Values.showcase.baseRoute }}/dashboard/?$
+        handle @dashboard_root {
+            redir {vars.basePath}
+        }
+        handle {{ .Values.showcase.baseRoute }}* {
+            @websockets {
+                header Connection *Upgrade*
+                header Upgrade    websocket
+            }
+            reverse_proxy @websockets {$SHOWCASE_API_UPSTREAM} {
+                header_up Host {{ include "showcase.server.fullname" . }}:{{ .Values.showcase.server.containerPort }}
+            }
+            @spa_router {
+                not path {{ .Values.showcase.baseRoute }}/demo/* {{ .Values.showcase.baseRoute }}/server/* {{ .Values.showcase.baseRoute }}/agent/ready {{ .Values.showcase.baseRoute }}/public/* {{ .Values.showcase.baseRoute }}/qr
+                file {
+                    try_files {path} /index.html
+                }
+            }
+            rewrite @spa_router {http.matchers.file.relative}
+            @pass {
+                path {{ .Values.showcase.baseRoute }}/demo/* {{ .Values.showcase.baseRoute }}/server/* {{ .Values.showcase.baseRoute }}/agent/ready {{ .Values.showcase.baseRoute }}/public/* {{ .Values.showcase.baseRoute }}/qr
+            }
+            reverse_proxy @pass {$SHOWCASE_API_UPSTREAM} {
+                trusted_proxies {{ .Values.showcase.frontend.trustedProxies }}
+                # Stable Host for API (TCP dial uses ClusterIP from SHOWCASE_API_UPSTREAM service-link expansion).
+                header_up Host {{ include "showcase.server.fullname" . }}:{{ .Values.showcase.server.containerPort }}
+                header_up X-Forwarded-Host {host}
+            }
+        }
+        handle {
+            redir {vars.basePath}
+        }
+    }

--- a/charts/showcase/templates/frontend/deployment.yaml
+++ b/charts/showcase/templates/frontend/deployment.yaml
@@ -1,0 +1,79 @@
+apiVersion: apps/v1
+kind: Deployment
+{{- include "showcase.validatePublicOrigin" . }}
+metadata:
+  name: {{ include "showcase.frontend.fullname" . }}
+  namespace: {{ include "showcase.namespace" . | quote }}
+  labels: {{- include "showcase.labels" . | nindent 4 }}
+    app.kubernetes.io/component: frontend
+  {{- with .Values.commonAnnotations }}
+  annotations: {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  replicas: {{ .Values.showcase.frontend.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "showcase.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: frontend
+  template:
+    metadata:
+      labels:
+        {{- include "showcase.labels" . | nindent 8 }}
+        app.kubernetes.io/component: frontend
+        {{- range $k, $v := .Values.showcase.frontend.podLabels }}
+        {{ $k }}: {{ $v | quote }}
+        {{- end }}
+      {{- if .Values.showcase.frontend.podAnnotations }}
+      annotations: {{- toYaml .Values.showcase.frontend.podAnnotations | nindent 8 }}
+      {{- end }}
+    spec:
+      enableServiceLinks: true
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: frontend
+          image: {{ include "showcase.frontend.image" . }}
+          imagePullPolicy: {{ .Values.showcase.frontend.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.showcase.frontend.containerPort }}
+          env:
+            {{- $apiSvcEnv := include "showcase.server.serviceEnvPrefix" . }}
+            - name: SHOWCASE_API_UPSTREAM
+              value: {{ printf "http://$(%s_SERVICE_HOST):$(%s_SERVICE_PORT_HTTP)" $apiSvcEnv $apiSvcEnv | quote }}
+            # Caddyfile runtime vars; SPA paths are baked at image build — keep baseRoute in sync with the image.
+            - name: VITE_BASE_ROUTE
+              value: {{ .Values.showcase.baseRoute | quote }}
+            - name: VITE_HOST_BACKEND
+              value: {{ .Values.showcase.publicOrigin | quote }}
+            {{- if .Values.showcase.insightsProjectId }}
+            - name: VITE_INSIGHTS_PROJECT_ID
+              value: {{ .Values.showcase.insightsProjectId | quote }}
+            {{- end }}
+          volumeMounts:
+            - name: caddyfile
+              mountPath: /etc/caddy/Caddyfile
+              subPath: Caddyfile
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          {{- with .Values.showcase.frontend.resources }}
+          resources: {{- toYaml . | nindent 12 }}
+          {{- end }}
+      volumes:
+        - name: caddyfile
+          configMap:
+            name: {{ include "showcase.frontend.configmapName" . }}
+      {{- with .Values.showcase.frontend.nodeSelector }}
+      nodeSelector: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.showcase.frontend.tolerations }}
+      tolerations: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.showcase.frontend.affinity }}
+      affinity: {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/showcase/templates/frontend/ingress.yaml
+++ b/charts/showcase/templates/frontend/ingress.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "showcase.frontend.fullname" . }}-ingress
+  namespace: {{ include "showcase.namespace" . | quote }}
+  labels: {{- include "showcase.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations: {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className | quote }}
+  {{- end }}
+  rules:
+    - host: {{ include "showcase.ingressFrontendHost" . | quote }}
+      http:
+        paths:
+          - path: {{ .Values.ingress.frontend.path | default "/" | quote }}
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "showcase.frontend.fullname" . }}
+                port:
+                  name: http
+{{- end }}

--- a/charts/showcase/templates/frontend/networkpolicy.yaml
+++ b/charts/showcase/templates/frontend/networkpolicy.yaml
@@ -1,0 +1,64 @@
+{{- if .Values.showcase.networkPolicy.enabled }}
+{{- $ingNs := .Values.showcase.networkPolicy.openshiftIngressNamespace | default "openshift-ingress" }}
+---
+# Ingress / OpenShift router -> frontend (Caddy).
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "showcase.fullname" . }}-frontend-from-ingress
+  namespace: {{ include "showcase.namespace" . | quote }}
+  labels: {{- include "showcase.labels" . | nindent 4 }}
+    app.kubernetes.io/component: frontend
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "showcase.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: frontend
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ $ingNs | quote }}
+        - namespaceSelector:
+            matchLabels:
+              policy-group.network.openshift.io/ingress: ""
+      ports:
+        - protocol: TCP
+          port: {{ .Values.showcase.frontend.containerPort }}
+---
+# Frontend egress: API, DNS, HTTPS (Caddy reverse_proxy + external calls).
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "showcase.fullname" . }}-frontend-egress
+  namespace: {{ include "showcase.namespace" . | quote }}
+  labels: {{- include "showcase.labels" . | nindent 4 }}
+    app.kubernetes.io/component: frontend
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "showcase.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: frontend
+  policyTypes:
+    - Egress
+  egress:
+    # API pods
+    - to:
+        - podSelector:
+            matchLabels:
+              {{- include "showcase.selectorLabels" . | nindent 14 }}
+              app.kubernetes.io/component: server
+      ports:
+        - protocol: TCP
+          port: {{ .Values.showcase.server.containerPort }}
+    # DNS + HTTPS: no `to` peers — cluster DNS paths vary on OpenShift; Caddy needs 443 for upstream TLS.
+    - ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+        - protocol: TCP
+          port: 443
+{{- end }}

--- a/charts/showcase/templates/frontend/service.yaml
+++ b/charts/showcase/templates/frontend/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "showcase.frontend.fullname" . }}
+  namespace: {{ include "showcase.namespace" . | quote }}
+  labels: {{- include "showcase.labels" . | nindent 4 }}
+    app.kubernetes.io/component: frontend
+spec:
+  type: ClusterIP
+  selector:
+    {{- include "showcase.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: frontend
+  ports:
+    - name: http
+      port: {{ .Values.showcase.frontend.containerPort }}
+      targetPort: http

--- a/charts/showcase/templates/mongodb/networkpolicy.yaml
+++ b/charts/showcase/templates/mongodb/networkpolicy.yaml
@@ -1,0 +1,27 @@
+{{- /* MongoDB: ingress from API only. Keep this policy ingress-only; workload egress belongs on the server Deployment, not on MongoDB pods. */}}
+{{- if and .Values.showcase.networkPolicy.enabled .Values.mongodb.enabled }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "showcase.mongodb.host" . }}
+  namespace: {{ include "showcase.namespace" . | quote }}
+  labels: {{- include "showcase.labels" . | nindent 4 }}
+    app.kubernetes.io/component: mongodb
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: mongodb
+      app.kubernetes.io/instance: {{ .Release.Name | quote }}
+  policyTypes:
+    - Ingress
+  ingress:
+    - ports:
+        - protocol: TCP
+          port: 27017
+      from:
+        - podSelector:
+            matchLabels:
+              {{- include "showcase.selectorLabels" . | nindent 14 }}
+              app.kubernetes.io/component: server
+{{- end }}

--- a/charts/showcase/templates/server/deployment.yaml
+++ b/charts/showcase/templates/server/deployment.yaml
@@ -1,0 +1,115 @@
+{{- include "showcase.validateMongoAuth" . }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "showcase.server.fullname" . }}
+  namespace: {{ include "showcase.namespace" . | quote }}
+  labels: {{- include "showcase.labels" . | nindent 4 }}
+    app.kubernetes.io/component: server
+  {{- with .Values.commonAnnotations }}
+  annotations: {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  replicas: {{ .Values.showcase.server.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "showcase.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: server
+  template:
+    metadata:
+      labels:
+        {{- include "showcase.labels" . | nindent 8 }}
+        app.kubernetes.io/component: server
+        {{- range $k, $v := .Values.showcase.server.podLabels }}
+        {{ $k }}: {{ $v | quote }}
+        {{- end }}
+      {{- if .Values.showcase.server.podAnnotations }}
+      annotations: {{- toYaml .Values.showcase.server.podAnnotations | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if and .Values.mongodb.enabled (default true .Values.showcase.server.waitForMongoTcp) }}
+      initContainers:
+        - name: wait-for-mongo-tcp
+          image: {{ .Values.showcase.server.mongoWaitInitContainerImage | quote }}
+          {{- with .Values.showcase.server.mongoWaitInitContainerSecurityContext }}
+          securityContext: {{- toYaml . | nindent 12 }}
+          {{- end }}
+          command:
+            - bash
+            - -c
+            - |
+              set -euo pipefail
+              host="{{ include "showcase.mongodb.uriHost" . }}"
+              tcp_open() {
+                local h="$1" pid t=0
+                bash -c "exec 3<>/dev/tcp/${h}/27017" &
+                pid=$!
+                while kill -0 "${pid}" 2>/dev/null && (( t < 40 )); do
+                  sleep 0.1
+                  t=$((t + 1))
+                done
+                if kill -0 "${pid}" 2>/dev/null; then
+                  kill "${pid}" 2>/dev/null || true
+                  wait "${pid}" 2>/dev/null || true
+                  return 1
+                fi
+                wait "${pid}" || return 1
+              }
+              echo "waiting for Mongo TCP on: ${host}"
+              for ((i = 0; i < 120; i++)); do
+                if tcp_open "${host}"; then
+                  echo "mongo tcp ok (${host})"
+                  exit 0
+                fi
+                if (( i % 15 == 0 && i > 0 )); then
+                  echo "still waiting (attempt block ${i}/120)..."
+                fi
+                sleep 2
+              done
+              echo "timeout waiting for mongo tcp (host: ${host})"
+              exit 1
+      {{- end }}
+      containers:
+        - name: server
+          image: {{ include "showcase.server.image" . }}
+          imagePullPolicy: {{ .Values.showcase.server.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.showcase.server.containerPort }}
+          {{- if .Values.showcase.server.existingSecret }}
+          envFrom:
+            - secretRef:
+                name: {{ .Values.showcase.server.existingSecret | quote }}
+          {{- else if eq (include "showcase.server.chartServerSecretNeeded" . | trim) "1" }}
+          envFrom:
+            - secretRef:
+                name: {{ include "showcase.server.secretName" . }}
+          {{- end }}
+          env:
+            - name: BASE_ROUTE
+              value: {{ .Values.showcase.baseRoute | quote }}
+          {{- range .Values.showcase.server.extraEnv }}
+            - name: {{ .name }}
+              value: {{ .value | quote }}
+          {{- end }}
+          readinessProbe:
+            httpGet:
+              path: {{ printf "%s/server/ready" .Values.showcase.baseRoute }}
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 10
+          {{- with .Values.showcase.server.resources }}
+          resources: {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.showcase.server.nodeSelector }}
+      nodeSelector: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.showcase.server.tolerations }}
+      tolerations: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.showcase.server.affinity }}
+      affinity: {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/showcase/templates/server/networkpolicy.yaml
+++ b/charts/showcase/templates/server/networkpolicy.yaml
@@ -1,0 +1,63 @@
+{{- if .Values.showcase.networkPolicy.enabled }}
+---
+# API ingress from frontend only.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "showcase.fullname" . }}-server-ingress
+  namespace: {{ include "showcase.namespace" . | quote }}
+  labels: {{- include "showcase.labels" . | nindent 4 }}
+    app.kubernetes.io/component: server
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "showcase.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: server
+  policyTypes:
+    - Ingress
+  ingress:
+    - ports:
+        - protocol: TCP
+          port: {{ .Values.showcase.server.containerPort }}
+      from:
+        - podSelector:
+            matchLabels:
+              {{- include "showcase.selectorLabels" . | nindent 14 }}
+              app.kubernetes.io/component: frontend
+---
+# API egress: Mongo (if enabled), DNS, HTTPS.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "showcase.fullname" . }}-server-egress
+  namespace: {{ include "showcase.namespace" . | quote }}
+  labels: {{- include "showcase.labels" . | nindent 4 }}
+    app.kubernetes.io/component: server
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "showcase.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: server
+  policyTypes:
+    - Egress
+  egress:
+    {{- if .Values.mongodb.enabled }}
+    # Restrict Mongo traffic to MongoDB workload pods for this Helm release.
+    - to:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: mongodb
+              app.kubernetes.io/instance: {{ .Release.Name | quote }}
+      ports:
+        - protocol: TCP
+          port: 27017
+    {{- end }}
+    # DNS + HTTPS: no `to` peers — cluster DNS backends vary (Service IP, hostNetwork, node-local); Caddy/server need outbound 443.
+    - ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+        - protocol: TCP
+          port: 443
+{{- end }}

--- a/charts/showcase/templates/server/service.yaml
+++ b/charts/showcase/templates/server/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "showcase.server.fullname" . }}
+  namespace: {{ include "showcase.namespace" . | quote }}
+  labels: {{- include "showcase.labels" . | nindent 4 }}
+    app.kubernetes.io/component: server
+spec:
+  type: ClusterIP
+  selector:
+    {{- include "showcase.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: server
+  ports:
+    - name: http
+      port: {{ .Values.showcase.server.containerPort }}
+      targetPort: http

--- a/charts/showcase/values.yaml
+++ b/charts/showcase/values.yaml
@@ -1,0 +1,156 @@
+## Default values for the showcase umbrella chart (BC Wallet Demo frontend + server + MongoDB).
+## MongoDB is the CloudPirates OCI subchart (not Bitnami); set `mongodb.enabled: false` for an external database only. See charts/showcase/README.md.
+## With Mongo on: either `showcase.server.existingSecret` (full env incl. MONGODB_URI), or chart-generated
+## `*-server-env` from chart-generated Mongo root password Secret (`mongodb.auth.existingSecret` + key lookup).
+
+global:
+  ## If set, used when `showcase.*.image.registry` is empty (see templates `_helpers.tpl` `showcase.image`).
+  imageRegistry: ''
+  imagePullSecrets: []
+
+## Optional Helm release overrides (usually leave empty).
+nameOverride: ''
+fullnameOverride: ''
+## If set, every namespaced resource uses this namespace instead of `helm install --namespace`.
+namespaceOverride: ''
+## If set, passed to subcharts that support `kubeVersion` constraints.
+kubeVersion: ''
+commonLabels: {}
+commonAnnotations: {}
+
+## CloudPirates MongoDB (subchart). Every key here is passed through to `mongodb` (see packaged chart
+## `charts/mongodb-*.tgz` → `values.yaml` for the full schema: probes, metrics, securityContext, etc.).
+##
+## GitOps: prefer `auth.existingSecret` for Mongo root password and `showcase.server.existingSecret` for
+## `MONGODB_URI` + app secrets, instead of inline passwords in this file.
+##
+## `customUsers`: optional extra DB users created at init (name, database, roles, optional existingSecret).
+## If you use a non-root app user for the API, set matching `showcase.server.mongodbConnection` fields
+## or supply `MONGODB_URI` yourself via `showcase.server.existingSecret`.
+mongodb:
+  ## When true, chart creates/reuses `{{ release }}-showcase-mongo-root` and points the Mongo subchart at it
+  ## via `auth.existingSecret`. Set `showcase.server.existingSecret` to bypass chart-managed server `MONGODB_URI`.
+  enabled: true
+  auth:
+    enabled: true
+    rootUsername: admin
+    rootPassword: ''
+    existingSecret: '{{ printf "%s-showcase-mongo-root" .Release.Name }}'
+    existingSecretPasswordKey: password
+  persistence:
+    enabled: true
+    size: 2Gi
+    storageClass: ''
+    accessMode: ReadWriteOnce
+  ## WiredTiger defaults to a large fraction of visible RAM; with a low cgroup memory limit the
+  ## process can be OOMKilled (mongod log ends with "Killed"). orgbook-publisher leaves resources
+  ## unset; we cap cache explicitly and give the pod enough headroom for connections + mongosh probes.
+  performance:
+    wiredTigerCacheSizeGB: '0.25'
+  resources:
+    limits:
+      memory: 1Gi
+    requests:
+      cpu: 100m
+      memory: 512Mi
+  ## Optional app users (CloudPirates init). Example (dev; do not commit real passwords):
+  ## customUsers:
+  ##   - name: showcase
+  ##     database: bcwallet_demo
+  ##     password: ''
+  ##     roles:
+  ##       - readWrite
+  ##       - dbAdmin
+  customUsers: []
+
+## Showcase API (Express server)
+showcase:
+  baseRoute: /digital-trust/showcase
+  ## Pod DNS suffix for in-cluster names (Service FQDNs). Override if the cluster uses a non-default domain.
+  clusterDNSDomain: cluster.local
+  ## Optional NetworkPolicies (deny-by-default namespaces, e.g. OpenShift Silver). See README "Networking".
+  networkPolicy:
+    enabled: false
+    openshiftIngressNamespace: openshift-ingress
+  server:
+    replicaCount: 1
+    ## HTTP listen port for the server container and Service.
+    containerPort: 5000
+    image:
+      ## ghcr.io/bcgov/bc-wallet-showcase-server:main (see https://github.com/orgs/bcgov/packages?repo_name=BC-Wallet-Demo)
+      registry: ghcr.io
+      repository: bcgov/bc-wallet-showcase-server
+      tag: main
+      digest: ''
+      pullPolicy: IfNotPresent
+    resources: {}
+    ## When mongodb.enabled, wait for Mongo TCP before starting the server (recommended). Set false only
+    ## to debug scheduling/SCC issues; the server may still fail until Mongo is reachable.
+    waitForMongoTcp: true
+    ## Init uses bash /dev/tcp against `showcase.mongodb.uriHost` (Service ClusterIP via Helm lookup when
+    ## possible, else Service FQDN) so the probe does not depend on pod DNS. Image must include bash.
+    mongoWaitInitContainerImage: docker.io/library/bash:5.2
+    ## Optional SecurityContext for the Mongo wait initContainer. Leave unset on OpenShift so the
+    ## namespace SCC assigns runAsUser (restricted-v2). Pin runAsUser only if your cluster allows it.
+    mongoWaitInitContainerSecurityContext: {}
+    extraEnv: []
+    ## Name of a pre-created Secret in the release namespace. If set, the chart does not create
+    ## `*-server-env`; the Deployment uses envFrom with this Secret (e.g. ExternalSecrets, SealedSecrets).
+    ## Include `MONGODB_URI` and all keys from `server/.env.example` (TRACTION_URL, API_KEY, etc.).
+    existingSecret: ''
+    ## Used only when the chart builds MONGODB_URI (no showcase.server.existingSecret).
+    ## Defaults target root auth + database `bcwallet_demo`.
+    mongodbConnection:
+      database: bcwallet_demo
+      authSource: admin
+    ## Non-sensitive runtime env vars for the server Deployment.
+    ## Use existingSecret for sensitive credentials and MONGODB_URI.
+    ## Example:
+    ## extraEnv:
+    ##   - name: LOG_LEVEL
+    ##     value: info
+    podAnnotations: {}
+    podLabels: {}
+    nodeSelector: {}
+    tolerations: []
+    affinity: {}
+
+  ## Showcase frontend (Caddy + Vite static build)
+  frontend:
+    replicaCount: 1
+    ## HTTP listen port for Caddy (Caddyfile site block, container, and Service must match).
+    containerPort: 3000
+    ## Caddy Content-Security-Policy header. Default is permissive for Vite/React + API/WS; tighten for production.
+    contentSecurityPolicy: "default-src * data: blob: filesystem: 'unsafe-inline' 'unsafe-eval'"
+    ## Caddy reverse_proxy trusted_proxies: use private_ranges (RFC1918 + loopback) for typical K8s ingress → pod hops.
+    ## Only use 0.0.0.0/0 if you must trust X-Forwarded-* from arbitrary client addresses (not recommended).
+    trustedProxies: private_ranges
+    image:
+      ## ghcr.io/bcgov/bc-wallet-showcase-frontend:main
+      registry: ghcr.io
+      repository: bcgov/bc-wallet-showcase-frontend
+      tag: main
+      digest: ''
+      pullPolicy: IfNotPresent
+    resources: {}
+    podAnnotations: {}
+    podLabels: {}
+    nodeSelector: {}
+    tolerations: []
+    affinity: {}
+
+  ## Browser-visible origin (scheme + host + optional port, no path) for `VITE_HOST_BACKEND`. Same URL the browser uses for UI + API through Caddy on one hostname.
+  ## Default matches repo `frontend/.env.example` (local `kubectl port-forward` to server :5000). When ingress.enabled and ingress.frontend.hostname is empty, the Ingress host is derived from this URL.
+  publicOrigin: 'http://127.0.0.1:5000'
+  ## Optional Microsoft Clarity / App Insights project id (`VITE_INSIGHTS_PROJECT_ID` on the frontend pod; typically baked at image build).
+  insightsProjectId: ''
+
+ingress:
+  enabled: false
+  ## Set when your cluster uses IngressClass (e.g. `openshift-default`, `nginx`).
+  className: ''
+  annotations: {}
+  frontend:
+    ## When empty and ingress.enabled, the host is derived from showcase.publicOrigin (single public origin).
+    hostname: ''
+    path: /

--- a/charts/showcase/values.yaml
+++ b/charts/showcase/values.yaml
@@ -125,6 +125,9 @@ showcase:
     ## Caddy reverse_proxy trusted_proxies: use private_ranges (RFC1918 + loopback) for typical K8s ingress → pod hops.
     ## Only use 0.0.0.0/0 if you must trust X-Forwarded-* from arbitrary client addresses (not recommended).
     trustedProxies: private_ranges
+    ## Optional full Caddy site config (Helm `tpl` over `.`). When empty, the chart uses `files/caddyfile.tpl`
+    ## (same behaviour as before); set this to override without a new chart version.
+    caddyfile: ''
     image:
       ## ghcr.io/bcgov/bc-wallet-showcase-frontend:main
       registry: ghcr.io

--- a/deploy/showcase/values-dev.yaml
+++ b/deploy/showcase/values-dev.yaml
@@ -1,0 +1,45 @@
+## Shared dev overlay (BC Gov OpenShift Silver + public dev URL). Merge with chart defaults:
+## From `charts/showcase`: `helm upgrade --install <rel> . -f ../../deploy/showcase/values-dev.yaml -n <ns>`
+## Set `showcase.publicOrigin` to your HTTPS origin (no path). Ingress host is derived unless `ingress.frontend.hostname` is set.
+## Secrets: chart always creates/reuses `{{ release }}-showcase-mongo-root` for Mongo root password. Set
+## `showcase.server.existingSecret` to use a pre-created server env secret instead of chart-managed `MONGODB_URI`.
+## Enable `showcase.networkPolicy` for deny-by-default namespaces. Route timeout matches bcgov demo web (Socket.IO long-poll).
+
+ingress:
+  enabled: true
+  className: ''
+  annotations:
+    route.openshift.io/termination: edge
+    haproxy.router.openshift.io/timeout: 120s
+  frontend:
+    path: /
+    tls: false
+
+showcase:
+  publicOrigin: 'https://bc-wallet-showcase-dev.apps.silver.devops.gov.bc.ca'
+  networkPolicy:
+    enabled: true
+  server:
+    existingSecret: ''
+    resources:
+      requests:
+        cpu: 25m
+        memory: 256Mi
+      limits:
+        memory: 512Mi
+  frontend:
+    trustedProxies: '0.0.0.0/0'
+    resources:
+      requests:
+        cpu: 25m
+        memory: 128Mi
+      limits:
+        memory: 256Mi
+
+## Mongo root password Secret name (tpl). If you replace the Secret but keep the PVC, expect SCRAM errors until PVC/auth align — see README.
+mongodb:
+  enabled: true
+  auth:
+    rootUsername: admin
+    existingSecret: '{{ printf "%s-showcase-mongo-root" .Release.Name }}'
+    existingSecretPasswordKey: password

--- a/deploy/showcase/values-pr.yaml
+++ b/deploy/showcase/values-pr.yaml
@@ -1,0 +1,50 @@
+## Ephemeral PR overlay (OpenShift Silver). CI sets:
+##   - showcase.publicOrigin → https://pr-<N>-<SHOWCASE_PR_HOST_SUFFIX>
+##   - showcase.server.image.tag / showcase.frontend.image.tag → pr-<N>
+##
+## Requires repository variable SHOWCASE_PR_HOST_SUFFIX (e.g. bc-wallet-showcase-dev.apps.silver.devops.gov.bc.ca).
+
+ingress:
+  enabled: true
+  className: ''
+  annotations:
+    route.openshift.io/termination: edge
+    haproxy.router.openshift.io/timeout: 120s
+  frontend:
+    path: /
+    tls: false
+
+showcase:
+  autoProvisionSecrets: true
+  ## Overridden in CI; placeholder keeps helm lint/template valid locally.
+  publicOrigin: 'https://bc-wallet-showcase-pr-0.apps.silver.devops.gov.bc.ca'
+  networkPolicy:
+    enabled: true
+  server:
+    existingSecret: ''
+    image:
+      pullPolicy: Always
+    resources:
+      requests:
+        cpu: 25m
+        memory: 256Mi
+      limits:
+        memory: 512Mi
+  frontend:
+    trustedProxies: '0.0.0.0/0'
+    image:
+      pullPolicy: Always
+    resources:
+      requests:
+        cpu: 25m
+        memory: 128Mi
+      limits:
+        memory: 256Mi
+
+mongodb:
+  enabled: true
+  auth:
+    rootUsername: admin
+    rootPassword: ''
+    existingSecret: '{{ printf "%s-showcase-mongo-root" .Release.Name }}'
+    existingSecretPasswordKey: password

--- a/frontend/Caddyfile
+++ b/frontend/Caddyfile
@@ -23,12 +23,13 @@
     # Enable serving static files
     file_server
 
-    # Enable gzip, zstd compression
-    encode zstd gzip
+    # Long-poll / streaming (Socket.IO polling, APIs): do not compress — can break or buffer Engine.IO.
+    @encode_static {
+        not path {$VITE_BASE_ROUTE}/demo/* {$VITE_BASE_ROUTE}/server/* {$VITE_BASE_ROUTE}/agent/* {$VITE_BASE_ROUTE}/public/* {$VITE_BASE_ROUTE}/qr
+    }
+    encode @encode_static zstd gzip
 
-    # Enable templates module - required for 
-    templates
-    
+    # No global `templates` — Engine.IO bodies can confuse the templates parser (see chart ConfigMap comment).
     # Matcher `*` is required: otherwise `basePath` is parsed as a path matcher (Caddy 2.8+ vars syntax).
     vars * basePath {$VITE_BASE_ROUTE}
     
@@ -36,10 +37,13 @@
     handle /health {
         respond 200
     }
-    handle {$VITE_BASE_ROUTE}/demo {
+    # Caddy `path` matches prefixes — `/demo` would also match `/demo/socket/…` and break Socket.IO polling.
+    @demo_root path_regexp demoRoot ^{$VITE_BASE_ROUTE}/demo/?$
+    handle @demo_root {
         redir {vars.basePath}
     }
-    handle {$VITE_BASE_ROUTE}/dashboard {
+    @dashboard_root path_regexp dashboardRoot ^{$VITE_BASE_ROUTE}/dashboard/?$
+    handle @dashboard_root {
         redir {vars.basePath}
     }
     handle {$VITE_BASE_ROUTE}* {

--- a/server/.env.example
+++ b/server/.env.example
@@ -8,6 +8,8 @@
 # MONGODB_PASSWORD=
 # Or supply the full URI directly (takes precedence over the individual vars above):
 # MONGODB_URI=mongodb://localhost:27017/bcwallet_demo
+# Optional; default 30000. Lower for faster fail in local tests.
+# MONGO_SERVER_SELECTION_TIMEOUT_MS=30000
 
 TENANT_ID=000000000000000000000000
 API_KEY=000000000000000000000000

--- a/server/src/db/__tests__/connection.test.ts
+++ b/server/src/db/__tests__/connection.test.ts
@@ -30,19 +30,35 @@ describe('connectDB', () => {
 
 describe('connectDB retry behaviour', () => {
   beforeEach(() => {
+    delete process.env.MONGO_SERVER_SELECTION_TIMEOUT_MS
     vi.useFakeTimers()
   })
 
   afterEach(() => {
     vi.useRealTimers()
     vi.restoreAllMocks()
+    delete process.env.MONGO_SERVER_SELECTION_TIMEOUT_MS
   })
 
   it('resolves immediately on first successful connect', async () => {
     vi.spyOn(mongoose, 'connect').mockResolvedValueOnce(mongoose)
     await expect(connectDB()).resolves.toBeUndefined()
     expect(mongoose.connect).toHaveBeenCalledTimes(1)
-    expect(mongoose.connect).toHaveBeenCalledWith(expect.any(String), { serverSelectionTimeoutMS: 3000 })
+    expect(mongoose.connect).toHaveBeenCalledWith(expect.any(String), { serverSelectionTimeoutMS: 30000 })
+  })
+
+  it('uses MONGO_SERVER_SELECTION_TIMEOUT_MS when set to a positive number', async () => {
+    process.env.MONGO_SERVER_SELECTION_TIMEOUT_MS = '12345'
+    vi.spyOn(mongoose, 'connect').mockResolvedValueOnce(mongoose)
+    await expect(connectDB()).resolves.toBeUndefined()
+    expect(mongoose.connect).toHaveBeenCalledWith(expect.any(String), { serverSelectionTimeoutMS: 12345 })
+  })
+
+  it('falls back to default timeout when MONGO_SERVER_SELECTION_TIMEOUT_MS is invalid', async () => {
+    process.env.MONGO_SERVER_SELECTION_TIMEOUT_MS = 'not-a-number'
+    vi.spyOn(mongoose, 'connect').mockResolvedValueOnce(mongoose)
+    await expect(connectDB()).resolves.toBeUndefined()
+    expect(mongoose.connect).toHaveBeenCalledWith(expect.any(String), { serverSelectionTimeoutMS: 30000 })
   })
 
   it('retries after a failed attempt and resolves on second', async () => {

--- a/server/src/db/connection.ts
+++ b/server/src/db/connection.ts
@@ -4,6 +4,18 @@ import logger from '../utils/logger'
 
 import { getMongoUri } from './uri'
 
+function mongoConnectOptions(): mongoose.ConnectOptions {
+  const raw = process.env.MONGO_SERVER_SELECTION_TIMEOUT_MS
+  let serverSelectionTimeoutMS = 30000
+  if (raw !== undefined && raw !== '') {
+    const n = Number(raw)
+    if (Number.isFinite(n) && n > 0) {
+      serverSelectionTimeoutMS = n
+    }
+  }
+  return { serverSelectionTimeoutMS }
+}
+
 function delay(ms: number): Promise<void> {
   return new Promise((resolve) => {
     setTimeout(resolve, ms)
@@ -18,7 +30,7 @@ export async function connectDB(): Promise<void> {
 
   for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
     try {
-      await mongoose.connect(uri, { serverSelectionTimeoutMS: 3000 })
+      await mongoose.connect(uri, mongoConnectOptions())
       logger.info({ uri: sanitizedUri }, 'Connected to MongoDB')
       return
     } catch (error) {


### PR DESCRIPTION
## Summary

Adds a Helm umbrella chart under `charts/showcase/` to deploy the BC Wallet Demo **showcase** stack: **frontend** (Caddy + static SPA), **server** (Express API + Socket.IO), and **MongoDB** (CloudPirates OCI subchart, on by default).

OpenShift behaviour depends on namespace defaults, Route, and whether the release was upgraded after template changes. **`charts/showcase/README.md`** documents **503 vs 502**, why **`oc run curl` → frontend Service** can hang under NetworkPolicy, and how **`SHOWCASE_API_UPSTREAM`** is set from kube service links (stale ConfigMap until **`helm upgrade`**).

## Highlights

- **MongoDB:** CloudPirates OCI subchart (`oci://registry-1.docker.io/cloudpirates/mongodb`), not Bitnami. Defaults tuned for small dev pods (e.g. WiredTiger cache cap).
- **Images:** `ghcr.io/bcgov/bc-wallet-showcase-server:main` and `ghcr.io/bcgov/bc-wallet-showcase-frontend:main` (overridable via `showcase.server.image` / `showcase.frontend.image`).
- **OpenShift overlays:** `deploy/showcase/values-dev.yaml` (shared dev) and `deploy/showcase/values-pr.yaml` (ephemeral PR releases) — ingress + route annotations (e.g. 120s timeout), `showcase.networkPolicy`, optional `showcase.autoProvisionSecrets` + tpl `mongodb.auth.existingSecret` for chart-generated Mongo root + server `MONGODB_URI`.
- **Caddy → API:** Service links + entrypoint sets **`SHOWCASE_API_UPSTREAM`** for `reverse_proxy`; `header_up Host` uses the API Service DNS name.
- **NetworkPolicy:** Router → frontend; frontend egress (API, DNS, HTTPS; broad TCP/5000 for ClusterIP / OVN); server ingress from frontend; server egress; Mongo ingress from server only (see `templates/networkpolicy-mongodb.yaml`).
- **Secrets:** Prefer `showcase.server.existingSecret` (`envFrom`) for production. Chart can build `MONGODB_URI` when Mongo password comes from `mongodb.auth.rootPassword` or `lookup` on `mongodb.auth.existingSecret`.
- **CI:** `helm-lint-showcase.yaml` — `helm dependency update`, `helm lint` (default + `values-dev` + `values-pr`), `helm template`. **`helm-publish-showcase.yaml`** packages the chart to GHCR on **`main`** (and `workflow_dispatch`). **`deploy-showcase-dev.yaml`** optionally upgrades a dev release when secrets/vars are set. **`deploy-showcase-pr.yaml`** / **`undeploy-showcase-pr.yaml`** build `:pr-<N>` images and manage per-PR releases (Traction-style OpenShift secrets).

## Socket.IO / long polling

Caddyfile / chart patterns: **`path_regexp`** for `/demo` and `/dashboard` roots, no global **`templates`**, scoped **`encode`**, Ingress route timeout **120s**.

## Related files

- `frontend/Caddyfile` — aligned with chart Caddy patterns where applicable.
- `server/` — configurable Mongo **`MONGO_SERVER_SELECTION_TIMEOUT_MS`** and connection retry behaviour.
