### PR TITLE
fix(compose): complete Docker Compose MongoDB for #329

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,4 @@
+# Optional web UI for MongoDB: docker compose --profile mongo-ui up
 services:
   mongodb:
     image: mongo:8
@@ -6,14 +7,30 @@ services:
       - mongo-data:/data/db
     environment:
       MONGO_INITDB_DATABASE: bcwallet_demo
-    expose:
-      - '27017'
+    ports:
+      # Published to loopback only — mongosh/Compass on the host; in-cluster use hostname `mongodb`
+      - '127.0.0.1:27017:27017'
     healthcheck:
       test: ['CMD', 'mongosh', '--quiet', '--eval', "db.adminCommand('ping').ok"]
       interval: 10s
       timeout: 5s
       retries: 5
       start_period: 20s
+
+  mongo-express:
+    image: mongo-express:1
+    restart: unless-stopped
+    profiles:
+      - mongo-ui
+    ports:
+      - '127.0.0.1:8081:8081'
+    environment:
+      ME_CONFIG_MONGODB_URL: mongodb://mongodb:27017/
+      ME_CONFIG_BASICAUTH_USERNAME: dev
+      ME_CONFIG_BASICAUTH_PASSWORD: dev
+    depends_on:
+      mongodb:
+        condition: service_healthy
 
   frontend:
     image: bc-wallet-demo-web
@@ -39,6 +56,11 @@ services:
       - '5000:5000'
     env_file:
       - ./server/.env
+    environment:
+      MONGODB_HOST: mongodb
+      MONGODB_PORT: '27017'
+      MONGODB_DB_NAME: bcwallet_demo
+      MONGODB_URI: mongodb://mongodb:27017/bcwallet_demo
     depends_on:
       mongodb:
         condition: service_healthy
@@ -52,6 +74,11 @@ services:
       - '5000:5000'
     volumes:
       - ./:/app
+    environment:
+      MONGODB_HOST: mongodb
+      MONGODB_PORT: '27017'
+      MONGODB_DB_NAME: bcwallet_demo
+      MONGODB_URI: mongodb://mongodb:27017/bcwallet_demo
     depends_on:
       mongodb:
         condition: service_healthy

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,4 +1,8 @@
-# MongoDB (docker-compose service name `mongodb`; optional until the server uses it)
+# MongoDB — docker-compose sets these on `backend` / `dev` (see docker-compose.yml).
+# For native `yarn dev` on the host with Compose Mongo publishing 127.0.0.1:27017, use localhost.
+# MONGODB_HOST=mongodb
+# MONGODB_PORT=27017
+# MONGODB_DB_NAME=bcwallet_demo
 # MONGODB_URI=mongodb://mongodb:27017/bcwallet_demo
 
 TENANT_ID=000000000000000000000000


### PR DESCRIPTION
## Summary

Closes gaps for **PE-06** (Docker Compose MongoDB) on top of the existing `mongodb` service and volume.

## Changes

- **Host port:** publish `27017` on `127.0.0.1` only (mongosh / Compass) — `expose` alone does not bind to the host.
- **Server env in Compose:** `MONGODB_HOST`, `MONGODB_PORT`, `MONGODB_DB_NAME`, and `MONGODB_URI` on `backend` and `dev` (same DB as `MONGO_INITDB_DATABASE`).
- **mongo-express (optional):** service `mongo-express` behind profile `mongo-ui`, loopback `8081`, basic auth `dev`/`dev` (local dev only).
- **Docs:** `server/.env.example` notes Compose vs native `yarn dev` (`localhost`).

## Usage

```bash
docker compose up -d
# optional UI
docker compose --profile mongo-ui up -d
# UI: http://127.0.0.1:8081 (user/pass dev/dev)
```

Made with [Cursor](https://cursor.com)
