### PR TITLE
Add basic login screen to placeholder without auth

### DIFF
--- a/frontend/src/admin/AdminApp.tsx
+++ b/frontend/src/admin/AdminApp.tsx
@@ -1,8 +1,14 @@
+import { Route, Routes } from 'react-router-dom'
+
+import { CreatorPage } from './pages/CreatorPage'
+import { LoginPage } from './pages/LoginPage'
+
 function AdminApp() {
   return (
-    <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100vh' }}>
-      <h1>Hello, Admin!</h1>
-    </div>
+    <Routes>
+      <Route index element={<LoginPage />} />
+      <Route path="creator" element={<CreatorPage />} />
+    </Routes>
   )
 }
 

--- a/frontend/src/admin/__tests__/AdminApp.test.tsx
+++ b/frontend/src/admin/__tests__/AdminApp.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { describe, expect, it, vi } from 'vitest'
+
+import AdminApp from '../AdminApp'
+
+vi.mock('../pages/LoginPage', () => ({
+  LoginPage: () => <div>Login Page</div>,
+}))
+
+vi.mock('../pages/CreatorPage', () => ({
+  CreatorPage: () => <div>Creator Page</div>,
+}))
+
+const renderAdminApp = (initialPath: string) =>
+  render(
+    <MemoryRouter initialEntries={[initialPath]}>
+      <Routes>
+        <Route path="/admin/*" element={<AdminApp />} />
+      </Routes>
+    </MemoryRouter>
+  )
+
+describe('AdminApp', () => {
+  it('renders LoginPage at the index route', () => {
+    renderAdminApp('/admin')
+    expect(screen.getByText('Login Page')).toBeInTheDocument()
+  })
+
+  it('renders CreatorPage at the creator route', () => {
+    renderAdminApp('/admin/creator')
+    expect(screen.getByText('Creator Page')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/admin/pages/CreatorPage.tsx
+++ b/frontend/src/admin/pages/CreatorPage.tsx
@@ -1,0 +1,27 @@
+export function CreatorPage() {
+  return (
+    <div className="container p-4 flex flex-col h-screen">
+      <div className="flex flex-row my-8 md:pt-4 sm:my-4">
+        <div className="flex-1" />
+      </div>
+
+      <div className="flex flex-col flex-grow items-center justify-center">
+        <div className="w-full max-w-sm text-center">
+          <h1 className="text-bcgov-black font-semibold text-3xl lg:text-4xl mb-4">Admin Portal</h1>
+          <p className="text-bcgov-darkgrey text-base">Admin dashboard coming soon.</p>
+        </div>
+      </div>
+
+      <div className="pb-4">
+        <div className="flex justify-center text-bcgov-darkgrey mt-2 select-none">
+          <a href="mailto:ditrust@gov.bc.ca">ditrust@gov.bc.ca</a>
+        </div>
+        <div className="flex justify-center select-none">
+          <p className="self-center mr-2 text-sm text-bcgov-darkgrey">
+            Copyright &#169; 2022 Government of British Columbia
+          </p>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/admin/pages/LoginPage.tsx
+++ b/frontend/src/admin/pages/LoginPage.tsx
@@ -1,0 +1,51 @@
+import { useNavigate } from 'react-router-dom'
+
+import landingScreen from '../../client/assets/light/landing-screen.svg'
+
+export function LoginPage() {
+  const navigate = useNavigate()
+
+  return (
+    <div className="container p-4 flex flex-col h-screen">
+      <div className="flex flex-row my-8 md:pt-4 sm:my-4">
+        <div className="flex-1" />
+      </div>
+
+      <div className="flex flex-col md:flex-row flex-grow">
+        <div className="flex-1 text-left text-bcgov-black font-semibold text-4xl lg:text-5xl xl:text-6xl m-auto">
+          <div className="overflow-hidden py-1 leading-tight">
+            <h1>BC Wallet Showcase</h1>
+          </div>
+          <div className="overflow-hidden">
+            <p className="text-base lg:text-lg font-normal mt-6 text-bcgov-darkgrey">
+              Administration portal for the BC Wallet Showcase.
+            </p>
+          </div>
+          <div className="flex flex-row text-base font-normal mt-6">
+            <button
+              className="bg-bcgov-blue text-white py-3 px-5 rounded-lg font-semibold shadow-sm select-none"
+              onClick={() => navigate('creator')}
+            >
+              Admin Log In
+            </button>
+          </div>
+        </div>
+
+        <div className="flex justify-center flex-grow">
+          <img className="m-5 max-w-lg" src={landingScreen} alt="bc-wallet-showcase" />
+        </div>
+      </div>
+
+      <div className="pb-4">
+        <div className="flex justify-center text-bcgov-darkgrey mt-2 select-none">
+          <a href="mailto:ditrust@gov.bc.ca">ditrust@gov.bc.ca</a>
+        </div>
+        <div className="flex justify-center select-none">
+          <p className="self-center mr-2 text-sm text-bcgov-darkgrey">
+            Copyright &#169; 2022 Government of British Columbia
+          </p>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/admin/pages/__tests__/CreatorPage.test.tsx
+++ b/frontend/src/admin/pages/__tests__/CreatorPage.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, expect, it } from 'vitest'
+
+import { CreatorPage } from '../CreatorPage'
+
+const renderCreatorPage = () =>
+  render(
+    <MemoryRouter>
+      <CreatorPage />
+    </MemoryRouter>
+  )
+
+describe('CreatorPage', () => {
+  it('renders the Admin Portal heading', () => {
+    renderCreatorPage()
+    expect(screen.getByRole('heading', { name: 'Admin Portal' })).toBeInTheDocument()
+  })
+
+  it('renders the placeholder message', () => {
+    renderCreatorPage()
+    expect(screen.getByText('Admin dashboard coming soon.')).toBeInTheDocument()
+  })
+
+  it('renders the contact email link', () => {
+    renderCreatorPage()
+    expect(screen.getByRole('link', { name: 'ditrust@gov.bc.ca' })).toBeInTheDocument()
+  })
+
+  it('renders the copyright notice', () => {
+    renderCreatorPage()
+    expect(screen.getByText(/Government of British Columbia/)).toBeInTheDocument()
+  })
+})

--- a/frontend/src/admin/pages/__tests__/LoginPage.test.tsx
+++ b/frontend/src/admin/pages/__tests__/LoginPage.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen } from '@testing-library/react'
+import { userEvent } from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, expect, it, vi } from 'vitest'
+
+import { LoginPage } from '../LoginPage'
+
+const mockNavigate = vi.fn()
+vi.mock('react-router-dom', async () => {
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  const actual = await vi.importActual('react-router-dom')
+  return { ...actual, useNavigate: () => mockNavigate }
+})
+
+vi.mock('../../../client/assets/light/landing-screen.svg', () => ({ default: 'landing-screen.svg' }))
+
+const renderLoginPage = () =>
+  render(
+    <MemoryRouter>
+      <LoginPage />
+    </MemoryRouter>
+  )
+
+describe('LoginPage', () => {
+  it('renders the page heading', () => {
+    renderLoginPage()
+    expect(screen.getByRole('heading', { name: 'BC Wallet Showcase' })).toBeInTheDocument()
+  })
+
+  it('renders the admin portal description', () => {
+    renderLoginPage()
+    expect(screen.getByText('Administration portal for the BC Wallet Showcase.')).toBeInTheDocument()
+  })
+
+  it('renders the Admin Log In button', () => {
+    renderLoginPage()
+    expect(screen.getByRole('button', { name: 'Admin Log In' })).toBeInTheDocument()
+  })
+
+  it('renders the landing screen image', () => {
+    renderLoginPage()
+    expect(screen.getByAltText('bc-wallet-showcase')).toBeInTheDocument()
+  })
+
+  it('renders the contact email link', () => {
+    renderLoginPage()
+    expect(screen.getByRole('link', { name: 'ditrust@gov.bc.ca' })).toBeInTheDocument()
+  })
+
+  it('navigates to creator page when Admin Log In is clicked', async () => {
+    renderLoginPage()
+    await userEvent.click(screen.getByRole('button', { name: 'Admin Log In' }))
+    expect(mockNavigate).toHaveBeenCalledWith('creator')
+  })
+})


### PR DESCRIPTION
This doesn't have to be merged yet but just creates a nicer styled admin login page that navigates to a placeholder of the admin portal/creator page.

I think I'll work on the auth part (AU-05) now, before trying to do anything with the creator page UI.