### PR TITLE
feat(server): provision MongoDB connection via Mongoose (PE-01,  PE-02)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     volumes:
       - mongo-data:/data/db
     environment:
-      MONGO_INITDB_DATABASE: bcwallet_demo
+      MONGO_INITDB_DATABASE: bc_wallet_showcase
     ports:
       # Published to loopback only — mongosh/Compass on the host; in-cluster use hostname `mongodb`
       - '127.0.0.1:27017:27017'
@@ -59,8 +59,8 @@ services:
     environment:
       MONGODB_HOST: mongodb
       MONGODB_PORT: '27017'
-      MONGODB_DB_NAME: bcwallet_demo
-      MONGODB_URI: mongodb://mongodb:27017/bcwallet_demo
+      MONGODB_DB_NAME: bc_wallet_showcase
+      MONGODB_URI: mongodb://mongodb:27017/bc_wallet_showcase
     depends_on:
       mongodb:
         condition: service_healthy
@@ -77,8 +77,8 @@ services:
     environment:
       MONGODB_HOST: mongodb
       MONGODB_PORT: '27017'
-      MONGODB_DB_NAME: bcwallet_demo
-      MONGODB_URI: mongodb://mongodb:27017/bcwallet_demo
+      MONGODB_DB_NAME: bc_wallet_showcase
+      MONGODB_URI: mongodb://mongodb:27017/bc_wallet_showcase
     depends_on:
       mongodb:
         condition: service_healthy

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,9 +1,13 @@
 # MongoDB — docker-compose sets these on `backend` / `dev` (see docker-compose.yml).
 # For native `yarn dev` on the host with Compose Mongo publishing 127.0.0.1:27017, use localhost.
-# MONGODB_HOST=mongodb
+# MONGODB_HOST=localhost
 # MONGODB_PORT=27017
 # MONGODB_DB_NAME=bcwallet_demo
-# MONGODB_URI=mongodb://mongodb:27017/bcwallet_demo
+# Auth is optional — omit for local dev (no-auth Mongo). Required for staging/prod.
+# MONGODB_USER=
+# MONGODB_PASSWORD=
+# Or supply the full URI directly (takes precedence over the individual vars above):
+# MONGODB_URI=mongodb://localhost:27017/bcwallet_demo
 
 TENANT_ID=000000000000000000000000
 API_KEY=000000000000000000000000

--- a/server/package.json
+++ b/server/package.json
@@ -24,6 +24,7 @@
     "class-validator": "^0.14.4",
     "cors": "^2.8.6",
     "express": "^4.22.1",
+    "mongoose": "^9.4.1",
     "pino": "^9",
     "pino-http": "^10",
     "reflect-metadata": "^0.2.2",
@@ -36,6 +37,7 @@
   "devDependencies": {
     "@vitest/coverage-v8": "^2",
     "dotenv": "^16",
+    "mongodb-memory-server": "^11.0.1",
     "pino-pretty": "^11",
     "ts-node-dev": "^2.0.0",
     "typescript": "^5",

--- a/server/src/db/__tests__/baseSchema.test.ts
+++ b/server/src/db/__tests__/baseSchema.test.ts
@@ -1,0 +1,56 @@
+import { MongoMemoryServer } from 'mongodb-memory-server'
+import mongoose, { Schema, model } from 'mongoose'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+import { baseSchemaOptions, embeddedSchemaOptions } from '../baseSchema'
+
+let mongod: MongoMemoryServer
+
+beforeAll(async () => {
+  mongod = await MongoMemoryServer.create()
+  await mongoose.connect(mongod.getUri())
+})
+
+afterAll(async () => {
+  await mongoose.disconnect()
+  await mongod.stop()
+})
+
+describe('baseSchemaOptions', () => {
+  const TopSchema = new Schema({ name: String }, baseSchemaOptions)
+  const TopModel = model('Top', TopSchema)
+
+  it('adds createdAt and updatedAt timestamps', async () => {
+    const doc = await TopModel.create({ name: 'test' })
+    expect(doc.createdAt).toBeInstanceOf(Date)
+    expect(doc.updatedAt).toBeInstanceOf(Date)
+  })
+
+  it('removes _id and __v from JSON output and exposes id', async () => {
+    const doc = await TopModel.create({ name: 'test' })
+    const json = doc.toJSON()
+    expect(json.id).toBeDefined()
+    expect(json._id).toBeUndefined()
+    expect(json.__v).toBeUndefined()
+  })
+})
+
+describe('embeddedSchemaOptions', () => {
+  const ChildSchema = new Schema({ label: String }, embeddedSchemaOptions)
+  const ParentSchema = new Schema({ children: [ChildSchema] }, baseSchemaOptions)
+  const ParentModel = model('Parent', ParentSchema)
+
+  it('removes _id from embedded subdocument JSON output', async () => {
+    const doc = await ParentModel.create({ children: [{ label: 'child' }] })
+    const json = doc.toJSON()
+    expect(json.children[0]._id).toBeUndefined()
+    expect(json.children[0].label).toBe('child')
+  })
+
+  it('does not add timestamps to embedded subdocuments', async () => {
+    const doc = await ParentModel.create({ children: [{ label: 'child' }] })
+    const json = doc.toJSON()
+    expect(json.children[0].createdAt).toBeUndefined()
+    expect(json.children[0].updatedAt).toBeUndefined()
+  })
+})

--- a/server/src/db/__tests__/connection.test.ts
+++ b/server/src/db/__tests__/connection.test.ts
@@ -42,6 +42,7 @@ describe('connectDB retry behaviour', () => {
     vi.spyOn(mongoose, 'connect').mockResolvedValueOnce(mongoose)
     await expect(connectDB()).resolves.toBeUndefined()
     expect(mongoose.connect).toHaveBeenCalledTimes(1)
+    expect(mongoose.connect).toHaveBeenCalledWith(expect.any(String), { serverSelectionTimeoutMS: 3000 })
   })
 
   it('retries after a failed attempt and resolves on second', async () => {

--- a/server/src/db/__tests__/connection.test.ts
+++ b/server/src/db/__tests__/connection.test.ts
@@ -1,0 +1,25 @@
+import { MongoMemoryServer } from 'mongodb-memory-server'
+import mongoose from 'mongoose'
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
+
+import { connectDB } from '../connection'
+
+let mongod: MongoMemoryServer
+
+beforeAll(async () => {
+  mongod = await MongoMemoryServer.create()
+  vi.stubEnv('MONGODB_URI', mongod.getUri())
+})
+
+afterAll(async () => {
+  await mongoose.disconnect()
+  await mongod.stop()
+  vi.unstubAllEnvs()
+})
+
+describe('connectDB', () => {
+  it('connects to MongoDB and sets readyState to connected', async () => {
+    await connectDB()
+    expect(mongoose.connection.readyState).toBe(1)
+  })
+})

--- a/server/src/db/__tests__/connection.test.ts
+++ b/server/src/db/__tests__/connection.test.ts
@@ -1,8 +1,10 @@
 import { MongoMemoryServer } from 'mongodb-memory-server'
 import mongoose from 'mongoose'
-import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { connectDB } from '../connection'
+import { connectDB, registerShutdownHandlers } from '../connection'
+
+// --- connectDB — happy path ---------------------------------------------------
 
 let mongod: MongoMemoryServer
 
@@ -18,8 +20,94 @@ afterAll(async () => {
 })
 
 describe('connectDB', () => {
-  it('connects to MongoDB and sets readyState to connected', async () => {
+  it('connects and sets readyState to 1', async () => {
     await connectDB()
     expect(mongoose.connection.readyState).toBe(1)
+  })
+})
+
+// --- connectDB — retry logic --------------------------------------------------
+
+describe('connectDB retry behaviour', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  it('resolves immediately on first successful connect', async () => {
+    vi.spyOn(mongoose, 'connect').mockResolvedValueOnce(mongoose)
+    await expect(connectDB()).resolves.toBeUndefined()
+    expect(mongoose.connect).toHaveBeenCalledTimes(1)
+  })
+
+  it('retries after a failed attempt and resolves on second', async () => {
+    vi.spyOn(mongoose, 'connect').mockRejectedValueOnce(new Error('ECONNREFUSED')).mockResolvedValueOnce(mongoose)
+
+    // attach .rejects/.resolves before advancing timers to avoid unhandled rejection warnings
+    const connectPromise = connectDB()
+    await vi.runAllTimersAsync()
+    await expect(connectPromise).resolves.toBeUndefined()
+    expect(mongoose.connect).toHaveBeenCalledTimes(2)
+  })
+
+  it('throws after exhausting all attempts', async () => {
+    vi.spyOn(mongoose, 'connect').mockRejectedValue(new Error('ECONNREFUSED'))
+
+    // attach .rejects immediately so the rejection is never unhandled
+    const assertion = expect(connectDB()).rejects.toThrow('ECONNREFUSED')
+    await vi.runAllTimersAsync()
+    await assertion
+    expect(mongoose.connect).toHaveBeenCalledTimes(3)
+  })
+})
+
+// --- registerShutdownHandlers ─────────────────────────────────────────────────
+
+describe('registerShutdownHandlers', () => {
+  beforeEach(() => {
+    vi.spyOn(process, 'exit').mockImplementation(() => undefined as never)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('registers handlers for SIGTERM and SIGINT', () => {
+    const once = vi.fn()
+    registerShutdownHandlers(vi.fn(), once)
+    expect(once).toHaveBeenCalledWith('SIGTERM', expect.any(Function))
+    expect(once).toHaveBeenCalledWith('SIGINT', expect.any(Function))
+  })
+
+  it('calls disconnectFn when SIGTERM fires', async () => {
+    const handlers: Record<string, () => void> = {}
+    const once = vi.fn((signal: string, handler: () => void) => {
+      handlers[signal] = handler
+    })
+    const disconnectFn = vi.fn().mockResolvedValue(undefined)
+
+    registerShutdownHandlers(disconnectFn, once)
+    handlers['SIGTERM']()
+
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(disconnectFn).toHaveBeenCalledOnce()
+  })
+
+  it('calls disconnectFn when SIGINT fires', async () => {
+    const handlers: Record<string, () => void> = {}
+    const once = vi.fn((signal: string, handler: () => void) => {
+      handlers[signal] = handler
+    })
+    const disconnectFn = vi.fn().mockResolvedValue(undefined)
+
+    registerShutdownHandlers(disconnectFn, once)
+    handlers['SIGINT']()
+
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(disconnectFn).toHaveBeenCalledOnce()
   })
 })

--- a/server/src/db/__tests__/uri.test.ts
+++ b/server/src/db/__tests__/uri.test.ts
@@ -45,7 +45,7 @@ describe('getMongoUri', () => {
     vi.stubEnv('MONGODB_HOST', '')
     vi.stubEnv('MONGODB_PORT', '')
     vi.stubEnv('MONGODB_DB_NAME', '')
-    expect(getMongoUri()).toBe('mongodb://localhost:27017/bcwallet_demo')
+    expect(getMongoUri()).toBe('mongodb://localhost:27017/bc_wallet_showcase')
   })
 
   it('does not include credentials when only user is set without password', () => {

--- a/server/src/db/__tests__/uri.test.ts
+++ b/server/src/db/__tests__/uri.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { getMongoUri } from '../uri'
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+})
+
+describe('getMongoUri', () => {
+  it('returns MONGODB_URI directly when set', () => {
+    vi.stubEnv('MONGODB_URI', 'mongodb://custom-host:27017/mydb')
+    expect(getMongoUri()).toBe('mongodb://custom-host:27017/mydb')
+  })
+
+  it('builds URI from parts with no auth', () => {
+    vi.stubEnv('MONGODB_URI', '')
+    vi.stubEnv('MONGODB_HOST', 'db.example.com')
+    vi.stubEnv('MONGODB_PORT', '27018')
+    vi.stubEnv('MONGODB_DB_NAME', 'myapp')
+    expect(getMongoUri()).toBe('mongodb://db.example.com:27018/myapp')
+  })
+
+  it('includes credentials and authSource=admin when user and password are set', () => {
+    vi.stubEnv('MONGODB_URI', '')
+    vi.stubEnv('MONGODB_HOST', 'db.example.com')
+    vi.stubEnv('MONGODB_PORT', '27017')
+    vi.stubEnv('MONGODB_DB_NAME', 'myapp')
+    vi.stubEnv('MONGODB_USER', 'admin')
+    vi.stubEnv('MONGODB_PASSWORD', 'secret')
+    expect(getMongoUri()).toBe('mongodb://admin:secret@db.example.com:27017/myapp?authSource=admin')
+  })
+
+  it('percent-encodes special characters in credentials', () => {
+    vi.stubEnv('MONGODB_URI', '')
+    vi.stubEnv('MONGODB_HOST', 'localhost')
+    vi.stubEnv('MONGODB_PORT', '27017')
+    vi.stubEnv('MONGODB_DB_NAME', 'myapp')
+    vi.stubEnv('MONGODB_USER', 'user@name')
+    vi.stubEnv('MONGODB_PASSWORD', 'p@ss:word')
+    expect(getMongoUri()).toBe('mongodb://user%40name:p%40ss%3Aword@localhost:27017/myapp?authSource=admin')
+  })
+
+  it('falls back to localhost defaults when no env vars are set', () => {
+    vi.stubEnv('MONGODB_URI', '')
+    vi.stubEnv('MONGODB_HOST', '')
+    vi.stubEnv('MONGODB_PORT', '')
+    vi.stubEnv('MONGODB_DB_NAME', '')
+    expect(getMongoUri()).toBe('mongodb://localhost:27017/bcwallet_demo')
+  })
+
+  it('does not include credentials when only user is set without password', () => {
+    vi.stubEnv('MONGODB_URI', '')
+    vi.stubEnv('MONGODB_HOST', 'localhost')
+    vi.stubEnv('MONGODB_PORT', '27017')
+    vi.stubEnv('MONGODB_DB_NAME', 'myapp')
+    vi.stubEnv('MONGODB_USER', 'admin')
+    vi.stubEnv('MONGODB_PASSWORD', '')
+    expect(getMongoUri()).toBe('mongodb://localhost:27017/myapp')
+  })
+})

--- a/server/src/db/baseSchema.ts
+++ b/server/src/db/baseSchema.ts
@@ -1,0 +1,20 @@
+import type { SchemaOptions } from 'mongoose'
+
+export const baseSchemaOptions: SchemaOptions = {
+  timestamps: true,
+  toJSON: {
+    virtuals: true,
+    transform: (_doc, ret: Record<string, unknown>) => {
+      delete ret['_id']
+      delete ret['__v']
+    },
+  },
+}
+
+export const embeddedSchemaOptions: SchemaOptions = {
+  toJSON: {
+    transform: (_doc, ret: Record<string, unknown>) => {
+      delete ret['_id']
+    },
+  },
+}

--- a/server/src/db/connection.ts
+++ b/server/src/db/connection.ts
@@ -18,7 +18,7 @@ export async function connectDB(): Promise<void> {
 
   for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
     try {
-      await mongoose.connect(uri)
+      await mongoose.connect(uri, { serverSelectionTimeoutMS: 3000 })
       logger.info({ uri: sanitizedUri }, 'Connected to MongoDB')
       return
     } catch (error) {

--- a/server/src/db/connection.ts
+++ b/server/src/db/connection.ts
@@ -4,10 +4,40 @@ import logger from '../utils/logger'
 
 import { getMongoUri } from './uri'
 
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms)
+  })
+}
+
 export async function connectDB(): Promise<void> {
   const uri = getMongoUri()
-  await mongoose.connect(uri)
-  logger.info({ uri: uri.replace(/\/\/.*@/, '//<credentials>@') }, 'Connected to MongoDB')
+  const sanitizedUri = uri.replace(/\/\/.*@/, '//<credentials>@')
+  const maxAttempts = 3
+  const initialBackoffMs = 500
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    try {
+      await mongoose.connect(uri)
+      logger.info({ uri: sanitizedUri }, 'Connected to MongoDB')
+      return
+    } catch (error) {
+      if (attempt === maxAttempts) {
+        logger.error(
+          { attempt, maxAttempts, uri: sanitizedUri, err: error },
+          'Failed to connect to MongoDB after maximum retry attempts'
+        )
+        throw error
+      }
+
+      const backoffMs = initialBackoffMs * 2 ** (attempt - 1)
+      logger.warn(
+        { attempt, maxAttempts, backoffMs, uri: sanitizedUri, err: error },
+        'MongoDB connection attempt failed; retrying'
+      )
+      await delay(backoffMs)
+    }
+  }
 }
 
 export function registerShutdownHandlers(): void {

--- a/server/src/db/connection.ts
+++ b/server/src/db/connection.ts
@@ -14,8 +14,19 @@ export function registerShutdownHandlers(): void {
   const disconnect = async (signal: string) => {
     logger.info({ signal }, 'Disconnecting from MongoDB')
     await mongoose.disconnect()
+    process.exit(0)
   }
 
-  process.once('SIGTERM', () => disconnect('SIGTERM'))
-  process.once('SIGINT', () => disconnect('SIGINT'))
+  process.once('SIGTERM', () => {
+    void disconnect('SIGTERM').catch((error: unknown) => {
+      logger.error({ signal: 'SIGTERM', error }, 'Failed to disconnect from MongoDB')
+      process.exit(1)
+    })
+  })
+  process.once('SIGINT', () => {
+    void disconnect('SIGINT').catch((error: unknown) => {
+      logger.error({ signal: 'SIGINT', error }, 'Failed to disconnect from MongoDB')
+      process.exit(1)
+    })
+  })
 }

--- a/server/src/db/connection.ts
+++ b/server/src/db/connection.ts
@@ -1,0 +1,21 @@
+import mongoose from 'mongoose'
+
+import logger from '../utils/logger'
+
+import { getMongoUri } from './uri'
+
+export async function connectDB(): Promise<void> {
+  const uri = getMongoUri()
+  await mongoose.connect(uri)
+  logger.info({ uri: uri.replace(/\/\/.*@/, '//<credentials>@') }, 'Connected to MongoDB')
+}
+
+export function registerShutdownHandlers(): void {
+  const disconnect = async (signal: string) => {
+    logger.info({ signal }, 'Disconnecting from MongoDB')
+    await mongoose.disconnect()
+  }
+
+  process.once('SIGTERM', () => disconnect('SIGTERM'))
+  process.once('SIGINT', () => disconnect('SIGINT'))
+}

--- a/server/src/db/connection.ts
+++ b/server/src/db/connection.ts
@@ -40,23 +40,25 @@ export async function connectDB(): Promise<void> {
   }
 }
 
-export function registerShutdownHandlers(): void {
+type DisconnectFn = () => Promise<void>
+type OnceFn = (event: string, listener: () => void) => NodeJS.EventEmitter
+
+export function registerShutdownHandlers(
+  disconnectFn: DisconnectFn = () => mongoose.disconnect(),
+  once: OnceFn = process.once.bind(process)
+): void {
   const disconnect = async (signal: string) => {
     logger.info({ signal }, 'Disconnecting from MongoDB')
-    await mongoose.disconnect()
+    await disconnectFn()
     process.exit(0)
   }
 
-  process.once('SIGTERM', () => {
-    void disconnect('SIGTERM').catch((error: unknown) => {
-      logger.error({ signal: 'SIGTERM', error }, 'Failed to disconnect from MongoDB')
-      process.exit(1)
+  for (const signal of ['SIGTERM', 'SIGINT']) {
+    once(signal, () => {
+      void disconnect(signal).catch((error: unknown) => {
+        logger.error({ signal, error }, 'Failed to disconnect from MongoDB')
+        process.exit(1)
+      })
     })
-  })
-  process.once('SIGINT', () => {
-    void disconnect('SIGINT').catch((error: unknown) => {
-      logger.error({ signal: 'SIGINT', error }, 'Failed to disconnect from MongoDB')
-      process.exit(1)
-    })
-  })
+  }
 }

--- a/server/src/db/uri.ts
+++ b/server/src/db/uri.ts
@@ -1,0 +1,17 @@
+export function getMongoUri(): string {
+  if (process.env.MONGODB_URI) return process.env.MONGODB_URI
+
+  const host = process.env.MONGODB_HOST || 'localhost'
+  const port = process.env.MONGODB_PORT || '27017'
+  const db = process.env.MONGODB_DB_NAME || 'bcwallet_demo'
+  const user = process.env.MONGODB_USER
+  const pass = process.env.MONGODB_PASSWORD
+
+  if (user && pass) {
+    const u = encodeURIComponent(user)
+    const p = encodeURIComponent(pass)
+    return `mongodb://${u}:${p}@${host}:${port}/${db}?authSource=admin`
+  }
+
+  return `mongodb://${host}:${port}/${db}`
+}

--- a/server/src/db/uri.ts
+++ b/server/src/db/uri.ts
@@ -3,7 +3,7 @@ export function getMongoUri(): string {
 
   const host = process.env.MONGODB_HOST || 'localhost'
   const port = process.env.MONGODB_PORT || '27017'
-  const db = process.env.MONGODB_DB_NAME || 'bcwallet_demo'
+  const db = process.env.MONGODB_DB_NAME || 'bc_wallet_showcase'
   const user = process.env.MONGODB_USER
   const pass = process.env.MONGODB_PASSWORD
 

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -128,4 +128,7 @@ const run = async () => {
   logger.info('Server listening on port 5000')
 }
 
-run()
+run().catch((error: unknown) => {
+  logger.error({ err: error }, 'Fatal startup error')
+  process.exit(1)
+})

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -3,10 +3,12 @@ import type { Express } from 'express'
 
 import { json, static as stx } from 'express'
 import * as http from 'http'
+import mongoose from 'mongoose'
 import { pinoHttp } from 'pino-http'
 import { createExpressServer } from 'routing-controllers'
 import { Server } from 'socket.io'
 
+import { connectDB, registerShutdownHandlers } from './db/connection'
 import logger from './utils/logger'
 import { tractionApiKeyUpdaterInit, tractionRequest, tractionGarbageCollection } from './utils/tractionHelper'
 
@@ -50,6 +52,9 @@ ws.on('connection', (socket) => {
 })
 
 const run = async () => {
+  await connectDB()
+  registerShutdownHandlers()
+
   await tractionApiKeyUpdaterInit()
   await tractionGarbageCollection()
 
@@ -101,7 +106,8 @@ const run = async () => {
 
   // respond to ditp health checks
   app.get(`${baseRoute}/server/ready`, async (req, res) => {
-    res.json({ ready: true })
+    const dbReady = mongoose.connection.readyState === 1
+    res.status(dbReady ? 200 : 503).json({ ready: dbReady })
     return res
   })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1813,6 +1813,13 @@
   resolved "https://registry.yarnpkg.com/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz#4fc56c15c580b9adb7dc3c333a134e540b44bfb1"
   integrity sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==
 
+"@mongodb-js/saslprep@^1.3.0":
+  version "1.4.8"
+  resolved "https://registry.yarnpkg.com/@mongodb-js/saslprep/-/saslprep-1.4.8.tgz#f978459b1c213a2d806fea0e02a03e9d7086b985"
+  integrity sha512-kpjr2jy2w71w0oqAMI8oibBmiF9lXxWkEQs5gMkW4hVE48bsqINGLxnCSYW62ck/NHXJQpQEfA9WlJ1sY0eqBg==
+  dependencies:
+    sparse-bitfield "^3.0.3"
+
 "@nicolo-ribaudo/eslint-scope-5-internals@5.1.1-v1":
   version "5.1.1-v1"
   resolved "https://registry.yarnpkg.com/@nicolo-ribaudo/eslint-scope-5-internals/-/eslint-scope-5-internals-5.1.1-v1.tgz#dbf733a965ca47b1973177dc0bb6c889edcfb129"
@@ -2762,6 +2769,18 @@
   resolved "https://registry.yarnpkg.com/@types/validator/-/validator-13.15.10.tgz#742b77ec34d58554b94a76a14cef30d59e3c16b9"
   integrity sha512-T8L6i7wCuyoK8A/ZeLYt1+q0ty3Zb9+qbSSvrIVitzT3YjZqkTZ40IbRsPanlB4h1QB3JVL1SYCdR6ngtFYcuA==
 
+"@types/webidl-conversions@*":
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/@types/webidl-conversions/-/webidl-conversions-7.0.3.tgz#1306dbfa53768bcbcfc95a1c8cde367975581859"
+  integrity sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA==
+
+"@types/whatwg-url@^13.0.0":
+  version "13.0.0"
+  resolved "https://registry.yarnpkg.com/@types/whatwg-url/-/whatwg-url-13.0.0.tgz#2b11e32772fd321c0dedf4d655953ea8ce587b2a"
+  integrity sha512-N8WXpbE6Wgri7KUSvrmQcqrMllKZ9uxkYWMt+mCSGwNc0Hsw9VQTW7ApqI4XNrx6/SaM2QQJCzMPDEXE058s+Q==
+  dependencies:
+    "@types/webidl-conversions" "*"
+
 "@types/ws@^8.5.12", "@types/ws@^8.5.5":
   version "8.18.1"
   resolved "https://registry.yarnpkg.com/@types/ws/-/ws-8.18.1.tgz#48464e4bf2ddfd17db13d845467f6070ffea4aa9"
@@ -3579,6 +3598,13 @@ async-function@^1.0.0:
   resolved "https://registry.yarnpkg.com/async-function/-/async-function-1.0.0.tgz#509c9fca60eaf85034c6829838188e4e4c8ffb2b"
   integrity sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==
 
+async-mutex@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/async-mutex/-/async-mutex-0.5.0.tgz#353c69a0b9e75250971a64ac203b0ebfddd75482"
+  integrity sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==
+  dependencies:
+    tslib "^2.4.0"
+
 async@^3.2.0, async@^3.2.6:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/async/-/async-3.2.6.tgz#1b0728e14929d51b85b449b7f06e27c1145e38ce"
@@ -3645,6 +3671,11 @@ axobject-query@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-4.1.0.tgz#28768c76d0e3cff21bc62a9e2d0b6ac30042a1ee"
   integrity sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==
+
+b4a@^1.6.4:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/b4a/-/b4a-1.8.0.tgz#1ca3ba0edc9469aaabef5647e769a83d50180b1a"
+  integrity sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg==
 
 babel-jest@^27.4.2, babel-jest@^27.5.1:
   version "27.5.1"
@@ -3804,6 +3835,49 @@ balanced-match@^4.0.2:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-4.0.4.tgz#bfb10662feed8196a2c62e7c68e17720c274179a"
   integrity sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==
 
+bare-events@^2.5.4, bare-events@^2.7.0:
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/bare-events/-/bare-events-2.8.2.tgz#7b3e10bd8e1fc80daf38bb516921678f566ab89f"
+  integrity sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==
+
+bare-fs@^4.5.5:
+  version "4.7.1"
+  resolved "https://registry.yarnpkg.com/bare-fs/-/bare-fs-4.7.1.tgz#6e81f784761102867c13f0823aa48c942d160f00"
+  integrity sha512-WDRsyVN52eAx/lBamKD6uyw8H4228h/x0sGGGegOamM2cd7Pag88GfMQalobXI+HaEUxpCkbKQUDOQqt9wawRw==
+  dependencies:
+    bare-events "^2.5.4"
+    bare-path "^3.0.0"
+    bare-stream "^2.6.4"
+    bare-url "^2.2.2"
+    fast-fifo "^1.3.2"
+
+bare-os@^3.0.1:
+  version "3.8.7"
+  resolved "https://registry.yarnpkg.com/bare-os/-/bare-os-3.8.7.tgz#09c7c4e8c817de750b0b69b65c929513f69ede65"
+  integrity sha512-G4Gr1UsGeEy2qtDTZwL7JFLo2wapUarz7iTMcYcMFdS89AIQuBoyjgXZz0Utv7uHs3xA9LckhVbeBi8lEQrC+w==
+
+bare-path@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/bare-path/-/bare-path-3.0.0.tgz#b59d18130ba52a6af9276db3e96a2e3d3ea52178"
+  integrity sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==
+  dependencies:
+    bare-os "^3.0.1"
+
+bare-stream@^2.6.4:
+  version "2.13.0"
+  resolved "https://registry.yarnpkg.com/bare-stream/-/bare-stream-2.13.0.tgz#dea59458dcf2689e9387134efccec015dfdbe3cf"
+  integrity sha512-3zAJRZMDFGjdn+RVnNpF9kuELw+0Fl3lpndM4NcEOhb9zwtSo/deETfuIwMSE5BXanA0FrN1qVjffGwAg2Y7EA==
+  dependencies:
+    streamx "^2.25.0"
+    teex "^1.0.1"
+
+bare-url@^2.2.2:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/bare-url/-/bare-url-2.4.0.tgz#1546d63057917189cab9b24629e946e1e8f7af31"
+  integrity sha512-NSTU5WN+fy/L0DDenfE8SXQna4voXuW0FHM7wH8i3/q9khUSchfPbPezO4zSFMnDGIf9YE+mt/RWhZgNRKRIXA==
+  dependencies:
+    bare-path "^3.0.0"
+
 base64-js@^1.3.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
@@ -3945,6 +4019,11 @@ bser@2.1.1:
   dependencies:
     node-int64 "^0.4.0"
 
+bson@^7.1.1:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/bson/-/bson-7.2.0.tgz#1a496a42d9ff130b9f3ab8efd465459c758c747f"
+  integrity sha512-YCEo7KjMlbNlyHhz7zAZNDpIpQbd+wOEHJYezv0nMYTn4x31eIUM2yomNNubclAt63dObUzKHWsBLJ9QcZNSnQ==
+
 buffer-crc32@~0.2.3:
   version "0.2.13"
   resolved "https://registry.yarnpkg.com/buffer-crc32/-/buffer-crc32-0.2.13.tgz#0d333e3f00eac50aa1454abd30ef8c2a5d9a7242"
@@ -4058,7 +4137,7 @@ camelcase@^5.3.1:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
   integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
 
-camelcase@^6.2.0, camelcase@^6.2.1:
+camelcase@^6.2.0, camelcase@^6.2.1, camelcase@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.3.0.tgz#5685b95eb209ac9c0c177467778c9c84df58ba9a"
   integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
@@ -6064,6 +6143,13 @@ eventemitter3@^4.0.0:
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.7.tgz#2de9b68f6528d5644ef5c59526a1b4a07306169f"
   integrity sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==
 
+events-universal@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/events-universal/-/events-universal-1.0.1.tgz#b56a84fd611b6610e0a2d0f09f80fdf931e2dfe6"
+  integrity sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==
+  dependencies:
+    bare-events "^2.7.0"
+
 events@^3.2.0, events@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/events/-/events-3.3.0.tgz#31a95ad0a924e2d2c419a813aeb2c4e878ea7400"
@@ -6223,6 +6309,11 @@ fast-equals@^2.0.3:
   resolved "https://registry.yarnpkg.com/fast-equals/-/fast-equals-2.0.4.tgz#3add9410585e2d7364c2deeb6a707beadb24b927"
   integrity sha512-caj/ZmjHljPrZtbzJ3kfH5ia/k4mTJe/qSiXAGzxZWRZgsgDV0cvNaQULqUX8t0/JVlzzEdYOwCN5DmzTxoD4w==
 
+fast-fifo@^1.2.0, fast-fifo@^1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/fast-fifo/-/fast-fifo-1.3.2.tgz#286e31de96eb96d38a97899815740ba2a4f3640c"
+  integrity sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==
+
 fast-glob@^3.2.9, fast-glob@^3.3.2:
   version "3.3.3"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.3.3.tgz#d06d585ce8dba90a16b0505c543c3ccfb3aeb818"
@@ -6341,7 +6432,7 @@ finalhandler@~1.3.1:
     statuses "~2.0.2"
     unpipe "~1.0.0"
 
-find-cache-dir@^3.3.1:
+find-cache-dir@^3.3.1, find-cache-dir@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/find-cache-dir/-/find-cache-dir-3.3.2.tgz#b30c5b6eff0730731aea9bbd9dbecbd80256d64b"
   integrity sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==
@@ -7058,7 +7149,7 @@ https-proxy-agent@^5.0.0:
     agent-base "6"
     debug "4"
 
-https-proxy-agent@^7.0.5:
+https-proxy-agent@^7.0.5, https-proxy-agent@^7.0.6:
   version "7.0.6"
   resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz#da8dfeac7da130b05c2ba4b59c9b6cd66611a6b9"
   integrity sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==
@@ -8386,6 +8477,11 @@ jsprim@^2.0.2:
     object.assign "^4.1.4"
     object.values "^1.1.6"
 
+kareem@3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/kareem/-/kareem-3.2.0.tgz#8f69b25f9ceac80e9bc46b391008da7fc93d4ab0"
+  integrity sha512-VS8MWZz/cT+SqBCpVfNN4zoVz5VskR3N4+sTmUXme55e9avQHntpwpNq0yjnosISXqwJ3AQVjlbI4Dyzv//JtA==
+
 kbar@^0.1.0-beta.48:
   version "0.1.0-beta.48"
   resolved "https://registry.yarnpkg.com/kbar/-/kbar-0.1.0-beta.48.tgz#2db254cb2943f14200c5a5f47064135737527983"
@@ -8769,6 +8865,11 @@ memfs@^3.1.2, memfs@^3.4.3:
   dependencies:
     fs-monkey "^1.0.4"
 
+memory-pager@^1.0.2:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/memory-pager/-/memory-pager-1.5.0.tgz#d8751655d22d384682741c972f2c3d6dfa3e66b5"
+  integrity sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==
+
 merge-descriptors@1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/merge-descriptors/-/merge-descriptors-1.0.3.tgz#d80319a65f3c7935351e5cfdac8f9318504dbed5"
@@ -8906,6 +9007,61 @@ mkdirp@~0.5.1:
   dependencies:
     minimist "^1.2.6"
 
+mongodb-connection-string-url@^7.0.0:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/mongodb-connection-string-url/-/mongodb-connection-string-url-7.0.1.tgz#347b664cd9e6ddff10d5c1c6010d6d8dbfe9272d"
+  integrity sha512-h0AZ9A7IDVwwHyMxmdMXKy+9oNlF0zFoahHiX3vQ8e3KFcSP3VmsmfvtRSuLPxmyv2vjIDxqty8smTgie/SNRQ==
+  dependencies:
+    "@types/whatwg-url" "^13.0.0"
+    whatwg-url "^14.1.0"
+
+mongodb-memory-server-core@11.0.1:
+  version "11.0.1"
+  resolved "https://registry.yarnpkg.com/mongodb-memory-server-core/-/mongodb-memory-server-core-11.0.1.tgz#952709a231acad192c3cd8b9795b15cdf2a04ff6"
+  integrity sha512-IcIb2S9Xf7Lmz43Z1ZujMqNg7PU5Q7yn+4wOnu7l6pfeGPkEmlqzV1hIbroVx8s4vXhPB1oMGC1u8clW7aj3Xw==
+  dependencies:
+    async-mutex "^0.5.0"
+    camelcase "^6.3.0"
+    debug "^4.4.3"
+    find-cache-dir "^3.3.2"
+    follow-redirects "^1.15.11"
+    https-proxy-agent "^7.0.6"
+    mongodb "^7.0.0"
+    new-find-package-json "^2.0.0"
+    semver "^7.7.3"
+    tar-stream "^3.1.7"
+    tslib "^2.8.1"
+    yauzl "^3.2.0"
+
+mongodb-memory-server@^11.0.1:
+  version "11.0.1"
+  resolved "https://registry.yarnpkg.com/mongodb-memory-server/-/mongodb-memory-server-11.0.1.tgz#6d2848f41460989ef7253d86e2632f387ac4d62a"
+  integrity sha512-nUlKovSJZBh7q5hPsewFRam9H66D08Ne18nyknkNalfXMPtK1Og3kOcuqQhcX88x/pghSZPIJHrLbxNFW3OWiw==
+  dependencies:
+    mongodb-memory-server-core "11.0.1"
+    tslib "^2.8.1"
+
+mongodb@^7.0.0, mongodb@~7.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/mongodb/-/mongodb-7.1.1.tgz#d08479221b81ba66f1f4a858af621edaaa598d95"
+  integrity sha512-067DXiMjcpYQl6bGjWQoTUEE9UoRViTtKFcoqX7z08I+iDZv/emH1g8XEFiO3qiDfXAheT5ozl1VffDTKhIW/w==
+  dependencies:
+    "@mongodb-js/saslprep" "^1.3.0"
+    bson "^7.1.1"
+    mongodb-connection-string-url "^7.0.0"
+
+mongoose@^9.4.1:
+  version "9.4.1"
+  resolved "https://registry.yarnpkg.com/mongoose/-/mongoose-9.4.1.tgz#a329c6b99c417bdc3be7cab32fad840051a1b7b0"
+  integrity sha512-4rFBWa+/wdBQSfvnOPJBpiSG6UCEbhSQh865dEdaH9Y8WfHBUC+I2XT28dp0IBIGrEwmh+gzrgZgea5PbmrHWA==
+  dependencies:
+    kareem "3.2.0"
+    mongodb "~7.1"
+    mpath "0.9.0"
+    mquery "6.0.0"
+    ms "2.1.3"
+    sift "17.1.3"
+
 motion-dom@^12.38.0:
   version "12.38.0"
   resolved "https://registry.yarnpkg.com/motion-dom/-/motion-dom-12.38.0.tgz#9ef3253ea0fb28b6757588327073848d940e9aab"
@@ -8917,6 +9073,16 @@ motion-utils@^12.36.0:
   version "12.36.0"
   resolved "https://registry.yarnpkg.com/motion-utils/-/motion-utils-12.36.0.tgz#cff2df2a28c3fe53a3de7e0103ba7f73ff7d77a7"
   integrity sha512-eHWisygbiwVvf6PZ1vhaHCLamvkSbPIeAYxWUuL3a2PD/TROgE7FvfHWTIH4vMl798QLfMw15nRqIaRDXTlYRg==
+
+mpath@0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/mpath/-/mpath-0.9.0.tgz#0c122fe107846e31fc58c75b09c35514b3871904"
+  integrity sha512-ikJRQTk8hw5DEoFVxHG1Gn9T/xcjtdnOKIU1JTmGjZZlg9LST2mBLmcX3/ICIbgJydT2GOc15RnNy5mHmzfSew==
+
+mquery@6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/mquery/-/mquery-6.0.0.tgz#ef6d744619ff13368c1b137d09a7adc5530fce9e"
+  integrity sha512-b2KQNsmgtkscfeDgkYMcWGn9vZI9YoXh802VDEwE6qc50zxBFQ0Oo8ROkawbPAsXCY1/Z1yp0MagqsZStPWJjw==
 
 ms@2.0.0:
   version "2.0.0"
@@ -8989,6 +9155,13 @@ neo-async@^2.6.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
   integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
+
+new-find-package-json@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/new-find-package-json/-/new-find-package-json-2.0.0.tgz#96553638781db35061f351e8ccb4d07126b6407d"
+  integrity sha512-lDcBsjBSMlj3LXH2v/FW3txlh2pYTjmbOXPYJD93HI5EwuLzI11tdHSIpUMmfq/IOsldj4Ps8M8flhm+pCK4Ew==
+  dependencies:
+    debug "^4.3.4"
 
 no-case@^3.0.4:
   version "3.0.4"
@@ -11104,7 +11277,7 @@ semver@^7.3.2:
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.6.3.tgz#980f7b5550bc175fb4dc09403085627f9eb33143"
   integrity sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==
 
-semver@^7.3.5, semver@^7.3.7, semver@^7.5.3, semver@^7.5.4:
+semver@^7.3.5, semver@^7.3.7, semver@^7.5.3, semver@^7.5.4, semver@^7.7.3:
   version "7.7.4"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.7.4.tgz#28464e36060e991fa7a11d0279d2d3f3b57a7e8a"
   integrity sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==
@@ -11286,6 +11459,11 @@ side-channel@^1.1.0:
     side-channel-map "^1.0.1"
     side-channel-weakmap "^1.0.2"
 
+sift@17.1.3:
+  version "17.1.3"
+  resolved "https://registry.yarnpkg.com/sift/-/sift-17.1.3.tgz#9d2000d4d41586880b0079b5183d839c7a142bf7"
+  integrity sha512-Rtlj66/b0ICeFzYTuNvX/EF1igRbbnGSvEyT79McoZa/DeGhMyC5pWKOEsZKnpkqtSeovd5FL/bjHWC3CIIvCQ==
+
 siginfo@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/siginfo/-/siginfo-2.0.0.tgz#32e76c70b79724e3bb567cb9d543eb858ccfaf30"
@@ -11438,6 +11616,13 @@ sourcemap-codec@^1.4.8:
   resolved "https://registry.yarnpkg.com/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz#ea804bd94857402e6992d05a38ef1ae35a9ab4c4"
   integrity sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==
 
+sparse-bitfield@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz#ff4ae6e68656056ba4b3e792ab3334d38273ca11"
+  integrity sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==
+  dependencies:
+    memory-pager "^1.0.2"
+
 spawn-command@^0.0.2-1:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/spawn-command/-/spawn-command-0.0.2.tgz#9544e1a43ca045f8531aac1a48cb29bdae62338e"
@@ -11552,6 +11737,15 @@ streamsearch@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/streamsearch/-/streamsearch-1.1.0.tgz#404dd1e2247ca94af554e841a8ef0eaa238da764"
   integrity sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==
+
+streamx@^2.12.5, streamx@^2.15.0, streamx@^2.25.0:
+  version "2.25.0"
+  resolved "https://registry.yarnpkg.com/streamx/-/streamx-2.25.0.tgz#cc967e99390fda8b918b1eeaf3bc437637c8c7af"
+  integrity sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==
+  dependencies:
+    events-universal "^1.0.0"
+    fast-fifo "^1.3.2"
+    text-decoder "^1.1.0"
 
 string-length@^4.0.1:
   version "4.0.2"
@@ -11909,6 +12103,23 @@ tapable@^2.0.0, tapable@^2.2.1, tapable@^2.3.0:
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-2.3.2.tgz#86755feabad08d82a26b891db044808c6ad00f15"
   integrity sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA==
 
+tar-stream@^3.1.7:
+  version "3.1.8"
+  resolved "https://registry.yarnpkg.com/tar-stream/-/tar-stream-3.1.8.tgz#a26f5b26c34dfd4936a4f8a9e694a8f5102af13d"
+  integrity sha512-U6QpVRyCGHva435KoNWy9PRoi2IFYCgtEhq9nmrPPpbRacPs9IH4aJ3gbrFC8dPcXvdSZ4XXfXT5Fshbp2MtlQ==
+  dependencies:
+    b4a "^1.6.4"
+    bare-fs "^4.5.5"
+    fast-fifo "^1.2.0"
+    streamx "^2.15.0"
+
+teex@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/teex/-/teex-1.0.1.tgz#b8fa7245ef8e8effa8078281946c85ab780a0b12"
+  integrity sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==
+  dependencies:
+    streamx "^2.12.5"
+
 temp-dir@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/temp-dir/-/temp-dir-2.0.0.tgz#bde92b05bdfeb1516e804c9c00ad45177f31321e"
@@ -11974,6 +12185,13 @@ test-exclude@^7.0.1:
     "@istanbuljs/schema" "^0.1.2"
     glob "^10.4.1"
     minimatch "^10.2.2"
+
+text-decoder@^1.1.0:
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/text-decoder/-/text-decoder-1.2.7.tgz#5d073a9a74b9c0a9d28dfadcab96b604af57d8ba"
+  integrity sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==
+  dependencies:
+    b4a "^1.6.4"
 
 text-table@^0.2.0:
   version "0.2.0"
@@ -12206,7 +12424,7 @@ tslib@^1.8.1:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.0.3:
+tslib@^2.0.3, tslib@^2.8.1:
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
   integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
@@ -12858,7 +13076,7 @@ whatwg-mimetype@^4.0.0:
   resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz#bc1bf94a985dc50388d54a9258ac405c3ca2fc0a"
   integrity sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==
 
-whatwg-url@^14.0.0:
+whatwg-url@^14.0.0, whatwg-url@^14.1.0:
   version "14.2.0"
   resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-14.2.0.tgz#4ee02d5d725155dae004f6ae95c73e7ef5d95663"
   integrity sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==
@@ -13314,6 +13532,14 @@ yauzl@^2.10.0:
   dependencies:
     buffer-crc32 "~0.2.3"
     fd-slicer "~1.1.0"
+
+yauzl@^3.2.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/yauzl/-/yauzl-3.3.0.tgz#5be5e287b9a8112941c177734a34bf61a3e11bb4"
+  integrity sha512-PtGEvEP30p7sbIBJKUBjUnqgTVOyMURc4dLo9iNyAJnNIEz9pm88cCXF21w94Kg3k6RXkeZh5DHOGS0qEONvNQ==
+  dependencies:
+    buffer-crc32 "~0.2.3"
+    pend "~1.2.0"
 
 yn@3.1.1:
   version "3.1.1"


### PR DESCRIPTION
Add a MongoDB connection layer so the server can persist showcase definitions, sessions, and audit data across restarts.

This PR resolves #321 and #322 

- Add getMongoUri() which resolves the connection URI from MONGODB_URI (direct) or from individual MONGODB_HOST/PORT/DB_NAME/USER/PASSWORD vars, with localhost defaults for native dev
- Add connectDB() (mongoose.connect) and registerShutdownHandlers() for graceful SIGTERM/SIGINT disconnect
- Call connectDB() at server startup before any other init
- Update /server/ready to return 503 when the DB connection is not open
- Add mongodb-memory-server for in-process test isolation
- Document MONGODB_USER and MONGODB_PASSWORD in .env.example
- Add base Mongoose schema options