### PR TITLE
ci: Node 22, workflow hardening, GHCR builds, docs

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -87,16 +87,11 @@ Images are pushed to **GitHub Container Registry** (`ghcr.io`):
 | `SHOWCASE_SERVER_IMAGE`   | `ghcr.io/<owner>/bc-wallet-showcase-server`   |
 | `SHOWCASE_FRONTEND_IMAGE` | `ghcr.io/<owner>/bc-wallet-showcase-frontend` |
 
-Jobs use `docker/login-action@v3`, `docker/setup-buildx-action@v3`, `docker/metadata-action@v5`, and `docker/build-push-action@v7` with **minimal provenance** and **SBOM** attestations (`provenance: mode=min`, `sbom: true`).
+Jobs use `docker/login-action@v3`, `docker/setup-buildx-action@v3`, `docker/metadata-action@v5`, and `docker/build-push-action@v7` with **minimal provenance** and **SBOM** attestations (`provenance: mode=min`, `sbom: true`). Image build jobs set **`permissions: id-token: write`** (with `packages: write`) so attestation upload to GHCR is supported.
 
 ### Frontend image: build-time configuration
 
-Create React App reads **`REACT_APP_*`** at **build** time. The release workflow passes secrets into the Docker build as **build-args** (see `build-args` on the frontend `docker/build-push-action` step). The **`frontend/Dockerfile`** declares matching `ARG`/`ENV` values before `yarn workspace frontend build`.
-
-Required repository **secrets** for a correct production frontend bundle (names must match the workflow):
-
-- `REACT_APP_INSIGHTS_PROJECT_ID`
-- `REACT_APP_HOST_BACKEND`
+Create React App reads **`REACT_APP_*`** at **build** time. Those values are **inlined into the client bundle**, so they are **not secret**—prefer **[repository Variables](https://docs.github.com/en/actions/learn-github-actions/variables)** (`REACT_APP_INSIGHTS_PROJECT_ID`, `REACT_APP_HOST_BACKEND`) so they are not treated as encrypted secrets. The workflow still falls back to **secrets** with the same names if variables are unset (see `build-args` on the frontend `docker/build-push-action` step). The **`frontend/Dockerfile`** declares matching `ARG`/`ENV` values before `yarn workspace frontend build`.
 
 Optional / other secrets (e.g. Cypress) are documented in the workflow file and org settings.
 

--- a/.github/README.md
+++ b/.github/README.md
@@ -1,0 +1,125 @@
+# GitHub Actions and CI
+
+This folder defines automation for the BC Wallet Demo monorepo (`frontend` and `server` Yarn workspaces). All Node-based jobs use **Node.js 22**, matching `engines.node` in `package.json`.
+
+## Composite action: `actions/setup-node`
+
+**Path:** `.github/actions/setup-node/action.yml`
+
+**Purpose:** Install Node and enable Yarn dependency caching in one step.
+
+**Inputs:**
+
+| Input           | Required | Description        |
+|-----------------|----------|--------------------|
+| `node-version`  | yes      | Node major or semver (e.g. `22`) |
+
+**Behaviour:**
+
+- Runs [`actions/setup-node@v4`](https://github.com/actions/setup-node) with `cache: yarn` and `cache-dependency-path: yarn.lock` (repository root). No separate `actions/cache` step and no `yarn` invocation before Node is installed.
+
+**Usage:**
+
+```yaml
+- uses: ./.github/actions/setup-node
+  with:
+    node-version: 22
+```
+
+---
+
+## Workflow: Continuous Integration
+
+**File:** `.github/workflows/continuous-integration.yml`  
+**Name:** `Continuous Integration`
+
+**Triggers:** Pull requests targeting `main` or `release`.
+
+**Concurrency:** One active run per PR (`cancel-in-progress: true`) so new pushes cancel older runs.
+
+**Global env:** `HUSKY=0` so Husky does not run during `yarn install` in CI.
+
+| Job                    | What it does |
+|------------------------|--------------|
+| **Server Unit Tests**  | `yarn install --frozen-lockfile`, then `yarn workspace server test` |
+| **Frontend Unit Tests**| `yarn install --frozen-lockfile`, then `yarn workspace frontend test:unit` |
+| **Cypress E2E Tests**  | Lint (`yarn lint`), Prettier check, `yarn check-types`, then Cypress with `yarn workspace frontend start` and `wait-on` for `http://localhost:3000` |
+
+---
+
+## Workflow: PR Docker smoke build
+
+**File:** `.github/workflows/on_pr_opened.yaml`  
+**Name:** `PR Docker smoke build`
+
+**Triggers:** Non-draft pull requests to `main` when relevant paths change (see `paths:` in the workflow), on open/sync/reopen/ready for review.
+
+**Purpose:** Ensure `server/Dockerfile` and `frontend/Dockerfile` both build with the default GitHub-hosted runner (`DOCKER_BUILDKIT=1`). This does **not** push images and does **not** pass production `REACT_APP_*` build-args; it only verifies the Docker build graph.
+
+---
+
+## Workflow: Build and Publish Packages
+
+**File:** `.github/workflows/build_packages.yml`  
+**Name:** `Build and Publish Packages`
+
+**Triggers:**
+
+- **`release`:** `published` — runs when a GitHub Release is published.
+- **`workflow_dispatch`:** Manual run with optional input `run_cypress` (boolean) to run browser E2E before image builds.
+
+**Global env:** `HUSKY=0`.
+
+### Job graph
+
+1. **`cypress-run`** (conditional) — On every **release** publish, or when manual dispatch sets `run_cypress: true`. Checks out the repo, uses `setup-node` (Node 22), runs `yarn install --frozen-lockfile`, starts `yarn dev` in the background, waits with `wait-on` for `http://localhost:3000` and `http://localhost:5000`, short warm-up sleep, then runs **Cypress** (`cypress-io/github-action@v6`, `install: false`, optional Dashboard recording via `CYPRESS_RECORD_KEY`).
+
+2. **`cypress-skipped`** — Runs when Cypress is not required (manual dispatch with `run_cypress: false`). Satisfies `needs` for the image jobs without doing work.
+
+3. **`build-and-push-image-server`** and **`build-and-push-image-frontend`** — Both `need` the Cypress jobs and only proceed if nothing failed and at least one of the Cypress paths succeeded (see `if:` in the workflow). They **do not** run `yarn install` on the runner: the only install/build for the published images happens **inside Docker**, avoiding duplicate work.
+
+### GHCR images
+
+Images are pushed to **GitHub Container Registry** (`ghcr.io`):
+
+| Variable in workflow              | Image |
+|-----------------------------------|--------|
+| `SHOWCASE_SERVER_IMAGE`           | `ghcr.io/<owner>/bc-wallet-showcase-server` |
+| `SHOWCASE_FRONTEND_IMAGE`         | `ghcr.io/<owner>/bc-wallet-showcase-frontend` |
+
+Jobs use `docker/login-action@v3`, `docker/setup-buildx-action@v3`, `docker/metadata-action@v5`, and `docker/build-push-action@v7` with **minimal provenance** and **SBOM** attestations (`provenance: mode=min`, `sbom: true`).
+
+### Frontend image: build-time configuration
+
+Create React App reads **`REACT_APP_*`** at **build** time. The release workflow passes secrets into the Docker build as **build-args** (see `build-args` on the frontend `docker/build-push-action` step). The **`frontend/Dockerfile`** declares matching `ARG`/`ENV` values before `yarn workspace frontend build`.
+
+Required repository **secrets** for a correct production frontend bundle (names must match the workflow):
+
+- `REACT_APP_INSIGHTS_PROJECT_ID`
+- `REACT_APP_HOST_BACKEND`
+
+Optional / other secrets (e.g. Cypress) are documented in the workflow file and org settings.
+
+### Local Docker build (frontend)
+
+To approximate CI locally for the showcase web image:
+
+```bash
+docker build -f frontend/Dockerfile \
+  --build-arg REACT_APP_INSIGHTS_PROJECT_ID="..." \
+  --build-arg REACT_APP_HOST_BACKEND="..." \
+  -t bc-wallet-showcase-frontend:local .
+```
+
+---
+
+## Dependabot
+
+**File:** `.github/dependabot.yml` — version updates for GitHub Actions, npm (root workspace), and Dockerfiles under `/`, `/frontend`, and `/server`.
+
+---
+
+## Related docs
+
+- Root [README.md](../README.md) — run and Docker overview for developers.
+- [DEVELOPER/BC Wallet Showcase.md](../DEVELOPER/BC%20Wallet%20Showcase.md) — Traction, env files, and OpenShift-oriented notes.

--- a/.github/README.md
+++ b/.github/README.md
@@ -10,9 +10,9 @@ This folder defines automation for the BC Wallet Demo monorepo (`frontend` and `
 
 **Inputs:**
 
-| Input           | Required | Description        |
-|-----------------|----------|--------------------|
-| `node-version`  | yes      | Node major or semver (e.g. `22`) |
+| Input          | Required | Description                      |
+| -------------- | -------- | -------------------------------- |
+| `node-version` | yes      | Node major or semver (e.g. `22`) |
 
 **Behaviour:**
 
@@ -39,11 +39,11 @@ This folder defines automation for the BC Wallet Demo monorepo (`frontend` and `
 
 **Global env:** `HUSKY=0` so Husky does not run during `yarn install` in CI.
 
-| Job                    | What it does |
-|------------------------|--------------|
-| **Server Unit Tests**  | `yarn install --frozen-lockfile`, then `yarn workspace server test` |
-| **Frontend Unit Tests**| `yarn install --frozen-lockfile`, then `yarn workspace frontend test:unit` |
-| **Cypress E2E Tests**  | Lint (`yarn lint`), Prettier check, `yarn check-types`, then Cypress with `yarn workspace frontend start` and `wait-on` for `http://localhost:3000` |
+| Job                     | What it does                                                                                                                                        |
+| ----------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Server Unit Tests**   | `yarn install --frozen-lockfile`, then `yarn workspace server test`                                                                                 |
+| **Frontend Unit Tests** | `yarn install --frozen-lockfile`, then `yarn workspace frontend test:unit`                                                                          |
+| **Cypress E2E Tests**   | Lint (`yarn lint`), Prettier check, `yarn check-types`, then Cypress with `yarn workspace frontend start` and `wait-on` for `http://localhost:3000` |
 
 ---
 
@@ -82,10 +82,10 @@ This folder defines automation for the BC Wallet Demo monorepo (`frontend` and `
 
 Images are pushed to **GitHub Container Registry** (`ghcr.io`):
 
-| Variable in workflow              | Image |
-|-----------------------------------|--------|
-| `SHOWCASE_SERVER_IMAGE`           | `ghcr.io/<owner>/bc-wallet-showcase-server` |
-| `SHOWCASE_FRONTEND_IMAGE`         | `ghcr.io/<owner>/bc-wallet-showcase-frontend` |
+| Variable in workflow      | Image                                         |
+| ------------------------- | --------------------------------------------- |
+| `SHOWCASE_SERVER_IMAGE`   | `ghcr.io/<owner>/bc-wallet-showcase-server`   |
+| `SHOWCASE_FRONTEND_IMAGE` | `ghcr.io/<owner>/bc-wallet-showcase-frontend` |
 
 Jobs use `docker/login-action@v3`, `docker/setup-buildx-action@v3`, `docker/metadata-action@v5`, and `docker/build-push-action@v7` with **minimal provenance** and **SBOM** attestations (`provenance: mode=min`, `sbom: true`).
 

--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -10,24 +10,13 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Get yarn cache directory path
-      id: yarn-cache-dir-path
-      shell: bash
-      run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
-
-    - uses: actions/cache@v4
-      id: yarn-cache
-      with:
-        path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-        key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-yarn-
-
     - name: Setup node v${{ inputs.node-version }}
       uses: actions/setup-node@v4
       with:
         node-version: ${{ inputs.node-version }}
         registry-url: 'https://registry.npmjs.org/'
+        cache: yarn
+        cache-dependency-path: yarn.lock
 
 branding:
   icon: scissors

--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -14,7 +14,6 @@ runs:
       uses: actions/setup-node@v4
       with:
         node-version: ${{ inputs.node-version }}
-        registry-url: 'https://registry.npmjs.org/'
         cache: yarn
         cache-dependency-path: yarn.lock
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,7 +25,7 @@ updates:
       - dependency-name: '*'
         update-types: ['version-update:semver-major', 'version-update:semver-patch']
 
-  # Maintain dependencies for docker
+  # Docker base images: root dev image plus service Dockerfiles (one entry per directory)
   - package-ecosystem: 'docker'
     directory: '/'
     schedule:
@@ -34,7 +34,6 @@ updates:
       time: '04:00'
       timezone: 'Canada/Pacific'
 
-  # Maintain dependencies for docker
   - package-ecosystem: 'docker'
     directory: '/frontend'
     schedule:
@@ -43,7 +42,6 @@ updates:
       time: '04:00'
       timezone: 'Canada/Pacific'
 
-  # Maintain dependencies for docker
   - package-ecosystem: 'docker'
     directory: '/server'
     schedule:

--- a/.github/workflows/build_packages.yml
+++ b/.github/workflows/build_packages.yml
@@ -17,8 +17,6 @@ permissions:
 env:
   HUSKY: '0'
   REGISTRY: ghcr.io
-  FRONTEND_DIR: frontend
-  SERVER_DIR: server
   SHOWCASE_FRONTEND_IMAGE: ghcr.io/${{ github.repository_owner }}/bc-wallet-showcase-frontend
   SHOWCASE_SERVER_IMAGE: ghcr.io/${{ github.repository_owner }}/bc-wallet-showcase-server
 
@@ -44,8 +42,16 @@ jobs:
           yarn install --frozen-lockfile --network-timeout 600000
           NODE_ENV=test AGENT_WALLET_KEY=ba8e2462-f9ac-4da0-a9c6-99592a7dbc12 REACT_APP_HOST_BACKEND=http://localhost:5000 AGENT_PUBLIC_DID_SEED=testtesttesttesttesttesttesttest yarn dev &
 
-      - name: Wait for credential defs to be created
-        run: sleep 120s
+      - name: Wait for dev servers (HTTP)
+        run: >
+          npx --yes wait-on@8
+          http://localhost:3000
+          http://localhost:5000
+          --timeout 600000
+          --interval 5000
+
+      - name: Warm-up for agent / credential defs
+        run: sleep 45s
         shell: bash
 
       - name: Cypress run
@@ -71,14 +77,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 90
     needs: [cypress-run, cypress-skipped]
-    if: always() && (needs.cypress-run.result == 'success' || needs.cypress-skipped.result == 'success')
+    if: ${{ !cancelled() && needs.cypress-run.result != 'failure' && needs.cypress-skipped.result != 'failure' && (needs.cypress-run.result == 'success' || needs.cypress-skipped.result == 'success') }}
     permissions:
       contents: read
       packages: write
-
-    defaults:
-      run:
-        working-directory: ${{ env.SERVER_DIR }}
 
     steps:
       - name: Checkout repository
@@ -89,10 +91,11 @@ jobs:
         with:
           node-version: 22
 
-      - name: Install dependencies
+      - name: Install dependencies (workspace root)
         run: yarn install --frozen-lockfile --network-timeout 600000
 
-      - run: yarn build
+      - name: Build server
+        run: yarn workspace server build
 
       - name: Log in to the Container registry
         uses: docker/login-action@v3
@@ -100,6 +103,9 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
@@ -108,26 +114,24 @@ jobs:
           images: ${{ env.SHOWCASE_SERVER_IMAGE }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./server/Dockerfile
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          provenance: mode=min
+          sbom: true
 
   build-and-push-image-frontend:
     runs-on: ubuntu-latest
     timeout-minutes: 90
     needs: [cypress-run, cypress-skipped]
-    if: always() && (needs.cypress-run.result == 'success' || needs.cypress-skipped.result == 'success')
+    if: ${{ !cancelled() && needs.cypress-run.result != 'failure' && needs.cypress-skipped.result != 'failure' && (needs.cypress-run.result == 'success' || needs.cypress-skipped.result == 'success') }}
     permissions:
       contents: read
       packages: write
-
-    defaults:
-      run:
-        working-directory: ${{ env.FRONTEND_DIR }}
 
     steps:
       - name: Checkout repository
@@ -138,10 +142,14 @@ jobs:
         with:
           node-version: 22
 
-      - name: Install dependencies
+      - name: Install dependencies (workspace root)
         run: yarn install --frozen-lockfile --network-timeout 600000
 
-      - run: REACT_APP_INSIGHTS_PROJECT_ID=${{ secrets.REACT_APP_INSIGHTS_PROJECT_ID }} REACT_APP_HOST_BACKEND=${{ secrets.REACT_APP_HOST_BACKEND }} yarn build
+      - name: Build frontend
+        env:
+          REACT_APP_INSIGHTS_PROJECT_ID: ${{ secrets.REACT_APP_INSIGHTS_PROJECT_ID }}
+          REACT_APP_HOST_BACKEND: ${{ secrets.REACT_APP_HOST_BACKEND }}
+        run: yarn workspace frontend build
 
       - name: Log in to the Container registry
         uses: docker/login-action@v3
@@ -150,6 +158,9 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v5
@@ -157,10 +168,12 @@ jobs:
           images: ${{ env.SHOWCASE_FRONTEND_IMAGE }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./frontend/Dockerfile
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          provenance: mode=min
+          sbom: true

--- a/.github/workflows/build_packages.yml
+++ b/.github/workflows/build_packages.yml
@@ -15,6 +15,7 @@ permissions:
   contents: read
 
 env:
+  HUSKY: '0'
   REGISTRY: ghcr.io
   FRONTEND_DIR: frontend
   SERVER_DIR: server
@@ -25,6 +26,7 @@ jobs:
   cypress-run:
     name: Cypress E2E (optional)
     runs-on: ubuntu-latest
+    timeout-minutes: 180
     if: github.event_name == 'release' || inputs.run_cypress == 'true'
     permissions:
       contents: read
@@ -39,7 +41,7 @@ jobs:
 
       - name: Start App
         run: |
-          yarn
+          yarn install --frozen-lockfile --network-timeout 600000
           NODE_ENV=test AGENT_WALLET_KEY=ba8e2462-f9ac-4da0-a9c6-99592a7dbc12 REACT_APP_HOST_BACKEND=http://localhost:5000 AGENT_PUBLIC_DID_SEED=testtesttesttesttesttesttesttest yarn dev &
 
       - name: Wait for credential defs to be created
@@ -47,8 +49,9 @@ jobs:
         shell: bash
 
       - name: Cypress run
-        uses: cypress-io/github-action@v2
+        uses: cypress-io/github-action@v6
         with:
+          install: false
           record: true
           browser: chrome
         env:
@@ -66,6 +69,7 @@ jobs:
 
   build-and-push-image-server:
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     needs: [cypress-run, cypress-skipped]
     if: always() && (needs.cypress-run.result == 'success' || needs.cypress-skipped.result == 'success')
     permissions:
@@ -86,7 +90,7 @@ jobs:
           node-version: 22
 
       - name: Install dependencies
-        run: yarn install
+        run: yarn install --frozen-lockfile --network-timeout 600000
 
       - run: yarn build
 
@@ -114,6 +118,7 @@ jobs:
 
   build-and-push-image-frontend:
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     needs: [cypress-run, cypress-skipped]
     if: always() && (needs.cypress-run.result == 'success' || needs.cypress-skipped.result == 'success')
     permissions:
@@ -134,7 +139,7 @@ jobs:
           node-version: 22
 
       - name: Install dependencies
-        run: yarn install
+        run: yarn install --frozen-lockfile --network-timeout 600000
 
       - run: REACT_APP_INSIGHTS_PROJECT_ID=${{ secrets.REACT_APP_INSIGHTS_PROJECT_ID }} REACT_APP_HOST_BACKEND=${{ secrets.REACT_APP_HOST_BACKEND }} yarn build
 

--- a/.github/workflows/build_packages.yml
+++ b/.github/workflows/build_packages.yml
@@ -25,7 +25,7 @@ jobs:
     name: Cypress E2E (optional)
     runs-on: ubuntu-latest
     timeout-minutes: 180
-    if: github.event_name == 'release' || inputs.run_cypress == 'true'
+    if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.run_cypress)
     permissions:
       contents: read
     steps:
@@ -67,7 +67,7 @@ jobs:
   cypress-skipped:
     name: Cypress skipped
     runs-on: ubuntu-latest
-    if: github.event_name != 'release' && inputs.run_cypress != 'true'
+    if: github.event_name == 'workflow_dispatch' && !inputs.run_cypress
     permissions:
       contents: read
     steps:
@@ -81,6 +81,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write
 
     steps:
       - name: Checkout repository
@@ -121,6 +122,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write
 
     steps:
       - name: Checkout repository
@@ -153,5 +155,5 @@ jobs:
           provenance: mode=min
           sbom: true
           build-args: |
-            REACT_APP_INSIGHTS_PROJECT_ID=${{ secrets.REACT_APP_INSIGHTS_PROJECT_ID }}
-            REACT_APP_HOST_BACKEND=${{ secrets.REACT_APP_HOST_BACKEND }}
+            REACT_APP_INSIGHTS_PROJECT_ID=${{ vars.REACT_APP_INSIGHTS_PROJECT_ID || secrets.REACT_APP_INSIGHTS_PROJECT_ID }}
+            REACT_APP_HOST_BACKEND=${{ vars.REACT_APP_HOST_BACKEND || secrets.REACT_APP_HOST_BACKEND }}

--- a/.github/workflows/build_packages.yml
+++ b/.github/workflows/build_packages.yml
@@ -91,7 +91,7 @@ jobs:
       - run: yarn build
 
       - name: Log in to the Container registry
-        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -99,12 +99,12 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        uses: docker/metadata-action@v5
         with:
           images: ${{ env.SHOWCASE_SERVER_IMAGE }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: ./server/Dockerfile
@@ -128,13 +128,18 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Setup NodeJS
+        uses: ./.github/actions/setup-node
+        with:
+          node-version: 22
+
       - name: Install dependencies
         run: yarn install
 
       - run: REACT_APP_INSIGHTS_PROJECT_ID=${{ secrets.REACT_APP_INSIGHTS_PROJECT_ID }} REACT_APP_HOST_BACKEND=${{ secrets.REACT_APP_HOST_BACKEND }} yarn build
 
       - name: Log in to the Container registry
-        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -142,12 +147,12 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        uses: docker/metadata-action@v5
         with:
           images: ${{ env.SHOWCASE_FRONTEND_IMAGE }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: ./frontend/Dockerfile

--- a/.github/workflows/build_packages.yml
+++ b/.github/workflows/build_packages.yml
@@ -86,17 +86,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Setup NodeJS
-        uses: ./.github/actions/setup-node
-        with:
-          node-version: 22
-
-      - name: Install dependencies (workspace root)
-        run: yarn install --frozen-lockfile --network-timeout 600000
-
-      - name: Build server
-        run: yarn workspace server build
-
       - name: Log in to the Container registry
         uses: docker/login-action@v3
         with:
@@ -137,20 +126,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Setup NodeJS
-        uses: ./.github/actions/setup-node
-        with:
-          node-version: 22
-
-      - name: Install dependencies (workspace root)
-        run: yarn install --frozen-lockfile --network-timeout 600000
-
-      - name: Build frontend
-        env:
-          REACT_APP_INSIGHTS_PROJECT_ID: ${{ secrets.REACT_APP_INSIGHTS_PROJECT_ID }}
-          REACT_APP_HOST_BACKEND: ${{ secrets.REACT_APP_HOST_BACKEND }}
-        run: yarn workspace frontend build
-
       - name: Log in to the Container registry
         uses: docker/login-action@v3
         with:
@@ -177,3 +152,6 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           provenance: mode=min
           sbom: true
+          build-args: |
+            REACT_APP_INSIGHTS_PROJECT_ID=${{ secrets.REACT_APP_INSIGHTS_PROJECT_ID }}
+            REACT_APP_HOST_BACKEND=${{ secrets.REACT_APP_HOST_BACKEND }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -4,13 +4,21 @@ on:
   pull_request:
     branches: [main, release]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
+
+env:
+  HUSKY: '0'
 
 jobs:
   server-unit-tests:
     name: Server Unit Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -29,6 +37,7 @@ jobs:
   frontend-unit-tests:
     name: Frontend Unit Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -47,6 +56,7 @@ jobs:
   cypress-run:
     name: Cypress E2E Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/on_pr_opened.yaml
+++ b/.github/workflows/on_pr_opened.yaml
@@ -17,6 +17,10 @@ on:
       - reopened
       - ready_for_review
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
@@ -26,6 +30,8 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event.pull_request.draft == false }}
     timeout-minutes: 45
+    env:
+      DOCKER_BUILDKIT: '1'
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/on_pr_opened.yaml
+++ b/.github/workflows/on_pr_opened.yaml
@@ -11,6 +11,11 @@ on:
       - 'server/**'
       - 'package.json'
       - 'yarn.lock'
+      - '.dockerignore'
+      - '.github/workflows/**'
+      - 'dev.dockerfile'
+      - 'frontend/Dockerfile'
+      - 'server/Dockerfile'
     types:
       - opened
       - synchronize

--- a/DEVELOPER/BC Wallet Showcase.md
+++ b/DEVELOPER/BC Wallet Showcase.md
@@ -4,6 +4,10 @@ https://github.com/bcgov/BC-Wallet-Demo
 
 The BC Wallet Showcase is an application used to issue demo credentials and proof requests. It consists of a React frontend and a TS-Node Backend. Additionally it needs to be connected to a traction agent.
 
+## Continuous integration
+
+GitHub Actions run on pull requests (unit tests, lint, Cypress, Docker smoke builds) and on releases (optional Cypress, then publishing showcase images to GHCR). Node **22** is required in CI, matching the repo `engines` field. For workflow names, job graph, secrets used at Docker build time, and the reusable **setup-node** composite action, see **[.github/README.md](../.github/README.md)** in the repository.
+
 ## Setup: Local Development
 
 There are two env files that you need to configure. This stage assumes you already have access to a traction agent. If you have a fresh setup on your traction agent you'll need to do a couple things to connect it with the showcase. Log on to your traction agent, depending on the environment the url will be slightly different:

--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@ This application provides a showcase for the BC Wallet to illustrate the use cas
 
 ### Copy env files
 
-Copy the files server/.env.example and client/.env.example to server/.env and client/.env  
-Edit the .env files to match your project needs
+Copy `server/.env.example` → `server/.env` and `frontend/.env.example` → `frontend/.env`.  
+Edit the `.env` files to match your project needs (see [DEVELOPER/BC Wallet Showcase.md](DEVELOPER/BC%20Wallet%20Showcase.md) for Traction and webhook setup).
 
 ### Option 1 - Native
 
-Please make sure you have a recent version of node, npm, and yarn installed
-These steps are executed from the root folder of the project:
+Use **Node.js 22 or newer** (see `engines` in `package.json`), plus Yarn 1.x.  
+From the repository root:
 
 > yarn install
 
@@ -27,36 +27,43 @@ The application will now be running at http://localhost:3000
 
 ### Option 2 - Docker
 
-These steps assume that you have docker installed
+Requires Docker (BuildKit recommended). From the repository root:
 
-These steps are executed from the root folder of the project:
+Build the frontend (Caddy serves the static showcase). For a production-like bundle, pass Create React App variables at **build** time:
 
-Build the client:
-
-> docker build -t bc-wallet-demo-client . -f DockerfileClient
+```bash
+docker build -f frontend/Dockerfile \
+  --build-arg REACT_APP_INSIGHTS_PROJECT_ID="your-project-id" \
+  --build-arg REACT_APP_HOST_BACKEND="https://your-api-base" \
+  -t bc-wallet-demo-web:local .
+```
 
 Build the server:
 
-> docker build -t bc-wallet-demo-server . -f DockerfileServer
+```bash
+docker build -f server/Dockerfile -t bc-wallet-demo-server:local .
+```
 
-Start the server:
+Run the server (example):
 
-> docker run --name bc-wallet-demo-server -p5000:5000 --rm --env-file server/.env bc-wallet-demo-server
+```bash
+docker run --name bc-wallet-demo-server -p 5000:5000 --rm --env-file server/.env bc-wallet-demo-server:local
+```
 
-Start the client:
+Run the frontend (mount a `Caddyfile` if you need custom routing; see `frontend/Caddyfile` in this repo):
 
-> docker run --name bc-wallet-demo-client -p3000:3000 -v \`pwd\`/Caddyfile:/etc/caddy/Caddyfile --rm --env-file client/.env bc-wallet-demo-client
+```bash
+docker run --name bc-wallet-demo-web -p 3000:3000 \
+  -v "$(pwd)/frontend/Caddyfile:/etc/caddy/Caddyfile:ro" --rm \
+  --env-file frontend/.env bc-wallet-demo-web:local
+```
 
-The application will now be running at http://localhost:3000
+The app is then available at http://localhost:3000 (with defaults from your Caddyfile and env).
+
+For **CI workflows, GHCR image names, and the `setup-node` composite action**, see [.github/README.md](.github/README.md).
 
 ## Contributing
 
-**Pull requests are always welcome!**
+Pull requests and issues are welcome.
 
-Please see the [Contributions Guide](CONTRIBUTING.md) for the repo.
-
-Before contributing please run `yarn lint --fix` and fix any linter warnings in your code contribution.
-
-You may also create an issue if you would like to suggest additional resources to include in this repository.
-
-All contrbutions to this repository should adhere to our [Code of Conduct](./CODE_OF_CONDUCT).
+Before submitting a change, run `yarn lint` (use `yarn lint --fix` where appropriate) and keep formatting consistent with the project’s Prettier setup.

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -4,9 +4,15 @@ ARG runtime_image=caddy:alpine
 # build stage
 FROM ${build_image} AS build-stage
 WORKDIR /app
+ENV HUSKY=0
 COPY . .
-RUN yarn install
-RUN yarn build
+# CRA inlines REACT_APP_* at compile time — pass from CI via --build-arg.
+ARG REACT_APP_INSIGHTS_PROJECT_ID
+ARG REACT_APP_HOST_BACKEND
+ENV REACT_APP_INSIGHTS_PROJECT_ID=$REACT_APP_INSIGHTS_PROJECT_ID
+ENV REACT_APP_HOST_BACKEND=$REACT_APP_HOST_BACKEND
+RUN yarn install --frozen-lockfile --network-timeout 600000
+RUN yarn workspace frontend build
 
 
 # production stage

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,7 +17,7 @@
     "kbar": "^0.1.0-beta.48",
     "lodash": "^4.17.21",
     "loglevel": "^1.9.2",
-    "qrcode.react": "^1.0.1",
+    "qrcode.react": "^4.2.0",
     "react": "^18.3.1",
     "react-confetti": "^6.0.1",
     "react-device-detect": "^2.2.3",
@@ -51,6 +51,10 @@
     ]
   },
   "devDependencies": {
+    "@babel/core": "^7.28.0",
+    "@babel/plugin-syntax-flow": "^7.27.1",
+    "@babel/plugin-transform-react-jsx": "^7.27.1",
+    "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6",
     "@testing-library/react": "^14",
     "@testing-library/user-event": "^14",
@@ -59,16 +63,16 @@
     "@types/react-dom": "^18.3.0",
     "@types/react-router": "^5.1.20",
     "@types/react-router-dom": "^5.3.3",
-    "@vitejs/plugin-react": "^4",
+    "@vitejs/plugin-react": "^4.3.4",
     "@vitest/coverage-v8": "^2",
     "autoprefixer": "^10.4.0",
     "eslint-plugin-cypress": "^3.6.0",
     "jsdom": "^25",
     "postcss": "^8.4.4",
-    "postcss-loader": "^6.2.1",
     "react-scripts": "^5.0.1",
     "tailwindcss": "^3.0.23",
     "typescript": "^5",
+    "vite": "^5.4.21",
     "vitest": "^2"
   },
   "homepage": "/digital-trust/showcase/"

--- a/frontend/src/client/components/QRCode.tsx
+++ b/frontend/src/client/components/QRCode.tsx
@@ -1,12 +1,10 @@
 import { track } from 'insights-js'
+import { QRCodeSVG } from 'qrcode.react'
 import React, { useEffect } from 'react'
 
 import { isConnected } from '../utils/Helpers'
 
 import { CheckMark } from './Checkmark'
-
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const QR = require('qrcode.react')
 
 export interface Props {
   invitationUrl: string
@@ -27,7 +25,7 @@ export const QRCode: React.FC<Props> = ({ invitationUrl, connectionState, overla
 
   const renderQRCode = invitationUrl && (
     <div className={`relative ${overlay ? 'bg-none' : 'rounded-lg bg-bcgov-lightgrey p-4 m-auto'}`}>
-      <QR value={invitationUrl} size={165} />
+      <QRCodeSVG value={invitationUrl} size={165} />
       {isCompleted && (
         <div className="absolute inset-0 flex justify-center items-center bg-grey bg-opacity-60 rounded-lg">
           <CheckMark height="64" colorCircle="grey" />

--- a/frontend/src/client/pages/onboarding/components/WalletModal.tsx
+++ b/frontend/src/client/pages/onboarding/components/WalletModal.tsx
@@ -1,13 +1,11 @@
 import { AnimatePresence, motion } from 'framer-motion'
+import { QRCodeSVG } from 'qrcode.react'
 
 import { standardFade, dropIn } from '../../../FramerAnimations'
 import { baseUrl } from '../../../api/BaseUrl'
 import appStore from '../../../assets/light/app-store-badge.svg'
 import playStore from '../../../assets/light/google-play-badge.png'
 import { SmallButton } from '../../../components/SmallButton'
-
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const QRCode = require('qrcode.react')
 
 export interface Wallet {
   id: number
@@ -104,7 +102,7 @@ export const WalletModal: React.FC<Props> = ({ isWalletModalOpen, setIsWalletMod
                 </div>
                 {!isMobile() && (
                   <div className="mt-10 mr-10">
-                    <QRCode value={`${baseUrl}/qr`} size={125} />
+                    <QRCodeSVG value={`${baseUrl}/qr`} size={125} />
                   </div>
                 )}
               </div>

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "devDependencies": {
     "concurrently": "^7.0.0",
     "cypress": "^13",
+    "eslint": "^8.57.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-import-resolver-typescript": "^2.7.0",
     "eslint-plugin-cypress": "^2.12.1",

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-alpine as base
+FROM node:22-alpine AS base
 
 WORKDIR /app
 COPY . .

--- a/server/package.json
+++ b/server/package.json
@@ -34,6 +34,7 @@
     "ws": "^8.20.0"
   },
   "devDependencies": {
+    "@types/node": "^22.13.0",
     "@vitest/coverage-v8": "^2",
     "dotenv": "^16",
     "pino-pretty": "^11",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2269,6 +2269,20 @@
     "@svgr/plugin-svgo" "^5.5.0"
     loader-utils "^2.0.0"
 
+"@testing-library/dom@^10.4.0":
+  version "10.4.1"
+  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-10.4.1.tgz#d444f8a889e9a46e9a3b4f3b88e0fcb3efb6cf95"
+  integrity sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==
+  dependencies:
+    "@babel/code-frame" "^7.10.4"
+    "@babel/runtime" "^7.12.5"
+    "@types/aria-query" "^5.0.1"
+    aria-query "5.3.0"
+    dom-accessibility-api "^0.5.9"
+    lz-string "^1.5.0"
+    picocolors "1.1.1"
+    pretty-format "^27.0.2"
+
 "@testing-library/dom@^9.0.0":
   version "9.3.4"
   resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-9.3.4.tgz#50696ec28376926fec0a1bf87d9dbac5e27f60ce"
@@ -2581,6 +2595,13 @@
   dependencies:
     undici-types "~6.19.2"
 
+"@types/node@^22.13.0":
+  version "22.19.17"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.19.17.tgz#09c71fb34ba2510f8ac865361b1fcb9552b8a581"
+  integrity sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==
+  dependencies:
+    undici-types "~6.21.0"
+
 "@types/parse-json@^4.0.0":
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.2.tgz#5950e50960793055845e956c427fc2b0d70c5239"
@@ -2891,7 +2912,7 @@
   resolved "https://registry.yarnpkg.com/@ungap/structured-clone/-/structured-clone-1.3.0.tgz#d06bbb384ebcf6c505fde1c3d0ed4ddffe0aaff8"
   integrity sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==
 
-"@vitejs/plugin-react@^4":
+"@vitejs/plugin-react@^4.3.4":
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz#647af4e7bb75ad3add578e762ad984b90f4a24b9"
   integrity sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==
@@ -3355,6 +3376,13 @@ aria-query@5.1.3:
   integrity sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ==
   dependencies:
     deep-equal "^2.0.5"
+
+aria-query@5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-5.3.0.tgz#650c569e41ad90b51b3d7df5e5eed1c7549c103e"
+  integrity sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==
+  dependencies:
+    dequal "^2.0.3"
 
 aria-query@^5.0.0, aria-query@^5.3.2:
   version "5.3.2"
@@ -5062,6 +5090,11 @@ depd@~1.1.2:
   resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
   integrity sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==
 
+dequal@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/dequal/-/dequal-2.0.3.tgz#2644214f1997d39ed0ee0ece72335490a7ac67be"
+  integrity sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==
+
 destroy@1.2.0, destroy@^1.2.0, destroy@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.2.0.tgz#4803735509ad8be552934c67df614f94e66fa015"
@@ -5940,7 +5973,7 @@ eslint-webpack-plugin@^3.1.1:
     normalize-path "^3.0.0"
     schema-utils "^4.0.0"
 
-eslint@^8.3.0:
+eslint@^8.3.0, eslint@^8.57.0:
   version "8.57.1"
   resolved "https://registry.yarnpkg.com/eslint/-/eslint-8.57.1.tgz#7df109654aba7e3bbe5c8eae533c5e461d3c6ca9"
   integrity sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==
@@ -9432,15 +9465,15 @@ performance-now@^2.1.0:
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
   integrity sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==
 
+picocolors@1.1.1, picocolors@^1.0.0, picocolors@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.1.1.tgz#3d321af3eab939b083c8f929a1d12cda81c26b6b"
+  integrity sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==
+
 picocolors@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-0.2.1.tgz#570670f793646851d1ba135996962abad587859f"
   integrity sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA==
-
-picocolors@^1.0.0, picocolors@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.1.1.tgz#3d321af3eab939b083c8f929a1d12cda81c26b6b"
-  integrity sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==
 
 picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.2.2, picomatch@^2.2.3, picomatch@^2.3.1:
   version "2.3.2"
@@ -10178,7 +10211,7 @@ prompts@^2.0.1, prompts@^2.4.2:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
-prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.8.1:
+prop-types@^15.6.1, prop-types@^15.8.1:
   version "15.8.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
@@ -10228,19 +10261,10 @@ q@^1.1.2:
   resolved "https://registry.yarnpkg.com/q/-/q-1.5.1.tgz#7e32f75b41381291d04611f1bf14109ac00651d7"
   integrity sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw==
 
-qr.js@0.0.0:
-  version "0.0.0"
-  resolved "https://registry.yarnpkg.com/qr.js/-/qr.js-0.0.0.tgz#cace86386f59a0db8050fa90d9b6b0e88a1e364f"
-  integrity sha512-c4iYnWb+k2E+vYpRimHqSu575b1/wKl4XFeJGpFmrJQz5I88v9aY2czh7s0w36srfCM1sXgC/xpoJz5dJfq+OQ==
-
-qrcode.react@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/qrcode.react/-/qrcode.react-1.0.1.tgz#2834bb50e5e275ffe5af6906eff15391fe9e38a5"
-  integrity sha512-8d3Tackk8IRLXTo67Y+c1rpaiXjoz/Dd2HpcMdW//62/x8J1Nbho14Kh8x974t9prsLHN6XqVgcnRiBGFptQmg==
-  dependencies:
-    loose-envify "^1.4.0"
-    prop-types "^15.6.0"
-    qr.js "0.0.0"
+qrcode.react@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/qrcode.react/-/qrcode.react-4.2.0.tgz#1bce8363f348197d145c0da640929a24c83cbca3"
+  integrity sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA==
 
 qs@^6.5.2:
   version "6.13.0"
@@ -12442,6 +12466,11 @@ undici-types@~6.19.2:
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.19.8.tgz#35111c9d1437ab83a7cdc0abae2f26d88eda0a02"
   integrity sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==
 
+undici-types@~6.21.0:
+  version "6.21.0"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.21.0.tgz#691d00af3909be93a7faa13be61b3a5b50ef12cb"
+  integrity sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==
+
 unicode-canonical-property-names-ecmascript@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.1.tgz#cb3173fe47ca743e228216e4a3ddc4c84d628cc2"
@@ -12609,7 +12638,7 @@ vite-node@2.1.9:
     pathe "^1.1.2"
     vite "^5.0.0"
 
-vite@^5.0.0:
+vite@^5.0.0, vite@^5.4.21:
   version "5.4.21"
   resolved "https://registry.yarnpkg.com/vite/-/vite-5.4.21.tgz#84a4f7c5d860b071676d39ba513c0d598fdc7027"
   integrity sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==


### PR DESCRIPTION
## Summary
- **CI / GitHub Actions:** Node 22 for all JS jobs; refresh Docker actions (login/metadata/build-push); optional Cypress and release workflow improvements (concurrency, timeouts, `HUSKY=0`, `wait-on`, stricter job gates).
- **Release images (`build_packages.yml`):** Remove redundant runner `yarn install` before Docker; frontend image gets `REACT_APP_*` via Docker `build-args`; Buildx + provenance/SBOM on push.
- **Composite `setup-node`:** Yarn cache via `actions/setup-node` (no pre-Node `yarn` step).
- **Dependencies:** Root `eslint`, frontend/server peer cleanups, `qrcode.react` v4, explicit `vite`, etc. (`yarn.lock` updated).
- **Docs:** `.github/README.md` (workflows + action reference), README Docker/env updates, developer doc link.
- **Docker:** `server/Dockerfile` — `AS` casing for BuildKit `FromAsCasing`.

## Test plan
- [ ] PR checks: Continuous Integration + PR Docker smoke
- [ ] After merge: optional manual `workflow_dispatch` of Build and Publish Packages if you validate release path


Made with [Cursor](https://cursor.com)