### PR TITLE
feat: Anoncreds format support

### DIFF
--- a/frontend/src/client/api/CredentialApi.ts
+++ b/frontend/src/client/api/CredentialApi.ts
@@ -16,7 +16,7 @@ export const issueCredential = async (
       attributes: cred.attributes,
     },
     filter: {
-      indy: {
+      anoncreds: {
         cred_def_id: credDefId,
       },
     },
@@ -36,7 +36,7 @@ export const issueDeepCredential = async (
       attributes: cred.attributes,
     },
     filter: {
-      indy: {
+      anoncreds: {
         cred_def_id: credDefId,
       },
     },

--- a/frontend/src/client/api/ProofApi.ts
+++ b/frontend/src/client/api/ProofApi.ts
@@ -7,7 +7,7 @@ export const createProofRequest = (data: ProofRequestData): Promise<AxiosRespons
   return apiCall.post(`/demo/proofs/requestProof`, {
     connection_id: data.connectionId,
     presentation_request: {
-      indy: {
+      anoncreds: {
         requested_attributes: Object.assign({}, data.attributes),
         requested_predicates: Object.assign({}, data.predicates),
         version: '1.0.0',
@@ -24,7 +24,7 @@ export const createDeepProofRequest = (data: ProofRequestData): Promise<AxiosRes
   return apiCall.post(`/demo/deeplink/requestProof`, {
     connection_id: data.connectionId,
     presentation_request: {
-      indy: {
+      anoncreds: {
         requested_attributes: Object.assign({}, data.attributes),
         requested_predicates: Object.assign({}, data.predicates),
         version: '1.0.0',
@@ -40,7 +40,7 @@ export const createDeepProofRequest = (data: ProofRequestData): Promise<AxiosRes
 export const createOOBProofRequest = (data: ProofRequestData): Promise<AxiosResponse> => {
   return apiCall.post(`/demo/proofs/requestProofOOB`, {
     presentation_request: {
-      indy: {
+      anoncreds: {
         requested_attributes: Object.assign({}, data.attributes),
         requested_predicates: Object.assign({}, data.predicates),
         version: '1.0.0',

--- a/frontend/src/client/pages/introduction/steps/AcceptCredential.tsx
+++ b/frontend/src/client/pages/introduction/steps/AcceptCredential.tsx
@@ -133,7 +133,7 @@ export const AcceptCredential: React.FC<Props> = ({
   const sendNewCredentials = () => {
     // credentials.forEach((cred) => {
     //   if (!isCredIssued(cred.state)) {
-    //     dispatch(deleteCredentialById(cred.credential_exchange_id))
+    //     dispatch(deleteCredentialById(cred.cred_ex_id))
     //     const newCredential = getCharacterCreds().find((item) => {
     //       return item?.credentialDefinitionId === cred.credential_offer.cred_def_id
     //     })

--- a/frontend/src/client/pages/scenario/steps/StepCredential.tsx
+++ b/frontend/src/client/pages/scenario/steps/StepCredential.tsx
@@ -77,7 +77,7 @@
 //   const sendNewCredentials = () => {
 //     credentials.forEach((cred) => {
 //       if (!isCredIssued(cred.state)) {
-//         dispatch(deleteCredentialById(cred.credential_exchange_id))
+//         dispatch(deleteCredentialById(cred.cred_ex_id))
 //         const newCredential = issuedCredData.find((item) => {
 //           return item.credentialDefinitionId === cred.credential_offer.cred_def_id
 //         })

--- a/frontend/src/client/slices/credentials/__tests__/credentialsThunks.test.ts
+++ b/frontend/src/client/slices/credentials/__tests__/credentialsThunks.test.ts
@@ -36,7 +36,7 @@ beforeEach(() => {
 describe('issueCredential thunk', () => {
   it('sets isIssueCredentialLoading=false on fulfilled', async () => {
     vi.mocked(CredentialApi.issueCredential).mockResolvedValue({
-      data: { credential_exchange_id: 'cred-1' },
+      data: { cred_ex_id: 'cred-1' },
     } as any)
 
     const store = makeStore()
@@ -46,7 +46,7 @@ describe('issueCredential thunk', () => {
 
   it('sets isIssueCredentialLoading=true while pending', async () => {
     vi.mocked(CredentialApi.issueCredential).mockResolvedValue({
-      data: { credential_exchange_id: 'cred-1' },
+      data: { cred_ex_id: 'cred-1' },
     } as any)
 
     const store = makeStore()
@@ -74,7 +74,7 @@ describe('issueDeepCredential thunk — retry loop', () => {
     vi.mocked(CredentialApi.issueDeepCredential)
       .mockRejectedValueOnce(new Error('not ready'))
       .mockRejectedValueOnce(new Error('not ready'))
-      .mockResolvedValue({ data: { credential_exchange_id: 'deep-cred-1' } } as any)
+      .mockResolvedValue({ data: { cred_ex_id: 'deep-cred-1' } } as any)
 
     const store = makeStore()
     const promise = store.dispatch(
@@ -84,7 +84,7 @@ describe('issueDeepCredential thunk — retry loop', () => {
     await vi.runAllTimersAsync()
     const result = await promise
 
-    expect(result.payload).toEqual({ credential_exchange_id: 'deep-cred-1' })
+    expect(result.payload).toEqual({ cred_ex_id: 'deep-cred-1' })
     expect(CredentialApi.issueDeepCredential).toHaveBeenCalledTimes(3)
   })
 
@@ -121,12 +121,12 @@ describe('issueDeepCredential thunk — retry loop', () => {
 describe('fetchCredentialById thunk', () => {
   it('returns credential data on success', async () => {
     vi.mocked(CredentialApi.getCredentialById).mockResolvedValue({
-      data: { credential_exchange_id: 'cred-fetch-1', state: 'credential_issued' },
+      data: { cred_ex_id: 'cred-fetch-1', state: 'credential_issued' },
     } as any)
 
     const store = makeStore()
     const result = await store.dispatch(fetchCredentialById('cred-fetch-1') as any)
-    expect(result.payload).toMatchObject({ credential_exchange_id: 'cred-fetch-1' })
+    expect(result.payload).toMatchObject({ cred_ex_id: 'cred-fetch-1' })
   })
 })
 

--- a/frontend/src/client/slices/credentials/__tests__/credentialsThunks.test.ts
+++ b/frontend/src/client/slices/credentials/__tests__/credentialsThunks.test.ts
@@ -147,7 +147,7 @@ describe('credentialsSlice reducers', () => {
       setCredential({
         by_format: {
           cred_issue: {
-            indy: {
+            anoncreds: {
               cred_def_id: 'ISSUER123:3:CL:100:CredentialName',
             },
           },
@@ -165,7 +165,7 @@ describe('credentialsSlice reducers', () => {
     const payload = {
       by_format: {
         cred_issue: {
-          indy: {
+          anoncreds: {
             cred_def_id: 'ISSUER123:3:CL:100:MyCredential',
           },
         },

--- a/frontend/src/client/slices/credentials/credentialsSlice.ts
+++ b/frontend/src/client/slices/credentials/credentialsSlice.ts
@@ -31,7 +31,7 @@ const credentialSlice = createSlice({
     },
     setCredential: (state, action) => {
       const credentialData = action.payload
-      const credDefParts = credentialData.by_format.cred_issue.indy.cred_def_id.split(':')
+      const credDefParts = credentialData.by_format.cred_issue.anoncreds.cred_def_id.split(':')
       const credName = credDefParts[credDefParts.length - 1]
       if (!state.issuedCredentials.includes(credName)) {
         state.issuedCredentials.push(credName)

--- a/frontend/src/client/slices/credentials/credentialsThunks.ts
+++ b/frontend/src/client/slices/credentials/credentialsThunks.ts
@@ -13,7 +13,7 @@ export const issueCredential = createAsyncThunk(
       credName: data.cred.name,
     })
     const response = await Api.issueCredential(data.connectionId, data.cred, data.credDefId)
-    log.info('[credentials] credential offered', { credentialExchangeId: response.data?.credential_exchange_id })
+    log.info('[credentials] credential offered', { credentialExchangeId: response.data?.cred_ex_id })
     return response.data
   },
 )
@@ -45,7 +45,7 @@ export const issueDeepCredential = createAsyncThunk(
         const response = await Api.issueDeepCredential(data.connectionId, data.cred, data.credDefId)
         log.info('[credentials] deep-link credential offered', {
           attempt,
-          credentialExchangeId: response.data?.credential_exchange_id,
+          credentialExchangeId: response.data?.cred_ex_id,
         })
         return response.data
       } catch {

--- a/frontend/src/client/utils/ProofUtils.tsx
+++ b/frontend/src/client/utils/ProofUtils.tsx
@@ -1,7 +1,7 @@
 import type { Attribute } from '../slices/types'
 
 export const getAttributesFromProof = (proof: any) => {
-  const proofData = proof.by_format.pres.indy.requested_proof.revealed_attrs
+  const proofData = proof.by_format.pres.anoncreds.requested_proof.revealed_attrs
 
   const attributes: Attribute[] = []
   for (const prop in proofData) {

--- a/server/src/controllers/CredentialController.ts
+++ b/server/src/controllers/CredentialController.ts
@@ -73,7 +73,7 @@ export class CredentialController {
   public async getOrCreateCredDef(@Body() credential: Credential) {
     logger.info({ name: credential.name, version: credential.version }, 'Resolving credential definition')
     const schemas = (
-      await tractionRequest.get(`/schemas/created`, {
+      await tractionRequest.get(`/anoncreds/schemas`, {
         params: { schema_name: credential.name, schema_version: credential.version },
       })
     ).data
@@ -82,13 +82,16 @@ export class CredentialController {
       logger.info({ name: credential.name, version: credential.version }, 'Schema not found, creating new schema')
       const schemaAttrs = credential.attributes.map((attr) => attr.name)
       const resp = (
-        await tractionRequest.post(`/schemas`, {
-          attributes: schemaAttrs,
-          schema_name: credential.name,
-          schema_version: credential.version,
+        await tractionRequest.post(`/anoncreds/schema`, {
+          schema: {
+            issuerId: process.env.TRACTION_DID,
+            attrNames: schemaAttrs,
+            name: credential.name,
+            version: credential.version,
+          },
         })
       ).data
-      schema_id = resp.sent.schema_id
+      schema_id = resp.schema_state.schema_id
       logger.info({ schema_id }, 'Schema created, waiting for ledger propagation')
       await new Promise((r) => setTimeout(r, 5000))
     } else {
@@ -96,19 +99,24 @@ export class CredentialController {
       logger.debug({ schema_id }, 'Existing schema found')
     }
 
-    const credDefs = (await tractionRequest.get(`/credential-definitions/created`, { params: { schema_id } })).data
+    const credDefs = (await tractionRequest.get(`/anoncreds/credential-definitions`, { params: { schema_id } })).data
     let cred_def_id = ''
     if (credDefs.credential_definition_ids.length <= 0) {
       logger.info({ schema_id }, 'Credential definition not found, creating new credential definition')
       const resp = (
-        await tractionRequest.post(`/credential-definitions`, {
-          revocation_registry_size: 25,
-          schema_id,
-          support_revocation: true,
-          tag: credential.name,
+        await tractionRequest.post(`/anoncreds/credential-definition`, {
+          credential_definition: {
+            schemaId: schema_id,
+            issuerId: process.env.TRACTION_DID,
+            tag: credential.name,
+          },
+          options: {
+            revocation_registry_size: 3000,
+            support_revocation: true,
+          },
         })
       ).data
-      cred_def_id = resp.sent.credential_definition_id
+      cred_def_id = resp.credential_definition_state.credential_definition_id
       logger.info({ cred_def_id }, 'Credential definition created')
     } else {
       cred_def_id = credDefs.credential_definition_ids[0]

--- a/server/src/controllers/DeepLinkController.ts
+++ b/server/src/controllers/DeepLinkController.ts
@@ -13,7 +13,7 @@ export class DeeplinkController {
     const state = await this.waitUntilConnected(params.connection_id)
     if (this.isConnected(state)) {
       logger.info({ connectionId: params.connection_id }, 'Deep link: connection established, issuing credential')
-      const resp = await tractionRequest.post(`/issue-credential/send`, params)
+      const resp = await tractionRequest.post(`/issue-credential-2.0/send-offer`, params)
       return resp.data
     }
     logger.warn(

--- a/server/src/controllers/__tests__/CredentialController.test.ts
+++ b/server/src/controllers/__tests__/CredentialController.test.ts
@@ -25,7 +25,13 @@ describe('CredentialController', () => {
 
   describe('getCredByConnId', () => {
     it('calls tractionRequest.get with connection_id as a query param', async () => {
-      vi.mocked(tractionRequest.get).mockResolvedValue({ data: { results: [] } })
+      vi.mocked(tractionRequest.get).mockResolvedValue({
+        data: { results: [] },
+        status: 200,
+        statusText: 'OK',
+        headers: {},
+        config: {},
+      } as any)
 
       await controller.getCredByConnId('conn1')
 
@@ -37,7 +43,13 @@ describe('CredentialController', () => {
 
     it('returns the response data', async () => {
       const mockData = { results: [{ cred_ex_id: 'cred1' }] }
-      vi.mocked(tractionRequest.get).mockResolvedValue({ data: mockData })
+      vi.mocked(tractionRequest.get).mockResolvedValue({
+        data: mockData,
+        status: 200,
+        statusText: 'OK',
+        headers: {},
+        config: {},
+      } as any)
 
       const result = await controller.getCredByConnId('conn1')
 
@@ -56,8 +68,20 @@ describe('CredentialController', () => {
 
     it('returns the existing credDef id without creating anything', async () => {
       vi.mocked(tractionRequest.get)
-        .mockResolvedValueOnce({ data: { schema_ids: ['existing-schema-id'] } })
-        .mockResolvedValueOnce({ data: { credential_definition_ids: ['existing-cred-def-id'] } })
+        .mockResolvedValueOnce({
+          data: { schema_ids: ['existing-schema-id'] },
+          status: 200,
+          statusText: 'OK',
+          headers: {},
+          config: {},
+        } as any)
+        .mockResolvedValueOnce({
+          data: { credential_definition_ids: ['existing-cred-def-id'] },
+          status: 200,
+          statusText: 'OK',
+          headers: {},
+          config: {},
+        } as any)
 
       const result = await controller.getOrCreateCredDef(credential)
 
@@ -79,11 +103,35 @@ describe('CredentialController', () => {
       vi.useFakeTimers()
 
       vi.mocked(tractionRequest.get)
-        .mockResolvedValueOnce({ data: { schema_ids: [] } })
-        .mockResolvedValueOnce({ data: { credential_definition_ids: [] } })
+        .mockResolvedValueOnce({
+          data: { schema_ids: [] },
+          status: 200,
+          statusText: 'OK',
+          headers: {},
+          config: {},
+        } as any)
+        .mockResolvedValueOnce({
+          data: { credential_definition_ids: [] },
+          status: 200,
+          statusText: 'OK',
+          headers: {},
+          config: {},
+        } as any)
       vi.mocked(tractionRequest.post)
-        .mockResolvedValueOnce({ data: { sent: { schema_id: 'new-schema-id' } } })
-        .mockResolvedValueOnce({ data: { sent: { credential_definition_id: 'new-cred-def-id' } } })
+        .mockResolvedValueOnce({
+          data: { schema_state: { schema_id: 'new-schema-id' } },
+          status: 200,
+          statusText: 'OK',
+          headers: {},
+          config: {},
+        } as any)
+        .mockResolvedValueOnce({
+          data: { credential_definition_state: { credential_definition_id: 'new-cred-def-id' } },
+          status: 200,
+          statusText: 'OK',
+          headers: {},
+          config: {},
+        } as any)
 
       const promise = controller.getOrCreateCredDef(credential)
       // advance past the 5-second ledger propagation wait
@@ -108,11 +156,27 @@ describe('CredentialController', () => {
 
     it('uses existing schema id and creates a new credential definition', async () => {
       vi.mocked(tractionRequest.get)
-        .mockResolvedValueOnce({ data: { schema_ids: ['pre-existing-schema-id'] } })
-        .mockResolvedValueOnce({ data: { credential_definition_ids: [] } })
+        .mockResolvedValueOnce({
+          data: { schema_ids: ['pre-existing-schema-id'] },
+          status: 200,
+          statusText: 'OK',
+          headers: {},
+          config: {},
+        } as any)
+        .mockResolvedValueOnce({
+          data: { credential_definition_ids: [] },
+          status: 200,
+          statusText: 'OK',
+          headers: {},
+          config: {},
+        } as any)
       vi.mocked(tractionRequest.post).mockResolvedValueOnce({
-        data: { sent: { credential_definition_id: 'brand-new-cred-def' } },
-      })
+        data: { credential_definition_state: { credential_definition_id: 'brand-new-cred-def' } },
+        status: 200,
+        statusText: 'OK',
+        headers: {},
+        config: {},
+      } as any)
 
       const result = await controller.getOrCreateCredDef(credential)
 
@@ -125,7 +189,13 @@ describe('CredentialController', () => {
   describe('offerCredential', () => {
     it('posts to the issue-credential/send endpoint with the params', async () => {
       const params = { connection_id: 'conn1', credential_preview: { attributes: [] } }
-      vi.mocked(tractionRequest.post).mockResolvedValue({ data: { cred_ex_id: 'cred-exch-1' } })
+      vi.mocked(tractionRequest.post).mockResolvedValue({
+        data: { cred_ex_id: 'cred-exch-1' },
+        status: 200,
+        statusText: 'OK',
+        headers: {},
+        config: {},
+      } as any)
 
       await controller.offerCredential(params)
 
@@ -141,7 +211,13 @@ describe('CredentialController', () => {
 
     it('returns the response data', async () => {
       const mockData = { cred_ex_id: 'cred-exch-1', state: 'offer_sent' }
-      vi.mocked(tractionRequest.post).mockResolvedValue({ data: mockData })
+      vi.mocked(tractionRequest.post).mockResolvedValue({
+        data: mockData,
+        status: 200,
+        statusText: 'OK',
+        headers: {},
+        config: {},
+      } as any)
 
       const result = await controller.offerCredential({})
 
@@ -161,7 +237,13 @@ describe('CredentialController', () => {
           ],
         },
       }
-      vi.mocked(tractionRequest.post).mockResolvedValue({ data: { cred_ex_id: 'cred-exch-1' } })
+      vi.mocked(tractionRequest.post).mockResolvedValue({
+        data: { cred_ex_id: 'cred-exch-1' },
+        status: 200,
+        statusText: 'OK',
+        headers: {},
+        config: {},
+      } as any)
 
       await controller.offerCredential(params)
 
@@ -190,7 +272,13 @@ describe('CredentialController', () => {
           attributes: [{ name: 'given_names', value: 'Bob' }],
         },
       }
-      vi.mocked(tractionRequest.post).mockResolvedValue({ data: {} })
+      vi.mocked(tractionRequest.post).mockResolvedValue({
+        data: {},
+        status: 200,
+        statusText: 'OK',
+        headers: {},
+        config: {},
+      } as any)
 
       await controller.offerCredential(params)
 

--- a/server/src/controllers/__tests__/CredentialController.test.ts
+++ b/server/src/controllers/__tests__/CredentialController.test.ts
@@ -36,7 +36,7 @@ describe('CredentialController', () => {
     })
 
     it('returns the response data', async () => {
-      const mockData = { results: [{ credential_exchange_id: 'cred1' }] }
+      const mockData = { results: [{ cred_ex_id: 'cred1' }] }
       vi.mocked(tractionRequest.get).mockResolvedValue({ data: mockData })
 
       const result = await controller.getCredByConnId('conn1')
@@ -125,7 +125,7 @@ describe('CredentialController', () => {
   describe('offerCredential', () => {
     it('posts to the issue-credential/send endpoint with the params', async () => {
       const params = { connection_id: 'conn1', credential_preview: { attributes: [] } }
-      vi.mocked(tractionRequest.post).mockResolvedValue({ data: { credential_exchange_id: 'cred-exch-1' } })
+      vi.mocked(tractionRequest.post).mockResolvedValue({ data: { cred_ex_id: 'cred-exch-1' } })
 
       await controller.offerCredential(params)
 
@@ -140,7 +140,7 @@ describe('CredentialController', () => {
     })
 
     it('returns the response data', async () => {
-      const mockData = { credential_exchange_id: 'cred-exch-1', state: 'offer_sent' }
+      const mockData = { cred_ex_id: 'cred-exch-1', state: 'offer_sent' }
       vi.mocked(tractionRequest.post).mockResolvedValue({ data: mockData })
 
       const result = await controller.offerCredential({})
@@ -161,7 +161,7 @@ describe('CredentialController', () => {
           ],
         },
       }
-      vi.mocked(tractionRequest.post).mockResolvedValue({ data: { credential_exchange_id: 'cred-exch-1' } })
+      vi.mocked(tractionRequest.post).mockResolvedValue({ data: { cred_ex_id: 'cred-exch-1' } })
 
       await controller.offerCredential(params)
 

--- a/server/src/controllers/__tests__/DeepLinkController.test.ts
+++ b/server/src/controllers/__tests__/DeepLinkController.test.ts
@@ -38,7 +38,7 @@ describe('DeeplinkController', () => {
       const result = await promise
 
       expect(result).toEqual({ cred_ex_id: 'cred1' })
-      expect(tractionRequest.post).toHaveBeenCalledWith('/issue-credential/send', { connection_id: 'conn1' })
+      expect(tractionRequest.post).toHaveBeenCalledWith('/issue-credential-2.0/send-offer', { connection_id: 'conn1' })
     })
 
     it('accepts "response" as a connected state', async () => {

--- a/server/src/controllers/__tests__/DeepLinkController.test.ts
+++ b/server/src/controllers/__tests__/DeepLinkController.test.ts
@@ -31,19 +31,19 @@ describe('DeeplinkController', () => {
   describe('offerCredential', () => {
     it('posts credential when connection becomes active', async () => {
       vi.mocked(tractionRequest.get).mockResolvedValue({ data: { state: 'complete' } })
-      vi.mocked(tractionRequest.post).mockResolvedValue({ data: { credential_exchange_id: 'cred1' } })
+      vi.mocked(tractionRequest.post).mockResolvedValue({ data: { cred_ex_id: 'cred1' } })
 
       const promise = controller.offerCredential({ connection_id: 'conn1' })
       await vi.runAllTimersAsync()
       const result = await promise
 
-      expect(result).toEqual({ credential_exchange_id: 'cred1' })
+      expect(result).toEqual({ cred_ex_id: 'cred1' })
       expect(tractionRequest.post).toHaveBeenCalledWith('/issue-credential/send', { connection_id: 'conn1' })
     })
 
     it('accepts "response" as a connected state', async () => {
       vi.mocked(tractionRequest.get).mockResolvedValue({ data: { state: 'response' } })
-      vi.mocked(tractionRequest.post).mockResolvedValue({ data: { credential_exchange_id: 'cred1' } })
+      vi.mocked(tractionRequest.post).mockResolvedValue({ data: { cred_ex_id: 'cred1' } })
 
       const promise = controller.offerCredential({ connection_id: 'conn1' })
       await vi.runAllTimersAsync()

--- a/server/src/utils/__tests__/tractionHelper.test.ts
+++ b/server/src/utils/__tests__/tractionHelper.test.ts
@@ -54,10 +54,10 @@ describe('tractionRequest', () => {
     vi.mocked(axios.post).mockResolvedValue({ data: {} })
     const body = { foo: 'bar' }
 
-    await th.tractionRequest.post('/issue-credential/send', body)
+    await th.tractionRequest.post('/issue-credential-2.0/send-offer', body)
 
     expect(axios.post).toHaveBeenCalledWith(
-      'https://traction.example.com/issue-credential/send',
+      'https://traction.example.com/issue-credential-2.0/send-offer',
       body,
       expect.objectContaining({
         timeout: 80000,


### PR DESCRIPTION
This adds support for the `anoncreds` format.

***Note:*** Does not have backwards compatibility. If this gets merge the traction tenant would need to be upgraded to be able to issue and verify credentials.  