### PR TITLE
Refactor frontend ConfigMap and add server ConfigMap with keycloak.json

### DIFF
--- a/charts/showcase/templates/_helpers.tpl
+++ b/charts/showcase/templates/_helpers.tpl
@@ -184,10 +184,17 @@ Server env Secret name.
 {{- end }}
 
 {{/*
-Frontend ConfigMap name (Caddyfile).
+Server ConfigMap name (keycloak.json).
+*/}}
+{{- define "showcase.server.configmapName" -}}
+{{- printf "%s-server" (include "showcase.fullname" .) }}
+{{- end }}
+
+{{/*
+Frontend ConfigMap name (Caddyfile + config.json).
 */}}
 {{- define "showcase.frontend.configmapName" -}}
-{{- printf "%s-frontend-caddy" (include "showcase.fullname" .) }}
+{{- printf "%s-frontend" (include "showcase.fullname" .) }}
 {{- end }}
 
 {{/*

--- a/charts/showcase/templates/frontend/configmap.yaml
+++ b/charts/showcase/templates/frontend/configmap.yaml
@@ -12,3 +12,5 @@ data:
 {{- else }}
 {{ tpl (.Files.Get "files/caddyfile.tpl") . | nindent 4 }}
 {{- end }}
+  config.json: |
+    {{- .Values.showcase.frontend.config | toJson | nindent 4 }}

--- a/charts/showcase/templates/frontend/deployment.yaml
+++ b/charts/showcase/templates/frontend/deployment.yaml
@@ -23,9 +23,11 @@ spec:
         {{- range $k, $v := .Values.showcase.frontend.podLabels }}
         {{ $k }}: {{ $v | quote }}
         {{- end }}
-      {{- if .Values.showcase.frontend.podAnnotations }}
-      annotations: {{- toYaml .Values.showcase.frontend.podAnnotations | nindent 8 }}
-      {{- end }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/frontend/configmap.yaml") . | sha256sum }}
+        {{- with .Values.showcase.frontend.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       enableServiceLinks: true
       {{- with .Values.global.imagePullSecrets }}

--- a/charts/showcase/templates/frontend/deployment.yaml
+++ b/charts/showcase/templates/frontend/deployment.yaml
@@ -52,9 +52,12 @@ spec:
               value: {{ .Values.showcase.insightsProjectId | quote }}
             {{- end }}
           volumeMounts:
-            - name: caddyfile
+            - name: frontend-config
               mountPath: /etc/caddy/Caddyfile
               subPath: Caddyfile
+            - name: frontend-config
+              mountPath: /srv{{ .Values.showcase.baseRoute }}/config.json
+              subPath: config.json
           readinessProbe:
             httpGet:
               path: /health
@@ -65,7 +68,7 @@ spec:
           resources: {{- toYaml . | nindent 12 }}
           {{- end }}
       volumes:
-        - name: caddyfile
+        - name: frontend-config
           configMap:
             name: {{ include "showcase.frontend.configmapName" . }}
       {{- with .Values.showcase.frontend.nodeSelector }}

--- a/charts/showcase/templates/server/configmap.yaml
+++ b/charts/showcase/templates/server/configmap.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "showcase.server.configmapName" . }}
+  namespace: {{ include "showcase.namespace" . | quote }}
+  labels: {{- include "showcase.labels" . | nindent 4 }}
+    app.kubernetes.io/component: server
+data:
+  keycloak.json: |
+    {{- .Values.showcase.server.keycloak | toJson | nindent 4 }}

--- a/charts/showcase/templates/server/deployment.yaml
+++ b/charts/showcase/templates/server/deployment.yaml
@@ -171,9 +171,17 @@ spec:
               port: http
             initialDelaySeconds: 15
             periodSeconds: 10
+          volumeMounts:
+            - name: server-config
+              mountPath: /app/server/config/keycloak.json
+              subPath: keycloak.json
           {{- with .Values.showcase.server.resources }}
           resources: {{- toYaml . | nindent 12 }}
           {{- end }}
+      volumes:
+        - name: server-config
+          configMap:
+            name: {{ include "showcase.server.configmapName" . }}
       {{- with .Values.showcase.server.nodeSelector }}
       nodeSelector: {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/showcase/templates/server/deployment.yaml
+++ b/charts/showcase/templates/server/deployment.yaml
@@ -23,9 +23,11 @@ spec:
         {{- range $k, $v := .Values.showcase.server.podLabels }}
         {{ $k }}: {{ $v | quote }}
         {{- end }}
-      {{- if .Values.showcase.server.podAnnotations }}
-      annotations: {{- toYaml .Values.showcase.server.podAnnotations | nindent 8 }}
-      {{- end }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/server/configmap.yaml") . | sha256sum }}
+        {{- with .Values.showcase.server.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       {{- with .Values.global.imagePullSecrets }}
       imagePullSecrets: {{- toYaml . | nindent 8 }}

--- a/charts/showcase/values.yaml
+++ b/charts/showcase/values.yaml
@@ -136,6 +136,12 @@ showcase:
     replicaCount: 1
     ## HTTP listen port for Caddy (Caddyfile site block, container, and Service must match).
     containerPort: 3000
+    ## Runtime config injected as /srv{baseRoute}/config.json via ConfigMap.
+    ## Specify as YAML here; the chart converts it to JSON automatically.
+    config:
+      keycloakUrl: "https://dev.loginproxy.gov.bc.ca"
+      keycloakRealm: digitaltrust-citz
+      keycloakClientId: showcase-admin
     ## Caddy Content-Security-Policy header. Default is permissive for Vite/React + API/WS; tighten for production.
     contentSecurityPolicy: "default-src * data: blob: filesystem: 'unsafe-inline' 'unsafe-eval'"
     ## Caddy reverse_proxy trusted_proxies: use private_ranges (RFC1918 + loopback) for typical K8s ingress → pod hops.

--- a/charts/showcase/values.yaml
+++ b/charts/showcase/values.yaml
@@ -122,7 +122,7 @@ showcase:
     ## Keycloak config injected as /app/server/config/keycloak.json via ConfigMap.
     ## Specify as YAML here; the chart converts it to JSON automatically.
     keycloak:
-      keycloakUrl: "https://dev.loginproxy.gov.bc.ca"
+      keycloakUrl: 'https://dev.loginproxy.gov.bc.ca'
       keycloakRealm: digitaltrust-citz
     ## Non-sensitive runtime env vars for the server Deployment.
     ## Use existingSecret for sensitive credentials and MONGODB_URI.
@@ -144,7 +144,7 @@ showcase:
     ## Runtime config injected as /srv{baseRoute}/config.json via ConfigMap.
     ## Specify as YAML here; the chart converts it to JSON automatically.
     config:
-      keycloakUrl: "https://dev.loginproxy.gov.bc.ca"
+      keycloakUrl: 'https://dev.loginproxy.gov.bc.ca'
       keycloakRealm: digitaltrust-citz
       keycloakClientId: showcase-admin
     ## Caddy Content-Security-Policy header. Default is permissive for Vite/React + API/WS; tighten for production.

--- a/charts/showcase/values.yaml
+++ b/charts/showcase/values.yaml
@@ -119,6 +119,11 @@ showcase:
     mongodbConnection:
       database: bcwallet_demo
       authSource: admin
+    ## Keycloak config injected as /app/server/config/keycloak.json via ConfigMap.
+    ## Specify as YAML here; the chart converts it to JSON automatically.
+    keycloak:
+      keycloakUrl: "https://dev.loginproxy.gov.bc.ca"
+      keycloakRealm: digitaltrust-citz
     ## Non-sensitive runtime env vars for the server Deployment.
     ## Use existingSecret for sensitive credentials and MONGODB_URI.
     ## Example:


### PR DESCRIPTION
This pull request updates the Helm chart for the Showcase application to improve configuration management for both the frontend and server components. The main changes introduce dedicated ConfigMaps for runtime configuration, allowing `keycloak.json` and `config.json` to be injected into the server and frontend containers, respectively, based on values from `values.yaml`. This enables more flexible and secure configuration without rebuilding images.

**Configuration management improvements:**

* Added a new server ConfigMap (`keycloak.json`) and associated template logic, mounting it into the server container at `/app/server/config/keycloak.json`. The content is sourced from the new `showcase.server.keycloak` value in `values.yaml`, which is specified as YAML and automatically converted to JSON. [[1]](diffhunk://#diff-f932bb36bdc9031863d1aae135703bebd5a17dd743383f554f3c82c169fbef63R1-R10) [[2]](diffhunk://#diff-fa5c561e50366f65a6c33f31b754b7632c2fd2ac23d97e9221fd5a53cfbe38f1R174-R184) [[3]](diffhunk://#diff-32fce2947f64cdb22a6d16839e42ba91185ad9b76be29ca510fe5d7cc3013117R122-R126)
* Added a new frontend ConfigMap (`config.json`) and updated template logic, mounting it into the frontend container at `/srv{baseRoute}/config.json`. The content is sourced from the new `showcase.frontend.config` value in `values.yaml`, specified as YAML and converted to JSON. [[1]](diffhunk://#diff-3e23cd45463dfee3014e7cc680190b8b8eb2ed89fe57a1ce64662bbfe0106d16R15-R16) [[2]](diffhunk://#diff-01439022593c2b93e54e9d2cfa815083768a7b1bba590efe0edf45e2fa026598L55-R60) [[3]](diffhunk://#diff-01439022593c2b93e54e9d2cfa815083768a7b1bba590efe0edf45e2fa026598L68-R71) [[4]](diffhunk://#diff-32fce2947f64cdb22a6d16839e42ba91185ad9b76be29ca510fe5d7cc3013117R144-R149)

**Template and naming standardization:**

* Standardized ConfigMap naming for both frontend and server components in `_helpers.tpl`, reflecting the new configuration approach and removing the old `-caddy` suffix from the frontend ConfigMap.

These changes make it easier to manage environment-specific configuration and credentials, improving security and maintainability.