### PR TITLE
feat: server keycloak connection error handling

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -159,7 +159,7 @@ const run = async () => {
   })
 
   // Error handler: map known errors to appropriate HTTP status codes.
-  // - ServiceUnavailableError → 503 (Keycloak service is unavailable)
+  // - ServiceUnavailableError → 503 (service dependency unavailable)
   // - UnauthorizedError → 401 (Invalid/missing/expired JWT)
   // - All others → 500 (Internal server error)
   // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -11,7 +11,7 @@ import { Server } from 'socket.io'
 
 import { connectDB, registerShutdownHandlers } from './db/connection'
 import { auditLoginMiddleware } from './middleware/auditLogin'
-import { requireAdmin } from './middleware/requireAdmin'
+import { requireAdmin, ServiceUnavailableError } from './middleware/requireAdmin'
 import adminAuditLogRouter from './routes/adminAuditLogRouter'
 import adminCredentialsRouter from './routes/adminCredentialsRouter'
 import adminImagesRouter from './routes/adminImagesRouter'
@@ -158,10 +158,16 @@ const run = async () => {
     return response
   })
 
-  // Map express-jwt UnauthorizedError → 401. Without this, Express's default
-  // error handler returns 500 for any error that isn't handled by a route.
+  // Error handler: map known errors to appropriate HTTP status codes.
+  // - ServiceUnavailableError → 503 (Keycloak service is unavailable)
+  // - UnauthorizedError → 401 (Invalid/missing/expired JWT)
+  // - All others → 500 (Internal server error)
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   app.use((err: unknown, _req: Request, res: Response, _next: NextFunction) => {
+    if (err instanceof ServiceUnavailableError) {
+      res.status(503).json({ error: err.message })
+      return
+    }
     if (err instanceof UnauthorizedError) {
       res.status(401).json({ error: err.message })
       return

--- a/server/src/middleware/__tests__/requireAdmin.service-unavailable.test.ts
+++ b/server/src/middleware/__tests__/requireAdmin.service-unavailable.test.ts
@@ -1,0 +1,121 @@
+/* eslint-disable @typescript-eslint/consistent-type-imports */
+import type { NextFunction, Request, Response } from 'express'
+
+import express from 'express'
+import nock from 'nock'
+import request from 'supertest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../utils/logger', () => ({
+  default: { info: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}))
+
+const { TEST_KEYCLOAK_URL, TEST_REALM } = vi.hoisted(() => ({
+  TEST_KEYCLOAK_URL: 'http://keycloak-service-test',
+  TEST_REALM: 'service-test-realm',
+}))
+
+// Mock fs before importing requireAdmin
+vi.mock('fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs')>()
+  return {
+    ...actual,
+    readFileSync: (path: string, encoding?: string) => {
+      if (typeof path === 'string' && path.endsWith('keycloak.json')) {
+        return JSON.stringify({ keycloakUrl: TEST_KEYCLOAK_URL, keycloakRealm: TEST_REALM })
+      }
+      return actual.readFileSync(path, encoding as BufferEncoding)
+    },
+  }
+})
+
+import { ServiceUnavailableError } from '../requireAdmin'
+
+const JWKS_PATH = `/realms/${TEST_REALM}/protocol/openid-connect/certs`
+
+/**
+ * Build an Express app that properly handles the new ServiceUnavailableError.
+ * This mirrors the error handler in src/index.ts.
+ */
+function buildAppWithErrorHandler(requireAdminMiddleware: express.RequestHandler) {
+  const app = express()
+  app.use(requireAdminMiddleware)
+  app.get('/protected', (_req, res) => res.json({ ok: true }))
+
+  // 4-parameter signature is required for Express to recognize an error handler.
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  app.use((err: unknown, _req: Request, res: Response, _next: NextFunction) => {
+    if (err instanceof ServiceUnavailableError) {
+      res.status(503).json({ error: err.message })
+      return
+    }
+    const status = (err as { status?: number }).status ?? 500
+    res.status(status).json({ error: (err as Error).message })
+  })
+
+  return app
+}
+
+describe('requireAdmin middleware — ServiceUnavailableError handling', () => {
+  afterEach(() => {
+    nock.cleanAll()
+  })
+
+  it('returns 503 when Keycloak JWKS endpoint is unreachable', async () => {
+    // Simulate Keycloak being completely down
+    nock(TEST_KEYCLOAK_URL).get(JWKS_PATH).replyWithError('connect ECONNREFUSED')
+
+    const { requireAdmin: requireAdminMiddleware } = await import('../requireAdmin')
+    const app = buildAppWithErrorHandler(requireAdminMiddleware)
+
+    const res = await request(app).get('/protected').set('Authorization', 'Bearer any-token')
+
+    expect(res.status).toBe(503)
+    expect(res.body.error).toMatch(/Failed to fetch JWKS/)
+  })
+
+  it('returns 503 when Keycloak returns a 5xx error', async () => {
+    nock(TEST_KEYCLOAK_URL).get(JWKS_PATH).reply(500, 'Internal Server Error')
+
+    const { requireAdmin: requireAdminMiddleware } = await import('../requireAdmin')
+    const app = buildAppWithErrorHandler(requireAdminMiddleware)
+
+    const res = await request(app).get('/protected').set('Authorization', 'Bearer any-token')
+
+    expect(res.status).toBe(503)
+    expect(res.body.error).toMatch(/Failed to fetch JWKS/)
+  })
+
+  it('returns 503 when JWKS response is invalid JSON', async () => {
+    nock(TEST_KEYCLOAK_URL).get(JWKS_PATH).reply(200, 'not valid json')
+
+    const { requireAdmin: requireAdminMiddleware } = await import('../requireAdmin')
+    const app = buildAppWithErrorHandler(requireAdminMiddleware)
+
+    const res = await request(app).get('/protected').set('Authorization', 'Bearer any-token')
+
+    expect(res.status).toBe(503)
+    expect(res.body.error).toMatch(/Failed to fetch JWKS/)
+  })
+
+  it('returns 401 when token is missing even if JWKS fetch fails', async () => {
+    nock(TEST_KEYCLOAK_URL).get(JWKS_PATH).replyWithError('JWKS unavailable')
+
+    const { requireAdmin: requireAdminMiddleware } = await import('../requireAdmin')
+    const app = buildAppWithErrorHandler(requireAdminMiddleware)
+
+    // express-jwt checks for Authorization header first and fails fast with 401
+    // before the secret function (getKey) is even called.
+    const res = await request(app).get('/protected')
+
+    expect(res.status).toBe(401)
+  })
+
+  it('ServiceUnavailableError is properly exported and instanceof check works', async () => {
+    const err = new ServiceUnavailableError('Test error')
+    expect(err).toBeInstanceOf(Error)
+    expect(err).toBeInstanceOf(ServiceUnavailableError)
+    expect(err.name).toBe('ServiceUnavailableError')
+    expect(err.message).toBe('Test error')
+  })
+})

--- a/server/src/middleware/requireAdmin.ts
+++ b/server/src/middleware/requireAdmin.ts
@@ -96,6 +96,7 @@ const getKey: GetVerificationKey = async (_req, token) => {
   try {
     keys = await getJwks()
   } catch (err) {
+    logger.error({ err }, 'Failed to fetch JWKS for JWT verification')
     const message = err instanceof Error ? err.message : String(err)
     throw new ServiceUnavailableError(`Failed to fetch JWKS: ${message}`)
   }

--- a/server/src/middleware/requireAdmin.ts
+++ b/server/src/middleware/requireAdmin.ts
@@ -84,8 +84,21 @@ async function getJwks(): Promise<Jwk[]> {
   }
 }
 
+export class ServiceUnavailableError extends Error {
+  public constructor(message: string) {
+    super(message)
+    this.name = 'ServiceUnavailableError'
+  }
+}
+
 const getKey: GetVerificationKey = async (_req, token) => {
-  const keys = await getJwks()
+  let keys: Jwk[]
+  try {
+    keys = await getJwks()
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    throw new ServiceUnavailableError(`Failed to fetch JWKS: ${message}`)
+  }
   const jwk = keys.find((k) => k.kid === token?.header.kid)
   if (!jwk) throw new Error(`No JWKS key found for kid: ${String(token?.header.kid)}`)
   return createPublicKey({ key: jwk as JsonWebKeyInput['key'], format: 'jwk' })


### PR DESCRIPTION
Adds error handling for the server when it can't access the keycloak service to validate the token.