### PR TITLE
fix(chart): allow-all egress NetworkPolicy + MongoDB SCC for OpenShift Silver

### DIFF
--- a/charts/showcase/templates/frontend/networkpolicy.yaml
+++ b/charts/showcase/templates/frontend/networkpolicy.yaml
@@ -53,13 +53,10 @@ spec:
       ports:
         - protocol: TCP
           port: {{ .Values.showcase.server.containerPort }}
-    # DNS (cluster DNS backends vary: ClusterIP, hostNetwork, node-local).
-    # Explicit ipBlock required — OVN-Kubernetes on OpenShift may not match
-    # external/node IPs when `to` is omitted.
-    - to:
-        - ipBlock:
-            cidr: 0.0.0.0/0
-      ports:
+    # DNS — no `to` selector so the rule covers the cluster DNS ClusterIP.
+    # ipBlock does not match ClusterIP traffic on OVN-Kubernetes (egress ACL
+    # is evaluated before Service DNAT), so DNS must use an open rule.
+    - ports:
         - protocol: UDP
           port: 53
         - protocol: TCP

--- a/charts/showcase/templates/frontend/networkpolicy.yaml
+++ b/charts/showcase/templates/frontend/networkpolicy.yaml
@@ -53,12 +53,22 @@ spec:
       ports:
         - protocol: TCP
           port: {{ .Values.showcase.server.containerPort }}
-    # DNS + HTTPS: no `to` peers — cluster DNS paths vary on OpenShift; Caddy needs 443 for upstream TLS.
-    - ports:
+    # DNS (cluster DNS backends vary: ClusterIP, hostNetwork, node-local).
+    # Explicit ipBlock required — OVN-Kubernetes on OpenShift may not match
+    # external/node IPs when `to` is omitted.
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+      ports:
         - protocol: UDP
           port: 53
         - protocol: TCP
           port: 53
+    # HTTPS: external services, upstream TLS via Caddy.
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+      ports:
         - protocol: TCP
           port: 443
 {{- end }}

--- a/charts/showcase/templates/frontend/networkpolicy.yaml
+++ b/charts/showcase/templates/frontend/networkpolicy.yaml
@@ -44,28 +44,5 @@ spec:
   policyTypes:
     - Egress
   egress:
-    # API pods
-    - to:
-        - podSelector:
-            matchLabels:
-              {{- include "showcase.selectorLabels" . | nindent 14 }}
-              app.kubernetes.io/component: server
-      ports:
-        - protocol: TCP
-          port: {{ .Values.showcase.server.containerPort }}
-    # DNS — no `to` selector so the rule covers the cluster DNS ClusterIP.
-    # ipBlock does not match ClusterIP traffic on OVN-Kubernetes (egress ACL
-    # is evaluated before Service DNAT), so DNS must use an open rule.
-    - ports:
-        - protocol: UDP
-          port: 53
-        - protocol: TCP
-          port: 53
-    # HTTPS: external services, upstream TLS via Caddy.
-    - to:
-        - ipBlock:
-            cidr: 0.0.0.0/0
-      ports:
-        - protocol: TCP
-          port: 443
+    - {}
 {{- end }}

--- a/charts/showcase/templates/server/networkpolicy.yaml
+++ b/charts/showcase/templates/server/networkpolicy.yaml
@@ -52,13 +52,10 @@ spec:
         - protocol: TCP
           port: 27017
     {{- end }}
-    # DNS (cluster DNS backends vary: ClusterIP, hostNetwork, node-local).
-    # Explicit ipBlock required — OVN-Kubernetes on OpenShift may not match
-    # external/node IPs when `to` is omitted.
-    - to:
-        - ipBlock:
-            cidr: 0.0.0.0/0
-      ports:
+    # DNS — no `to` selector so the rule covers the cluster DNS ClusterIP.
+    # ipBlock does not match ClusterIP traffic on OVN-Kubernetes (egress ACL
+    # is evaluated before Service DNAT), so DNS must use an open rule.
+    - ports:
         - protocol: UDP
           port: 53
         - protocol: TCP

--- a/charts/showcase/templates/server/networkpolicy.yaml
+++ b/charts/showcase/templates/server/networkpolicy.yaml
@@ -41,30 +41,5 @@ spec:
   policyTypes:
     - Egress
   egress:
-    {{- if .Values.mongodb.enabled }}
-    # Restrict Mongo traffic to MongoDB workload pods for this Helm release.
-    - to:
-        - podSelector:
-            matchLabels:
-              app.kubernetes.io/name: mongodb
-              app.kubernetes.io/instance: {{ .Release.Name | quote }}
-      ports:
-        - protocol: TCP
-          port: 27017
-    {{- end }}
-    # DNS — no `to` selector so the rule covers the cluster DNS ClusterIP.
-    # ipBlock does not match ClusterIP traffic on OVN-Kubernetes (egress ACL
-    # is evaluated before Service DNAT), so DNS must use an open rule.
-    - ports:
-        - protocol: UDP
-          port: 53
-        - protocol: TCP
-          port: 53
-    # HTTPS: external services (Traction, Keycloak / loginproxy, GHCR, etc.).
-    - to:
-        - ipBlock:
-            cidr: 0.0.0.0/0
-      ports:
-        - protocol: TCP
-          port: 443
+    - {}
 {{- end }}

--- a/charts/showcase/templates/server/networkpolicy.yaml
+++ b/charts/showcase/templates/server/networkpolicy.yaml
@@ -52,12 +52,22 @@ spec:
         - protocol: TCP
           port: 27017
     {{- end }}
-    # DNS + HTTPS: no `to` peers — cluster DNS backends vary (Service IP, hostNetwork, node-local); Caddy/server need outbound 443.
-    - ports:
+    # DNS (cluster DNS backends vary: ClusterIP, hostNetwork, node-local).
+    # Explicit ipBlock required — OVN-Kubernetes on OpenShift may not match
+    # external/node IPs when `to` is omitted.
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+      ports:
         - protocol: UDP
           port: 53
         - protocol: TCP
           port: 53
+    # HTTPS: external services (Traction, Keycloak / loginproxy, GHCR, etc.).
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+      ports:
         - protocol: TCP
           port: 443
 {{- end }}

--- a/deploy/showcase/values-dev.yaml
+++ b/deploy/showcase/values-dev.yaml
@@ -48,3 +48,9 @@ mongodb:
     rootUsername: admin
     existingSecret: '{{ printf "%s-showcase-mongo-root" .Release.Name }}'
     existingSecretPasswordKey: password
+  ## OpenShift restricted-v2 SCC assigns UIDs from the namespace range;
+  ## the subchart defaults (999) are rejected.
+  containerSecurityContext:
+    runAsUser: null
+  podSecurityContext:
+    fsGroup: null

--- a/deploy/showcase/values-pr.yaml
+++ b/deploy/showcase/values-pr.yaml
@@ -52,3 +52,9 @@ mongodb:
     rootPassword: ''
     existingSecret: '{{ printf "%s-showcase-mongo-root" .Release.Name }}'
     existingSecretPasswordKey: password
+  ## OpenShift restricted-v2 SCC assigns UIDs from the namespace range;
+  ## the subchart defaults (999) are rejected.
+  containerSecurityContext:
+    runAsUser: null
+  podSecurityContext:
+    fsGroup: null


### PR DESCRIPTION
## Summary

- **NetworkPolicy egress**: simplify server and frontend egress to allow-all (`- {}`). OVN-Kubernetes on OpenShift Silver does not reliably match port-specific egress rules against ClusterIP traffic — tested `ipBlock`, open rules (no `to`), and `namespaceSelector` for DNS; only `- {}` works. Ingress policies remain restrictive (frontend from router only, server from frontend only, MongoDB from server only).
- **MongoDB SCC**: override the CloudPirates subchart defaults (`runAsUser: 999`, `fsGroup: 999`) to `null` in both `values-dev.yaml` and `values-pr.yaml` so OpenShift's `restricted-v2` SCC can assign UIDs from the namespace range. Without this, MongoDB pods are rejected on pod recreation.

## Test plan

- [x] Verified `- {}` egress allows DNS resolution and HTTPS to external services from server pod
- [x] Verified MongoDB pod starts with SCC-assigned UID after StatefulSet recreation
- [ ] PR CI deploy completes successfully (Helm upgrade + rollout)
- [ ] Admin login (Keycloak JWKS fetch) works end-to-end
- [ ] Traction API reachable from server pod