### PR TITLE
Repair auto schema creddef creation

### DIFF
--- a/server/src/controllers/CredentialController.ts
+++ b/server/src/controllers/CredentialController.ts
@@ -79,13 +79,20 @@ export class CredentialController {
       })
     ).data
     let schema_id = ''
+    let issuerDid = ''
     if (schemas.schema_ids.length <= 0) {
       logger.info({ name: credential.name, version: credential.version }, 'Schema not found, creating new schema')
       const schemaAttrs = credential.attributes.map((attr) => attr.name)
+      issuerDid = (await tractionRequest.get('/wallet/did/public')).data.result.did
+
+      if (!issuerDid) {
+        logger.error('Failed to retrieve issuer DID from wallet')
+        throw new Error('Issuer DID not found')
+      }
       const resp = (
         await tractionRequest.post(`/anoncreds/schema`, {
           schema: {
-            issuerId: process.env.TRACTION_DID,
+            issuerId: issuerDid,
             attrNames: schemaAttrs,
             name: credential.name,
             version: credential.version,
@@ -108,7 +115,7 @@ export class CredentialController {
         await tractionRequest.post(`/anoncreds/credential-definition`, {
           credential_definition: {
             schemaId: schema_id,
-            issuerId: process.env.TRACTION_DID,
+            issuerId: issuerDid,
             tag: credential.name,
           },
           options: {

--- a/server/src/controllers/__tests__/CredentialController.test.ts
+++ b/server/src/controllers/__tests__/CredentialController.test.ts
@@ -191,6 +191,13 @@ describe('CredentialController', () => {
           config: {},
         } as any)
         .mockResolvedValueOnce({
+          data: { result: { did: 'did:example:issuer123' } },
+          status: 200,
+          statusText: 'OK',
+          headers: {},
+          config: {},
+        } as any)
+        .mockResolvedValueOnce({
           data: { credential_definition_ids: [] },
           status: 200,
           statusText: 'OK',
@@ -290,6 +297,7 @@ describe('CredentialController', () => {
     })
 
     it('returns the response data', async () => {
+      vi.clearAllMocks()
       const mockData = { cred_ex_id: 'cred-exch-1', state: 'offer_sent' }
       vi.mocked(tractionRequest.post).mockResolvedValue({
         data: mockData,


### PR DESCRIPTION
I think this is why the issuance isn't working with dev instance right now.

The `TRACTION_DID` env variable was removed from the deployment. When the schema and cred def don't exist for the credential they get auto created. `anoncreds` needs the issuer did. Easiest way to repair this is to use the public did.

This is going to get changed but I'd like the existing process to continue to work for now. This would still work if the schema and cred def already was created for this dev traction tenant.