### PR TITLE
Add webhook secret env to deployments

### DIFF
--- a/.github/workflows/deploy-showcase-dev.yaml
+++ b/.github/workflows/deploy-showcase-dev.yaml
@@ -15,9 +15,10 @@
 #   Secret:
 #     SHOWCASE_DEV_OC_TOKEN      — Service account or user token with permission to
 #                                  helm upgrade/install resources in that namespace
-#   Optional secrets (Traction tenant; synced to OpenShift Secret `${release}-traction` before Helm):
+#   Optional secrets (Traction tenant and webhook; synced to OpenShift Secret `${release}-traction` before Helm):
 #     TRACTION_DEV_TENANT_ID     — Tenant UUID (maps to env TRACTION_TENANT_ID in the pod)
 #     TRACTION_DEV_TENANT_API_KEY — Tenant API key (maps to env TRACTION_TENANT_API_KEY)
+#     WEBHOOK_SECRET_DEV         — Secret for webhook signature verification (maps to env WEBHOOK_SECRET)
 #
 # If SHOWCASE_DEV_OC_URL or SHOWCASE_DEV_NAMESPACE is unset, the Helm deploy job is skipped while
 # image builds still run on bcgov. If both are set but SHOWCASE_DEV_OC_TOKEN is missing, the deploy
@@ -140,6 +141,7 @@ jobs:
           SHOWCASE_DEV_HELM_RELEASE: ${{ vars.SHOWCASE_DEV_HELM_RELEASE }}
           TRACTION_DEV_TENANT_ID: ${{ secrets.TRACTION_DEV_TENANT_ID }}
           TRACTION_DEV_TENANT_API_KEY: ${{ secrets.TRACTION_DEV_TENANT_API_KEY }}
+          WEBHOOK_SECRET_DEV: ${{ secrets.WEBHOOK_SECRET_DEV }}
         run: |
           set -euo pipefail
           release="${SHOWCASE_DEV_HELM_RELEASE:-showcase}"
@@ -152,15 +154,16 @@ jobs:
             --timeout 15m
             --atomic
           )
-          if [[ -n "${TRACTION_DEV_TENANT_ID:-}" && -n "${TRACTION_DEV_TENANT_API_KEY:-}" ]]; then
+          if [[ -n "${TRACTION_DEV_TENANT_ID:-}" && -n "${TRACTION_DEV_TENANT_API_KEY:-}" && -n "${WEBHOOK_SECRET_DEV:-}" ]]; then
             oc create secret generic "${traction_secret}" \
               --from-literal=TRACTION_TENANT_ID="${TRACTION_DEV_TENANT_ID}" \
               --from-literal=TRACTION_TENANT_API_KEY="${TRACTION_DEV_TENANT_API_KEY}" \
+              --from-literal=WEBHOOK_SECRET="${WEBHOOK_SECRET_DEV}" \
               -n "${ns}" \
               --dry-run=client -o yaml | oc apply -f -
             helm_args+=(--set-string "showcase.server.traction.existingSecret=${traction_secret}")
           else
-            echo '::notice::TRACTION_DEV_TENANT_ID / TRACTION_DEV_TENANT_API_KEY not set — not creating traction Secret; set them in repo Actions secrets to enable Traction.'
+            echo '::notice::TRACTION_DEV_TENANT_ID / TRACTION_DEV_TENANT_API_KEY / WEBHOOK_SECRET_DEV not set — not creating traction Secret; set them in repo Actions secrets to enable Traction.'
           fi
           helm upgrade --install "${release}" . "${helm_args[@]}"
 

--- a/.github/workflows/deploy-showcase-pr.yaml
+++ b/.github/workflows/deploy-showcase-pr.yaml
@@ -4,8 +4,8 @@
 #
 # Configure on bcgov/BC-Wallet-Demo (repository Actions secrets):
 #   Secrets: OPENSHIFT_SERVER, OPENSHIFT_TOKEN, OPENSHIFT_DEV_NAMESPACE
-#   Optional (Traction dev tenant; synced to Secret `pr-<N>-showcase-traction` before Helm when both set):
-#     TRACTION_DEV_TENANT_ID, TRACTION_DEV_TENANT_API_KEY
+#   Optional (Traction dev tenant and webhook; synced to Secret `pr-<N>-showcase-traction` before Helm when both set):
+#     TRACTION_DEV_TENANT_ID, TRACTION_DEV_TENANT_API_KEY, WEBHOOK_SECRET_DEV
 # Optional variable: SHOWCASE_PR_HOST_SUFFIX — hostname without scheme (overrides workflow default).
 #   Default is Silver dev ingress (see env.SHOWCASE_PR_HOST_SUFFIX). Public URL:
 #   https://pr-<N>-<suffix>/digital-trust/showcase
@@ -174,6 +174,7 @@ jobs:
           OPENSHIFT_DEV_NAMESPACE: ${{ secrets.OPENSHIFT_DEV_NAMESPACE }}
           TRACTION_DEV_TENANT_ID: ${{ secrets.TRACTION_DEV_TENANT_ID }}
           TRACTION_DEV_TENANT_API_KEY: ${{ secrets.TRACTION_DEV_TENANT_API_KEY }}
+          WEBHOOK_SECRET_DEV: ${{ secrets.WEBHOOK_SECRET_DEV }}
         run: |
           set -euo pipefail
           origin="https://pr-${PR_NUM}-${HOST_SUFFIX}"
@@ -192,15 +193,16 @@ jobs:
             --wait
             --timeout 10m
           )
-          if [[ -n "${TRACTION_DEV_TENANT_ID:-}" && -n "${TRACTION_DEV_TENANT_API_KEY:-}" ]]; then
+          if [[ -n "${TRACTION_DEV_TENANT_ID:-}" && -n "${TRACTION_DEV_TENANT_API_KEY:-}" && -n "${WEBHOOK_SECRET_DEV:-}" ]]; then
             oc create secret generic "${traction_secret}" \
               --from-literal=TRACTION_TENANT_ID="${TRACTION_DEV_TENANT_ID}" \
               --from-literal=TRACTION_TENANT_API_KEY="${TRACTION_DEV_TENANT_API_KEY}" \
+              --from-literal=WEBHOOK_SECRET="${WEBHOOK_SECRET_DEV}" \
               -n "${ns}" \
               --dry-run=client -o yaml | oc apply -f -
             helm_args+=(--set-string "showcase.server.traction.existingSecret=${traction_secret}")
           else
-            echo '::notice::TRACTION_DEV_TENANT_ID / TRACTION_DEV_TENANT_API_KEY not set — PR deploy without Traction tenant Secret.'
+            echo '::notice::TRACTION_DEV_TENANT_ID / TRACTION_DEV_TENANT_API_KEY / WEBHOOK_SECRET_DEV not set — PR deploy without Traction tenant Secret.'
           fi
           if ! helm upgrade --install "pr-${PR_NUM}-showcase" . "${helm_args[@]}"; then
             echo '::error::helm upgrade failed; status and recent events follow.'

--- a/charts/showcase/README.md
+++ b/charts/showcase/README.md
@@ -77,18 +77,18 @@ The **`wait-for-mongo-tcp`** init container uses the same host as chart-built **
 
 ## Secrets
 
-Prefer a pre-created **`Secret`** and **`showcase.server.existingSecret`**: the server uses **`envFrom`**, so every key becomes an env var (**`MONGODB_URI`**, **`TRACTION_URL`**, **`TRACTION_TENANT_ID`**, **`TRACTION_TENANT_API_KEY`**, … — see **`server/.env.example`**).
+Prefer a pre-created **`Secret`** and **`showcase.server.existingSecret`**: the server uses **`envFrom`**, so every key becomes an env var (**`MONGODB_URI`**, **`TRACTION_URL`**, **`TRACTION_TENANT_ID`**, **`TRACTION_TENANT_API_KEY`**, **`WEBHOOK_SECRET`**, … — see **`server/.env.example`**).
 
 With **`mongodb.enabled: true`**, the chart creates/reuses **`{{ release }}-showcase-mongo-root`** and builds chart-managed **`MONGODB_URI`** from that password (Helm **`lookup`**). Keep **`mongodb.auth.existingSecret`** set to the tpl string in **`deploy/showcase/values-dev.yaml`** so the Mongo subchart and server URI use the same secret source. Use **`showcase.server.existingSecret`** when you want to supply your own full server env (including `MONGODB_URI`).
 
 ### Traction (optional split)
 
 - **`showcase.server.traction.url`** — sets **`TRACTION_URL`** on the server (non-secret; tenant proxy base URL, no path). **`deploy/showcase/values-*.yaml`** set the Silver dev proxy by default.
-- **`showcase.server.traction.existingSecret`** — name of a **`Secret`** in the release namespace with keys **`TRACTION_TENANT_ID`** and **`TRACTION_TENANT_API_KEY`**. The Deployment mounts these via **`valueFrom.secretKeyRef`** (after **`envFrom`**, so they override if the same keys were present in a monolithic secret).
+- **`showcase.server.traction.existingSecret`** — name of a **`Secret`** in the release namespace with keys **`TRACTION_TENANT_ID`** and **`TRACTION_TENANT_API_KEY`** (and optionally **`WEBHOOK_SECRET`** for webhook signature verification). The Deployment mounts these via **`valueFrom.secretKeyRef`** (after **`envFrom`**, so they override if the same keys were present in a monolithic secret).
 
 If you use **`showcase.server.existingSecret`** for a full env bundle, you can omit **`traction.existingSecret`** and include those keys (and **`TRACTION_URL`**) in that secret instead.
 
-On **bcgov**, GitHub Actions (**`deploy-showcase-dev.yaml`** / **`deploy-showcase-pr.yaml`**) can create **`${release}-traction`** / **`pr-<N>-showcase-traction`** from repository secrets **`TRACTION_DEV_TENANT_ID`** and **`TRACTION_DEV_TENANT_API_KEY`** before **`helm upgrade`**.
+On **bcgov**, GitHub Actions (**`deploy-showcase-dev.yaml`** / **`deploy-showcase-pr.yaml`**) can create **`${release}-traction`** / **`pr-<N>-showcase-traction`** from repository secrets **`TRACTION_DEV_TENANT_ID`**, **`TRACTION_DEV_TENANT_API_KEY`**, and optionally **`WEBHOOK_SECRET_DEV`** before **`helm upgrade`**.
 
 ### Short OOB invitation URLs (QR)
 

--- a/charts/showcase/templates/server/deployment.yaml
+++ b/charts/showcase/templates/server/deployment.yaml
@@ -170,6 +170,11 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.showcase.server.traction.existingSecret | quote }}
                   key: TRACTION_TENANT_API_KEY
+            - name: WEBHOOK_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.showcase.server.traction.existingSecret | quote }}
+                  key: WEBHOOK_SECRET
             {{- end }}
           {{- range .Values.showcase.server.extraEnv }}
             - name: {{ .name }}


### PR DESCRIPTION
We need the webhook secret env variable in the deployments because the showcase client app validates the incoming payload to make sure it's coming from traction. 