### PR TITLE
Use traction storage for lookup

### DIFF
--- a/server/src/controllers/CredentialController.ts
+++ b/server/src/controllers/CredentialController.ts
@@ -73,14 +73,24 @@ export class CredentialController {
   @Post('/getOrCreateCredDef')
   public async getOrCreateCredDef(@Body() credential: CreateCredentialInput) {
     logger.info({ name: credential.name, version: credential.version }, 'Resolving credential definition')
-    const schemas = (
-      await tractionRequest.get(`/anoncreds/schemas`, {
-        params: { schema_name: credential.name, schema_version: credential.version },
-      })
-    ).data
+    const schemasResponse = await tractionRequest.get(`/schema-storage`, {
+      params: {
+        schema_name: credential.name,
+        schema_version: credential.version,
+      },
+    })
+
     let schema_id = ''
     let issuerDid = ''
-    if (schemas.schema_ids.length <= 0) {
+
+    // Check if schema exists in the response
+    // Response can be an array or a single object
+    const schemas = schemasResponse.data.results
+    const existingSchema = schemas.find(
+      (s: any) => s?.schema?.name === credential.name && s?.schema?.version === credential.version,
+    )
+
+    if (!existingSchema) {
       logger.info({ name: credential.name, version: credential.version }, 'Schema not found, creating new schema')
       const schemaAttrs = credential.attributes.map((attr) => attr.name)
       issuerDid = (await tractionRequest.get('/wallet/did/public')).data.result.did
@@ -103,13 +113,19 @@ export class CredentialController {
       logger.info({ schema_id }, 'Schema created, waiting for ledger propagation')
       await new Promise((r) => setTimeout(r, LEDGER_PROPAGATION_MS))
     } else {
-      schema_id = schemas.schema_ids[0]
+      schema_id = existingSchema.schema_id
       logger.debug({ schema_id }, 'Existing schema found')
     }
 
-    const credDefs = (await tractionRequest.get(`/anoncreds/credential-definitions`, { params: { schema_id } })).data
+    const credDefsResponse = await tractionRequest.get(`/credential-definition-storage`, {
+      params: { schema_id },
+    })
+
     let cred_def_id = ''
-    if (credDefs.credential_definition_ids.length <= 0) {
+    const credDefs = credDefsResponse.data.results
+    const existingCredDef = credDefs.find((cd: any) => cd?.schema_id === schema_id)
+
+    if (!existingCredDef) {
       logger.info({ schema_id }, 'Credential definition not found, creating new credential definition')
       const resp = (
         await tractionRequest.post(`/anoncreds/credential-definition`, {
@@ -127,7 +143,7 @@ export class CredentialController {
       cred_def_id = resp.credential_definition_state.credential_definition_id
       logger.info({ cred_def_id }, 'Credential definition created')
     } else {
-      cred_def_id = credDefs.credential_definition_ids[0]
+      cred_def_id = existingCredDef.cred_def_id
       logger.debug({ cred_def_id }, 'Existing credential definition found')
     }
     return cred_def_id

--- a/server/src/controllers/__tests__/CredentialController.test.ts
+++ b/server/src/controllers/__tests__/CredentialController.test.ts
@@ -149,14 +149,30 @@ describe('CredentialController', () => {
     it('returns the existing credDef id without creating anything', async () => {
       vi.mocked(tractionRequest.get)
         .mockResolvedValueOnce({
-          data: { schema_ids: ['existing-schema-id'] },
+          data: {
+            schema_id: 'existing-schema-id',
+            schema: {
+              name: 'Student Card',
+              version: '1.6',
+              attrNames: ['given_names'],
+            },
+          },
           status: 200,
           statusText: 'OK',
           headers: {},
           config: {},
         } as any)
         .mockResolvedValueOnce({
-          data: { credential_definition_ids: ['existing-cred-def-id'] },
+          data: {
+            results: [
+              {
+                cred_def_id: 'existing-cred-def-id',
+                schema_id: 'existing-schema-id',
+                tag: 'Student Card',
+                state: 'active',
+              },
+            ],
+          },
           status: 200,
           statusText: 'OK',
           headers: {},
@@ -184,7 +200,7 @@ describe('CredentialController', () => {
 
       vi.mocked(tractionRequest.get)
         .mockResolvedValueOnce({
-          data: { schema_ids: [] },
+          data: [],
           status: 200,
           statusText: 'OK',
           headers: {},
@@ -198,7 +214,7 @@ describe('CredentialController', () => {
           config: {},
         } as any)
         .mockResolvedValueOnce({
-          data: { credential_definition_ids: [] },
+          data: { results: [] },
           status: 200,
           statusText: 'OK',
           headers: {},
@@ -244,14 +260,21 @@ describe('CredentialController', () => {
     it('uses existing schema id and creates a new credential definition', async () => {
       vi.mocked(tractionRequest.get)
         .mockResolvedValueOnce({
-          data: { schema_ids: ['pre-existing-schema-id'] },
+          data: {
+            schema_id: 'pre-existing-schema-id',
+            schema: {
+              name: 'Existing Schema Card',
+              version: '2.0',
+              attrNames: ['attr'],
+            },
+          },
           status: 200,
           statusText: 'OK',
           headers: {},
           config: {},
         } as any)
         .mockResolvedValueOnce({
-          data: { credential_definition_ids: [] },
+          data: { results: [] },
           status: 200,
           statusText: 'OK',
           headers: {},

--- a/server/src/controllers/__tests__/CredentialController.test.ts
+++ b/server/src/controllers/__tests__/CredentialController.test.ts
@@ -146,16 +146,24 @@ describe('CredentialController', () => {
       attributes: [{ name: 'given_names', value: 'Alice' }],
     }
 
+    beforeEach(() => {
+      vi.clearAllMocks()
+    })
+
     it('returns the existing credDef id without creating anything', async () => {
       vi.mocked(tractionRequest.get)
         .mockResolvedValueOnce({
           data: {
-            schema_id: 'existing-schema-id',
-            schema: {
-              name: 'Student Card',
-              version: '1.6',
-              attrNames: ['given_names'],
-            },
+            results: [
+              {
+                schema_id: 'existing-schema-id',
+                schema: {
+                  name: 'Student Card',
+                  version: '1.6',
+                  attrNames: ['given_names'],
+                },
+              },
+            ],
           },
           status: 200,
           statusText: 'OK',
@@ -195,12 +203,16 @@ describe('CredentialController', () => {
       attributes: [{ name: 'field_one', value: 'val' }],
     }
 
+    beforeEach(() => {
+      vi.clearAllMocks()
+    })
+
     it('creates schema then credential definition and returns the new credDef id', async () => {
       vi.useFakeTimers()
 
       vi.mocked(tractionRequest.get)
         .mockResolvedValueOnce({
-          data: [],
+          data: { results: [] },
           status: 200,
           statusText: 'OK',
           headers: {},
@@ -257,16 +269,24 @@ describe('CredentialController', () => {
       attributes: [{ name: 'attr', value: 'val' }],
     }
 
+    beforeEach(() => {
+      vi.clearAllMocks()
+    })
+
     it('uses existing schema id and creates a new credential definition', async () => {
       vi.mocked(tractionRequest.get)
         .mockResolvedValueOnce({
           data: {
-            schema_id: 'pre-existing-schema-id',
-            schema: {
-              name: 'Existing Schema Card',
-              version: '2.0',
-              attrNames: ['attr'],
-            },
+            results: [
+              {
+                schema_id: 'pre-existing-schema-id',
+                schema: {
+                  name: 'Existing Schema Card',
+                  version: '2.0',
+                  attrNames: ['attr'],
+                },
+              },
+            ],
           },
           status: 200,
           statusText: 'OK',
@@ -297,10 +317,15 @@ describe('CredentialController', () => {
   })
 
   describe('offerCredential', () => {
-    it('posts to the issue-credential/send endpoint with the params', async () => {
+    beforeEach(() => {
+      vi.clearAllMocks()
+    })
+
+    it('posts to the issue-credential-2.0/send-offer endpoint with the params', async () => {
       const params = { connection_id: 'conn1', credential_preview: { attributes: [] } }
+      const mockData = { cred_ex_id: 'cred-exch-1', state: 'offer_sent' }
       vi.mocked(tractionRequest.post).mockResolvedValue({
-        data: { cred_ex_id: 'cred-exch-1' },
+        data: mockData,
         status: 200,
         statusText: 'OK',
         headers: {},
@@ -320,7 +345,6 @@ describe('CredentialController', () => {
     })
 
     it('returns the response data', async () => {
-      vi.clearAllMocks()
       const mockData = { cred_ex_id: 'cred-exch-1', state: 'offer_sent' }
       vi.mocked(tractionRequest.post).mockResolvedValue({
         data: mockData,

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -168,6 +168,13 @@ const run = async () => {
   // - All others → 500 (Internal server error)
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   app.use((err: unknown, _req: Request, res: Response, _next: NextFunction) => {
+    // If headers were already sent, we can't send another response.
+    // Log the error and end the connection.
+    if (res.headersSent) {
+      logger.error({ err }, 'Error occurred after headers sent')
+      return res.end()
+    }
+
     if (err instanceof ServiceUnavailableError) {
       res.status(503).json({ error: err.message })
       return


### PR DESCRIPTION
I don't know why this happened exactly but for the dev tenant the schema only exists in traction schema-storage. The lookup would fail and it would try and create a new schema which fails because it already exists on the ledger.

This part is getting change soon. It would be nice to know why this happened. The schemas in the acapy wallet and the tenant plugin wallet should be the same :/