### PR TITLE
fix(assets): create /app/uploads with proper permissions

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -23,12 +23,18 @@ FROM node:22-alpine
 
 WORKDIR /app/server
 
-ENV NODE_ENV=production
+ENV NODE_ENV=production \
+    UPLOADS_DIR=/app/uploads
 
 COPY --from=build /app/package.json /app/yarn.lock /app/
 COPY --from=build /app/node_modules /app/node_modules
 COPY --from=build /app/server/package.json ./
 COPY --from=build /app/server/build ./build
+
+# OpenShift restricted-v2 SCC runs containers with an arbitrary UID but
+# always GID 0 (root group). Make the uploads dir group-writable so any
+# UID in group 0 can write to it.
+RUN mkdir -p /app/uploads && chgrp 0 /app/uploads && chmod g+rwx /app/uploads
 
 EXPOSE 5000
 

--- a/server/src/routes/__tests__/adminAssetsRouter.test.ts
+++ b/server/src/routes/__tests__/adminAssetsRouter.test.ts
@@ -39,7 +39,7 @@ vi.mock('../../utils/sanitizeSVG', () => ({
 import { AssetModel } from '../../db/models/Asset'
 import { sanitizeSVG } from '../../utils/sanitizeSVG'
 import { validateFileType } from '../../utils/validateFileType'
-import adminAssetsRouter from '../adminAssetsRouter'
+import adminAssetsRouter, { staticAssetCache } from '../adminAssetsRouter'
 
 let mongod: MongoMemoryServer
 
@@ -166,6 +166,10 @@ describe('POST /admin/assets', () => {
 })
 
 describe('GET /admin/assets', () => {
+  afterEach(() => {
+    staticAssetCache.clear()
+  })
+
   it('returns { files: [] } when no assets exist', async () => {
     const res = await request(app).get('/admin/assets')
 
@@ -201,6 +205,56 @@ describe('GET /admin/assets', () => {
 
     expect(res.status).toBe(200)
     expect(res.body.files[0]).toBe('/uploads/logo.png')
+  })
+
+  it('includes static bundled images for the requested type', async () => {
+    staticAssetCache.set('icon', ['/public/common/icon/icon-person-light.svg', '/public/common/icon/icon-wallet.png'])
+
+    const res = await request(app).get('/admin/assets?type=icon')
+
+    expect(res.status).toBe(200)
+    expect(res.body.files).toContain('/public/common/icon/icon-person-light.svg')
+    expect(res.body.files).toContain('/public/common/icon/icon-wallet.png')
+  })
+
+  it('static images appear before uploaded images', async () => {
+    staticAssetCache.set('persona', ['/public/common/persona/student.svg'])
+    await AssetModel.create({ filename: 'uploaded.png', mime_type: 'image/png', size_bytes: 100, type: 'persona' })
+
+    const res = await request(app).get('/admin/assets?type=persona')
+
+    expect(res.status).toBe(200)
+    expect(res.body.files[0]).toBe('/public/common/persona/student.svg')
+    expect(res.body.files[1]).toBe('/uploads/uploaded.png')
+  })
+
+  it('does not include static images for other types', async () => {
+    staticAssetCache.set('icon', ['/public/common/icon/icon-person-light.svg'])
+    staticAssetCache.set('persona', ['/public/common/persona/student.svg'])
+
+    const res = await request(app).get('/admin/assets?type=icon')
+
+    expect(res.status).toBe(200)
+    expect(res.body.files).not.toContain('/public/common/persona/student.svg')
+  })
+
+  it('returns no static images when type is not provided', async () => {
+    staticAssetCache.set('icon', ['/public/common/icon/icon-person-light.svg'])
+    await AssetModel.create({ filename: 'uploaded.png', mime_type: 'image/png', size_bytes: 100 })
+
+    const res = await request(app).get('/admin/assets')
+
+    expect(res.status).toBe(200)
+    // No static files when no type filter -- only DB records
+    expect(res.body.files).not.toContain('/public/common/icon/icon-person-light.svg')
+    expect(res.body.files).toContain('/uploads/uploaded.png')
+  })
+
+  it('returns empty files for unknown type with no DB records', async () => {
+    const res = await request(app).get('/admin/assets?type=unknowntype')
+
+    expect(res.status).toBe(200)
+    expect(res.body.files).toHaveLength(0)
   })
 })
 

--- a/server/src/routes/adminAssetsRouter.ts
+++ b/server/src/routes/adminAssetsRouter.ts
@@ -35,7 +35,8 @@ function loadStaticAssets() {
           .filter((e: string) => ALLOWED_EXTENSIONS.includes(path.extname(e).toLowerCase()))
           .map((e: string) => `/public/common/${type}/${e}`),
       )
-    } catch {
+    } catch (err) {
+      logger.warn({ type, dir, err }, 'Failed to read static asset directory')
       staticAssetCache.set(type, [])
     }
   }

--- a/server/src/routes/adminAssetsRouter.ts
+++ b/server/src/routes/adminAssetsRouter.ts
@@ -3,7 +3,7 @@ import type { NextFunction, Request, Response } from 'express'
 import { randomUUID } from 'crypto'
 import { Router } from 'express'
 import rateLimit from 'express-rate-limit'
-import { mkdirSync } from 'fs'
+import { mkdirSync, readdirSync } from 'fs'
 import mongoose from 'mongoose'
 import multer from 'multer'
 import fs from 'node:fs/promises'
@@ -19,6 +19,28 @@ import { validateFileType } from '../utils/validateFileType'
 
 const ALLOWED_EXTENSIONS = ['.svg', '.png', '.jpg', '.jpeg', '.webp']
 const MAX_FILE_SIZE = 5 * 1024 * 1024 // 5MB
+const STATIC_ASSET_TYPES = ['icon', 'screen', 'persona'] as const
+
+// Cache static (bundled) image paths per type at startup so we don't readdir on every request.
+// Exported for testing.
+export const staticAssetCache = new Map<string, string[]>()
+function loadStaticAssets() {
+  for (const type of STATIC_ASSET_TYPES) {
+    const dir = path.join(__dirname, '..', 'public', 'common', type)
+    try {
+      const entries = readdirSync(dir)
+      staticAssetCache.set(
+        type,
+        entries
+          .filter((e: string) => ALLOWED_EXTENSIONS.includes(path.extname(e).toLowerCase()))
+          .map((e: string) => `/public/common/${type}/${e}`),
+      )
+    } catch {
+      staticAssetCache.set(type, [])
+    }
+  }
+}
+loadStaticAssets()
 
 const EXT_TO_MIME: Record<string, string> = {
   '.svg': 'image/svg+xml',
@@ -181,8 +203,12 @@ router.get(
 
     try {
       const assets = await AssetModel.find(filter).lean()
-      const files = assets.map((a) => `/uploads/${a.filename}`)
-      res.json({ files })
+      const uploadedFiles = assets.map((a) => `/uploads/${a.filename}`)
+
+      // Merge in static (bundled) images cached at startup.
+      const staticFiles = type ? (staticAssetCache.get(type) ?? []) : []
+
+      res.json({ files: [...staticFiles, ...uploadedFiles] })
     } catch (err) {
       logger.error(err, 'Error listing assets')
       res.status(500).json({ error: 'Failed to list assets' })


### PR DESCRIPTION
Attempted hotfix for image assets upload. 

Original error logged
```
{
  "level": 50,
  "time": 1779981085838,
  "pid": 1,
  "hostname": "showcase-server-b78df6994-jhhtj",
  "err": {
    "type": "Error",
    "message": "EACCES: permission denied, open '/app/server/build/src/public/common/persona/aeeecc4e_doctor.png'",
    "stack": "Error: EACCES: permission denied, open '/app/server/build/src/public/common/persona/aeeecc4e_doctor.png'",
    "errno": -13,
    "code": "EACCES",
    "syscall": "open",
    "path": "/app/server/build/src/public/common/persona/aeeecc4e_doctor.png",
    "storageErrors": []
  },
  "msg": "Unhandled server error"
}
```
Likely an openshift permissions issue that this should resolve

also this should manually add static assets not yet included in the db