### PR TITLE
fix(chart): revert MongoDB PVC accessMode to ReadWriteOnce

### DIFF
--- a/charts/showcase/values.yaml
+++ b/charts/showcase/values.yaml
@@ -41,7 +41,7 @@ mongodb:
     enabled: true
     size: 2Gi
     storageClass: ''
-    accessMode: ReadWriteMany
+    accessMode: ReadWriteOnce
   ## WiredTiger defaults to a large fraction of visible RAM; with a low cgroup memory limit the
   ## process can be OOMKilled (mongod log ends with "Killed"). orgbook-publisher leaves resources
   ## unset; we cap cache explicitly and give the pod enough headroom for connections + mongosh probes.


### PR DESCRIPTION
## Summary
- Reverts `mongodb.persistence.accessMode` from `ReadWriteMany` to `ReadWriteOnce` in the showcase Helm chart.
- Fixes dev/prod `helm upgrade` failures: Kubernetes forbids changing StatefulSet `volumeClaimTemplates` on an existing `showcase-mongodb` release (introduced in #444).

## Test plan
- [ ] `helm upgrade` the `showcase` release on dev succeeds (no StatefulSet patch error)
- [ ] Mongo pod remains healthy after upgrade
- [ ] Server uploads PVC / asset API unchanged (`showcase.server.persistence` still `ReadWriteOnce`)


Made with [Cursor](https://cursor.com)