### PR TITLE
ci: update snok/container-retention-policy to v3.1.0

### DIFF
--- a/.github/workflows/undeploy-showcase-pr.yaml
+++ b/.github/workflows/undeploy-showcase-pr.yaml
@@ -107,7 +107,7 @@ jobs:
       - name: Delete GHCR images tagged pr-${{ github.event.pull_request.number }}
         if: always()
         continue-on-error: true
-        uses: snok/container-retention-policy@v3.0.1
+        uses: snok/container-retention-policy@v3.1.0
         with:
           account: ${{ github.repository_owner }}
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- The action would delete old container image layers, still used by current images. This would result in pull error.
- The PR updates the action to the latest release, `3.1.0` which may have a fix for this. (https://github.com/snok/container-retention-policy/issues/97#event-26102736808)