### PR TITLE
feat(showcases): add soft-delete with restore and permanent-delete

### DIFF
--- a/DEVELOPER/BC Wallet Showcase.md
+++ b/DEVELOPER/BC Wallet Showcase.md
@@ -485,6 +485,72 @@ All showcase mutations (create, update, delete) are logged asynchronously using 
 - Audit entries include: user ID from the Keycloak JWT (`req.auth?.sub`), action (`created`/`updated`/`deleted`), resource type (`showcase`), showcase ID, and details (name, etc.)
 - Failed audit logs are logged to the error stream but do not affect the API response
 
+### Showcases
+
+Showcase CRUD is handled under `/admin/showcases`. Deleting a showcase is a two-step process: soft-delete first, then permanently delete. This gives admins a chance to recover a showcase before it is gone for good.
+
+#### `GET /admin/showcases`
+
+Returns all active (non-deleted) showcases.
+
+Pass `?deleted=true` to list soft-deleted showcases instead. Supports `?limit=<n>` and `?skip=<n>` for pagination (default limit: 20).
+
+Available to `admin`, `creator`, and `viewer` roles.
+
+#### `GET /admin/showcases/:id`
+
+Returns a single active showcase by name. Returns 404 if the showcase does not exist or has been soft-deleted.
+
+Available to `admin`, `creator`, and `viewer` roles.
+
+#### `POST /admin/showcases`
+
+Creates a new showcase. The `name` field must be unique -- a duplicate name returns 409.
+
+Restricted to `admin` and `creator` roles.
+
+#### `PUT /admin/showcases/:id`
+
+Replaces an existing showcase by name. Returns 404 if the showcase does not exist or has been soft-deleted (soft-deleted showcases cannot be updated).
+
+Restricted to `admin` and `creator` roles.
+
+#### `DELETE /admin/showcases/:id`
+
+Soft-deletes a showcase by setting `deleted_at` to the current timestamp. The document and all embedded scenarios are kept in the database. The showcase immediately disappears from the public-facing and admin active lists.
+
+If the showcase is already soft-deleted, returns 404.
+
+Restricted to the `admin` role.
+
+#### `POST /admin/showcases/:id/restore`
+
+Restores a soft-deleted showcase. Sets `deleted_at` back to null and resets `status` to `pending` so the showcase does not go live automatically after restore.
+
+Returns 404 if the showcase does not exist at all. Returns 409 if the showcase exists but is not currently soft-deleted.
+
+Restricted to the `admin` role.
+
+#### `DELETE /admin/showcases/:id?permanent=true`
+
+Permanently deletes a showcase. The showcase must already be soft-deleted -- calling this on an active showcase returns 409.
+
+This operation:
+
+1. Hard-deletes the Showcase document (all embedded scenarios go with it).
+2. Removes asset files from disk for any images that are not referenced by other active showcases.
+3. Removes the corresponding Asset database records.
+
+Asset deletion is best-effort: missing files are ignored. Assets shared with other active showcases are left in place.
+
+**This cannot be undone.**
+
+Restricted to the `admin` role.
+
+#### Undo window
+
+The admin UI provides a 5-second undo toast after a soft-delete. Clicking Undo calls `POST /admin/showcases/:id/restore` before the timer expires. After the timer expires the showcase stays soft-deleted and can be recovered from the Trash tab.
+
 ## Deployment
 
 When pushing changes to github the dev showcase environment should automatically update. The openshift deployments for the showcase are located here: https://github.com/bcgov/BC-Wallet-Demo-Configurations

--- a/DEVELOPER/BC Wallet Showcase.md
+++ b/DEVELOPER/BC Wallet Showcase.md
@@ -493,9 +493,9 @@ Showcase CRUD is handled under `/admin/showcases`. Deleting a showcase is a two-
 
 Returns all active (non-deleted) showcases.
 
-Pass `?deleted=true` to list soft-deleted showcases instead. Supports `?limit=<n>` and `?skip=<n>` for pagination (default limit: 20).
+Pass `?deleted=true` to list soft-deleted showcases instead (admin-only). Supports `?limit=<n>` and `?skip=<n>` for pagination (default limit: 20).
 
-Available to `admin`, `creator`, and `viewer` roles.
+Available to `admin`, `creator`, and `viewer` roles for the active (non-deleted) list; when `?deleted=true`, restricted to the `admin` role.
 
 #### `GET /admin/showcases/:id`
 

--- a/frontend/src/admin/api/adminApi.tsx
+++ b/frontend/src/admin/api/adminApi.tsx
@@ -142,6 +142,44 @@ export const deleteScreenFromShowcase = async (
   })
 }
 
+export const deleteShowcase = async (auth: AuthContextProps, showcaseName: string): Promise<void> => {
+  const res = await fetch(`${adminBaseUrl}/showcases/${encodeURIComponent(showcaseName)}`, {
+    method: 'DELETE',
+    headers: { Authorization: `Bearer ${auth.user?.access_token ?? ''}` },
+  })
+  if (!res.ok) await handleErrorResponse(res)
+}
+
+export const getDeletedShowcases = async (
+  auth: AuthContextProps,
+  limit = 20,
+  skip = 0,
+): Promise<{ items: Showcase[]; total: number }> => {
+  const url = `${adminBaseUrl}/showcases?deleted=true&limit=${limit}&skip=${skip}`
+  const res = await fetch(url, {
+    method: 'GET',
+    headers: { Authorization: `Bearer ${auth.user?.access_token ?? ''}`, 'Content-Type': 'application/json' },
+  })
+  if (!res.ok) await handleErrorResponse(res)
+  return res.json() as Promise<{ items: Showcase[]; total: number }>
+}
+
+export const restoreShowcase = async (auth: AuthContextProps, showcaseName: string): Promise<void> => {
+  const res = await fetch(`${adminBaseUrl}/showcases/${encodeURIComponent(showcaseName)}/restore`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${auth.user?.access_token ?? ''}` },
+  })
+  if (!res.ok) await handleErrorResponse(res)
+}
+
+export const permanentDeleteShowcase = async (auth: AuthContextProps, showcaseName: string): Promise<void> => {
+  const res = await fetch(`${adminBaseUrl}/showcases/${encodeURIComponent(showcaseName)}?permanent=true`, {
+    method: 'DELETE',
+    headers: { Authorization: `Bearer ${auth.user?.access_token ?? ''}` },
+  })
+  if (!res.ok) await handleErrorResponse(res)
+}
+
 // ============================================================================
 // CREDENTIAL ENDPOINTS
 // ============================================================================

--- a/frontend/src/admin/components/UndoToast.tsx
+++ b/frontend/src/admin/components/UndoToast.tsx
@@ -1,0 +1,24 @@
+import { XMarkIcon } from '@heroicons/react/24/outline'
+
+interface UndoToastProps {
+  visible: boolean
+  message: string
+  onUndo: () => void
+  onDismiss: () => void
+}
+
+export function UndoToast({ visible, message, onUndo, onDismiss }: UndoToastProps) {
+  if (!visible) return null
+
+  return (
+    <div className="fixed bottom-6 left-1/2 -translate-x-1/2 z-50 flex items-center gap-4 bg-bcgov-black text-white px-5 py-3 rounded-lg shadow-lg">
+      <span className="text-sm">{message}</span>
+      <button onClick={onUndo} className="text-sm font-semibold text-yellow-300 hover:underline">
+        Undo
+      </button>
+      <button onClick={onDismiss} aria-label="Dismiss" className="ml-1 text-gray-400 hover:text-white">
+        <XMarkIcon className="w-4 h-4" />
+      </button>
+    </div>
+  )
+}

--- a/frontend/src/admin/components/showcase/ShowcaseCard.tsx
+++ b/frontend/src/admin/components/showcase/ShowcaseCard.tsx
@@ -1,6 +1,6 @@
 import type { Showcase } from '../../types'
 
-import { Cog6ToothIcon } from '@heroicons/react/24/outline'
+import { Cog6ToothIcon, TrashIcon } from '@heroicons/react/24/outline'
 import { useState } from 'react'
 
 import { useHasRole } from '../../hooks/useUserRole'
@@ -12,15 +12,30 @@ interface ShowcaseCardProps {
   showcase: Showcase
   onClick: () => void
   onRefresh?: () => void | Promise<void>
+  onDelete?: () => void
 }
 
-export function ShowcaseCard({ showcase, onClick, onRefresh }: ShowcaseCardProps) {
+export function ShowcaseCard({ showcase, onClick, onRefresh, onDelete }: ShowcaseCardProps) {
   const [isEditModalOpen, setIsEditModalOpen] = useState(false)
   const canEdit = useHasRole('creator')
+  const canDelete = useHasRole('admin')
 
   return (
     <>
       <div className="relative">
+        {canDelete && onDelete && (
+          <button
+            onClick={(e) => {
+              e.stopPropagation()
+              onDelete()
+            }}
+            className="absolute top-3 right-12 z-10 p-2 text-gray-500 hover:text-red-600 transition-colors cursor-pointer rounded hover:bg-gray-200"
+            title="Delete showcase"
+            aria-label="Delete showcase"
+          >
+            <TrashIcon className="w-5 h-5" />
+          </button>
+        )}
         {canEdit && (
           <button
             onClick={() => setIsEditModalOpen(true)}

--- a/frontend/src/admin/components/showcase/ShowcasesPanel.tsx
+++ b/frontend/src/admin/components/showcase/ShowcasesPanel.tsx
@@ -247,6 +247,7 @@ export function ShowcasesPanel() {
                   showcase={showcase}
                   onRestore={() => void handleRestore(showcase.name)}
                   onPermanentDelete={() => setConfirmPermanentDelete(showcase.name)}
+                  canManage={canManageTrash}
                 />
               ))}
             </div>

--- a/frontend/src/admin/components/showcase/ShowcasesPanel.tsx
+++ b/frontend/src/admin/components/showcase/ShowcasesPanel.tsx
@@ -25,7 +25,7 @@ export function ShowcasesPanel() {
   const auth = useAuth()
   const navigate = useNavigate()
   const canEdit = useHasRole('creator')
-
+  const canManageTrash = useHasRole('admin')
   // Active showcases
   const [showcases, setShowcases] = useState<Showcase[]>([])
   const [loading, setLoading] = useState(true)

--- a/frontend/src/admin/components/showcase/ShowcasesPanel.tsx
+++ b/frontend/src/admin/components/showcase/ShowcasesPanel.tsx
@@ -56,8 +56,8 @@ export function ShowcasesPanel() {
   const fetchShowcases = async () => {
     try {
       setLoading(true)
-      const data = await getAllShowcases(auth)
-      setShowcases(data)
+      const showcases = await getAllShowcases(auth)
+      setShowcases(showcases)
       setError(null)
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to fetch showcases')

--- a/frontend/src/admin/components/showcase/ShowcasesPanel.tsx
+++ b/frontend/src/admin/components/showcase/ShowcasesPanel.tsx
@@ -1,30 +1,63 @@
 import type { Showcase } from '../../types'
 
 import { PlusIcon } from '@heroicons/react/24/outline'
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useAuth } from 'react-oidc-context'
 import { useNavigate } from 'react-router-dom'
 
-import { adminBaseRoute, getAllShowcases } from '../../api/adminApi'
+import {
+  adminBaseRoute,
+  deleteShowcase,
+  getAllShowcases,
+  getDeletedShowcases,
+  permanentDeleteShowcase,
+  restoreShowcase,
+} from '../../api/adminApi'
 import { useHasRole } from '../../hooks/useUserRole'
+import { UndoToast } from '../UndoToast'
 
 import { ShowcaseCard } from './ShowcaseCard'
+import { TrashShowcaseCard } from './TrashShowcaseCard'
 import { CreateOrEditShowcaseModal } from './modals/CreateOrEditShowcaseModal'
+import { DeleteConfirmationModal } from './modals/DeleteConfirmationModal'
 
 export function ShowcasesPanel() {
   const auth = useAuth()
   const navigate = useNavigate()
   const canEdit = useHasRole('creator')
+
+  // Active showcases
   const [showcases, setShowcases] = useState<Showcase[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [isCreateModalOpen, setIsCreateModalOpen] = useState(false)
 
+  // Trash tab
+  const [activeTab, setActiveTab] = useState<'active' | 'trash'>('active')
+  const [trashedShowcases, setTrashedShowcases] = useState<Showcase[]>([])
+  const [trashTotal, setTrashTotal] = useState(0)
+  const [trashLoading, setTrashLoading] = useState(false)
+  const [trashError, setTrashError] = useState<string | null>(null)
+  const [confirmPermanentDelete, setConfirmPermanentDelete] = useState<string | null>(null)
+  const [permanentDeleteLoading, setPermanentDeleteLoading] = useState(false)
+
+  // Undo toast
+  const [undoVisible, setUndoVisible] = useState(false)
+  const [undoTarget, setUndoTarget] = useState<string | null>(null)
+  const undoTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  // Cleanup undo timer on unmount
+  useEffect(() => {
+    return () => {
+      if (undoTimerRef.current) clearTimeout(undoTimerRef.current)
+    }
+  }, [])
+
   const fetchShowcases = async () => {
     try {
       setLoading(true)
-      const showcases = await getAllShowcases(auth)
-      setShowcases(showcases)
+      const data = await getAllShowcases(auth)
+      setShowcases(data)
       setError(null)
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to fetch showcases')
@@ -33,15 +66,101 @@ export function ShowcasesPanel() {
     }
   }
 
+  const fetchTrashedShowcases = async () => {
+    try {
+      setTrashLoading(true)
+      const result = await getDeletedShowcases(auth)
+      setTrashedShowcases(result.items)
+      setTrashTotal(result.total)
+      setTrashError(null)
+    } catch (err) {
+      setTrashError(err instanceof Error ? err.message : 'Failed to fetch deleted showcases')
+    } finally {
+      setTrashLoading(false)
+    }
+  }
+
   useEffect(() => {
     void fetchShowcases()
+    // Fetch trash count for badge on mount
+    void getDeletedShowcases(auth)
+      .then((r) => setTrashTotal(r.total))
+      .catch(() => undefined)
   }, [auth.user?.access_token])
+
+  const handleDelete = async (showcaseName: string) => {
+    try {
+      await deleteShowcase(auth, showcaseName)
+      void fetchShowcases()
+      void getDeletedShowcases(auth)
+        .then((r) => setTrashTotal(r.total))
+        .catch(() => undefined)
+
+      // Start 5s undo window
+      if (undoTimerRef.current) clearTimeout(undoTimerRef.current)
+      setUndoTarget(showcaseName)
+      setUndoVisible(true)
+      undoTimerRef.current = setTimeout(() => {
+        setUndoVisible(false)
+        setUndoTarget(null)
+      }, 5000)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to delete showcase')
+    }
+  }
+
+  const handleUndo = async () => {
+    if (!undoTarget) return
+    if (undoTimerRef.current) clearTimeout(undoTimerRef.current)
+    setUndoVisible(false)
+    const target = undoTarget
+    setUndoTarget(null)
+    try {
+      await restoreShowcase(auth, target)
+      void fetchShowcases()
+      void getDeletedShowcases(auth)
+        .then((r) => setTrashTotal(r.total))
+        .catch(() => undefined)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to undo deletion')
+    }
+  }
+
+  const handleDismissUndo = () => {
+    if (undoTimerRef.current) clearTimeout(undoTimerRef.current)
+    setUndoVisible(false)
+    setUndoTarget(null)
+  }
+
+  const handleRestore = async (showcaseName: string) => {
+    try {
+      await restoreShowcase(auth, showcaseName)
+      void fetchShowcases()
+      void fetchTrashedShowcases()
+    } catch (err) {
+      setTrashError(err instanceof Error ? err.message : 'Failed to restore showcase')
+    }
+  }
+
+  const handlePermanentDelete = async (showcaseName: string) => {
+    if (permanentDeleteLoading) return
+    try {
+      setPermanentDeleteLoading(true)
+      await permanentDeleteShowcase(auth, showcaseName)
+      setConfirmPermanentDelete(null)
+      void fetchTrashedShowcases()
+    } catch (err) {
+      setTrashError(err instanceof Error ? err.message : 'Failed to permanently delete showcase')
+    } finally {
+      setPermanentDeleteLoading(false)
+    }
+  }
 
   return (
     <div>
       <div className="flex items-center justify-between mb-6">
         <h2 className="text-bcgov-black font-semibold text-2xl">Showcases</h2>
-        {canEdit && (
+        {canEdit && activeTab === 'active' && (
           <button
             onClick={() => setIsCreateModalOpen(true)}
             className="flex items-center gap-2 bg-bcgov-blue hover:bg-bcgov-blue-dark text-white font-semibold py-2 px-4 rounded-lg transition-colors"
@@ -51,23 +170,88 @@ export function ShowcasesPanel() {
           </button>
         )}
       </div>
-      <p className="text-bcgov-darkgrey mb-6">Manage your digital credential showcases.</p>
 
-      {loading && <p className="text-bcgov-darkgrey">Loading showcases…</p>}
-      {error && <p className="text-red-600">Error: {error}</p>}
-      {!loading && !error && showcases.length === 0 && <p className="text-bcgov-darkgrey">No showcases found.</p>}
+      {/* Active / Trash tabs */}
+      <div className="flex gap-1 mb-6 border-b border-gray-200">
+        <button
+          onClick={() => setActiveTab('active')}
+          className={`pb-2 px-4 font-medium text-sm transition-colors border-b-2 ${
+            activeTab === 'active'
+              ? 'border-bcgov-blue text-bcgov-blue'
+              : 'border-transparent text-bcgov-darkgrey hover:text-bcgov-black'
+          }`}
+        >
+          Active
+        </button>
+        <button
+          onClick={() => {
+            setActiveTab('trash')
+            void fetchTrashedShowcases()
+          }}
+          className={`pb-2 px-4 font-medium text-sm transition-colors border-b-2 flex items-center gap-2 ${
+            activeTab === 'trash'
+              ? 'border-bcgov-blue text-bcgov-blue'
+              : 'border-transparent text-bcgov-darkgrey hover:text-bcgov-black'
+          }`}
+        >
+          Trash
+          {trashTotal > 0 && (
+            <span className="bg-red-500 text-white text-xs font-bold px-1.5 py-0.5 rounded-full">{trashTotal}</span>
+          )}
+        </button>
+      </div>
 
-      {!loading && !error && showcases.length > 0 && (
-        <div className="space-y-4">
-          {showcases.map((showcase) => (
-            <ShowcaseCard
-              key={showcase.name}
-              showcase={showcase}
-              onClick={() => navigate(`${adminBaseRoute}/creator/showcase/${showcase.name}`, { state: { showcase } })}
-              onRefresh={fetchShowcases}
-            />
-          ))}
-        </div>
+      {/* Active tab content */}
+      {activeTab === 'active' && (
+        <>
+          <p className="text-bcgov-darkgrey mb-6">Manage your digital credential showcases.</p>
+
+          {loading && <p className="text-bcgov-darkgrey">Loading showcases...</p>}
+          {error && <p className="text-red-600">Error: {error}</p>}
+          {!loading && !error && showcases.length === 0 && <p className="text-bcgov-darkgrey">No showcases found.</p>}
+
+          {!loading && !error && showcases.length > 0 && (
+            <div className="space-y-4">
+              {showcases.map((showcase) => (
+                <ShowcaseCard
+                  key={showcase.name}
+                  showcase={showcase}
+                  onClick={() =>
+                    navigate(`${adminBaseRoute}/creator/showcase/${showcase.name}`, { state: { showcase } })
+                  }
+                  onRefresh={fetchShowcases}
+                  onDelete={() => void handleDelete(showcase.name)}
+                />
+              ))}
+            </div>
+          )}
+        </>
+      )}
+
+      {/* Trash tab content */}
+      {activeTab === 'trash' && (
+        <>
+          <p className="text-bcgov-darkgrey mb-6">Deleted showcases. Restore or permanently remove them.</p>
+
+          {trashLoading && <p className="text-bcgov-darkgrey">Loading deleted showcases...</p>}
+          {trashError && <p className="text-red-600">Error: {trashError}</p>}
+          {!trashLoading && !trashError && trashedShowcases.length === 0 && (
+            <p className="text-bcgov-darkgrey">Trash is empty.</p>
+          )}
+
+          {!trashLoading && !trashError && trashedShowcases.length > 0 && (
+            <div className="space-y-4">
+              {trashedShowcases.map((showcase) => (
+                <TrashShowcaseCard
+                  key={showcase.name}
+                  showcase={showcase}
+                  onRestore={() => void handleRestore(showcase.name)}
+                  onPermanentDelete={() => setConfirmPermanentDelete(showcase.name)}
+                />
+              ))}
+            </div>
+          )}
+        </>
       )}
 
       <CreateOrEditShowcaseModal
@@ -78,6 +262,23 @@ export function ShowcasesPanel() {
           void fetchShowcases()
           navigate(`${adminBaseRoute}/creator/showcase/${showcaseName}`, { state: { isNewShowcase: true } })
         }}
+      />
+
+      <DeleteConfirmationModal
+        isOpen={!!confirmPermanentDelete}
+        title="Delete Forever"
+        description="This cannot be undone. The showcase and all its assets will be permanently removed."
+        onCancel={() => setConfirmPermanentDelete(null)}
+        onConfirm={() => {
+          if (confirmPermanentDelete) void handlePermanentDelete(confirmPermanentDelete)
+        }}
+      />
+
+      <UndoToast
+        visible={undoVisible}
+        message="Showcase deleted"
+        onUndo={() => void handleUndo()}
+        onDismiss={handleDismissUndo}
       />
     </div>
   )

--- a/frontend/src/admin/components/showcase/TrashShowcaseCard.tsx
+++ b/frontend/src/admin/components/showcase/TrashShowcaseCard.tsx
@@ -1,0 +1,37 @@
+import type { Showcase } from '../../types'
+
+import { TrashIcon } from '@heroicons/react/24/outline'
+
+interface TrashShowcaseCardProps {
+  showcase: Showcase
+  onRestore: () => void
+  onPermanentDelete: () => void
+}
+
+export function TrashShowcaseCard({ showcase, onRestore, onPermanentDelete }: TrashShowcaseCardProps) {
+  const deletedDate = showcase.deleted_at ? new Date(showcase.deleted_at).toLocaleDateString() : 'Unknown date'
+
+  return (
+    <div className="border border-gray-200 rounded-lg p-5 bg-white flex items-center justify-between">
+      <div>
+        <h3 className="text-bcgov-black font-semibold text-lg">{showcase.name}</h3>
+        <p className="text-sm text-bcgov-darkgrey">Deleted {deletedDate}</p>
+      </div>
+      <div className="flex gap-3">
+        <button
+          onClick={onRestore}
+          className="px-3 py-1.5 text-sm border border-bcgov-blue text-bcgov-blue rounded-lg hover:bg-blue-50 transition-colors font-medium"
+        >
+          Restore
+        </button>
+        <button
+          onClick={onPermanentDelete}
+          className="px-3 py-1.5 text-sm bg-red-600 text-white rounded-lg hover:bg-red-700 transition-colors font-medium flex items-center gap-1"
+        >
+          <TrashIcon className="w-4 h-4" />
+          Delete Forever
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/admin/components/showcase/TrashShowcaseCard.tsx
+++ b/frontend/src/admin/components/showcase/TrashShowcaseCard.tsx
@@ -23,21 +23,23 @@ export function TrashShowcaseCard({
         <h3 className="text-bcgov-black font-semibold text-lg">{showcase.name}</h3>
         <p className="text-sm text-bcgov-darkgrey">Deleted {deletedDate}</p>
       </div>
-      <div className="flex gap-3">
-        <button
-          onClick={onRestore}
-          className="px-3 py-1.5 text-sm border border-bcgov-blue text-bcgov-blue rounded-lg hover:bg-blue-50 transition-colors font-medium"
-        >
-          Restore
-        </button>
-        <button
-          onClick={onPermanentDelete}
-          className="px-3 py-1.5 text-sm bg-red-600 text-white rounded-lg hover:bg-red-700 transition-colors font-medium flex items-center gap-1"
-        >
-          <TrashIcon className="w-4 h-4" />
-          Delete Forever
-        </button>
-      </div>
+      {canManage && (
+        <div className="flex gap-3">
+          <button
+            onClick={onRestore}
+            className="px-3 py-1.5 text-sm border border-bcgov-blue text-bcgov-blue rounded-lg hover:bg-blue-50 transition-colors font-medium"
+          >
+            Restore
+          </button>
+          <button
+            onClick={onPermanentDelete}
+            className="px-3 py-1.5 text-sm bg-red-600 text-white rounded-lg hover:bg-red-700 transition-colors font-medium flex items-center gap-1"
+          >
+            <TrashIcon className="w-4 h-4" />
+            Delete Forever
+          </button>
+        </div>
+      )}
     </div>
   )
 }

--- a/frontend/src/admin/components/showcase/TrashShowcaseCard.tsx
+++ b/frontend/src/admin/components/showcase/TrashShowcaseCard.tsx
@@ -6,9 +6,15 @@ interface TrashShowcaseCardProps {
   showcase: Showcase
   onRestore: () => void
   onPermanentDelete: () => void
+  canManage?: boolean
 }
 
-export function TrashShowcaseCard({ showcase, onRestore, onPermanentDelete }: TrashShowcaseCardProps) {
+export function TrashShowcaseCard({
+  showcase,
+  onRestore,
+  onPermanentDelete,
+  canManage = false,
+}: TrashShowcaseCardProps) {
   const deletedDate = showcase.deleted_at ? new Date(showcase.deleted_at).toLocaleDateString() : 'Unknown date'
 
   return (

--- a/frontend/src/admin/pages/__tests__/CreatorPage.test.tsx
+++ b/frontend/src/admin/pages/__tests__/CreatorPage.test.tsx
@@ -32,6 +32,8 @@ vi.mock('../../api/adminApi', () => ({
   adminBaseRoute: '/digital-trust/showcase/admin',
   adminBaseUrl: 'http://localhost:5000/digital-trust/showcase/admin',
   publicBaseUrl: 'http://localhost:5000/digital-trust/showcase/public',
+  getAllShowcases: vi.fn().mockResolvedValue([]),
+  getDeletedShowcases: vi.fn().mockResolvedValue({ items: [], total: 0 }),
 }))
 
 const renderCreatorPage = () =>

--- a/frontend/src/admin/types/index.ts
+++ b/frontend/src/admin/types/index.ts
@@ -93,6 +93,7 @@ export type ShowcaseStatus = 'active' | 'hidden' | 'pending'
 export interface Showcase {
   name: string
   status?: ShowcaseStatus
+  deleted_at?: string | null
   description?: string
   persona?: Persona
   progressBar: ProgressBarStep[]

--- a/frontend/src/client/api/BaseUrl.ts
+++ b/frontend/src/client/api/BaseUrl.ts
@@ -9,7 +9,6 @@ export const baseUrl = (import.meta.env.VITE_HOST_BACKEND || '') + baseRoute
 export const baseWsUrl = import.meta.env.VITE_HOST_BACKEND || ''
 export const socketPath = `${baseRoute}/demo/socket/`
 
-// eslint-disable-next-line import/no-named-as-default-member
 export const apiCall = axios.create({ baseURL: baseUrl })
 
 apiCall.interceptors.request.use((config: InternalAxiosRequestConfig) => {

--- a/server/src/content/types.ts
+++ b/server/src/content/types.ts
@@ -107,6 +107,7 @@ export type ShowcaseStatus = 'active' | 'hidden' | 'pending'
 export interface Showcase {
   name: string
   status: ShowcaseStatus
+  deleted_at?: Date | null
   description?: string
   persona?: Persona
   progressBar: ProgressBarStep[]

--- a/server/src/controllers/ScenarioController.ts
+++ b/server/src/controllers/ScenarioController.ts
@@ -13,7 +13,7 @@ export class ScenarioController {
   @Get('/:useCaseSlug')
   public async getScenarioBySlug(@Param('useCaseSlug') scenarioSlug: string) {
     logger.debug({ scenarioSlug }, 'Fetching scenario by slug')
-    const showcases = await ShowcaseModel.find().lean()
+    const showcases = await ShowcaseModel.find({ deleted_at: null }).lean()
     const scenario = showcases.flatMap((s) => s.scenarios).find((x) => x.id === scenarioSlug)
 
     if (!scenario) {
@@ -29,7 +29,7 @@ export class ScenarioController {
   @Get('/character/:type')
   public async getScenariosByCharType(@Param('type') type: string, @QueryParam('showHidden') showHidden?: boolean) {
     logger.debug({ type, showHidden }, 'Fetching scenarios by character type')
-    const character = await ShowcaseModel.findOne({ 'persona.type': type }).lean()
+    const character = await ShowcaseModel.findOne({ 'persona.type': type, deleted_at: null }).lean()
 
     if (!character) {
       logger.warn({ type }, 'Character type not found for scenario lookup')

--- a/server/src/controllers/ShowcaseController.ts
+++ b/server/src/controllers/ShowcaseController.ts
@@ -52,7 +52,7 @@ export class ShowcaseController {
   @Get('/:showcaseId')
   public async getShowcaseById(@Param('showcaseId') showcaseId: string) {
     logger.debug({ showcaseId }, 'Fetching showcase by id')
-    const showcase = await ShowcaseModel.findOne({ name: showcaseId }).lean()
+    const showcase = await ShowcaseModel.findOne({ name: showcaseId, deleted_at: null }).lean()
 
     if (!showcase) {
       logger.warn({ showcaseId }, 'Showcase not found')
@@ -68,7 +68,7 @@ export class ShowcaseController {
    */
   @Get('/')
   public async getShowcases() {
-    const showcases = await ShowcaseModel.find().lean()
+    const showcases = await ShowcaseModel.find({ deleted_at: null }).lean()
     logger.debug({ count: showcases.length }, 'Fetching all showcases')
     return Promise.all(showcases.map(hydrateCredentials))
   }

--- a/server/src/controllers/__tests__/AdminShowcaseController.test.ts
+++ b/server/src/controllers/__tests__/AdminShowcaseController.test.ts
@@ -163,8 +163,10 @@ describe('AdminShowcaseController', () => {
     it('returns items and total for soft-deleted showcases', async () => {
       const deleted = [{ ...mockShowcase, deleted_at: new Date() }]
       mockFns.find.mockReturnValue({
-        skip: vi.fn().mockReturnValue({
-          limit: vi.fn().mockReturnValue({ lean: vi.fn().mockResolvedValue(deleted) }),
+        sort: vi.fn().mockReturnValue({
+          skip: vi.fn().mockReturnValue({
+            limit: vi.fn().mockReturnValue({ lean: vi.fn().mockResolvedValue(deleted) }),
+          }),
         }),
       })
       mockFns.countDocuments.mockResolvedValue(1)
@@ -176,8 +178,10 @@ describe('AdminShowcaseController', () => {
 
     it('uses default limit and skip', async () => {
       mockFns.find.mockReturnValue({
-        skip: vi.fn().mockReturnValue({
-          limit: vi.fn().mockReturnValue({ lean: vi.fn().mockResolvedValue([]) }),
+        sort: vi.fn().mockReturnValue({
+          skip: vi.fn().mockReturnValue({
+            limit: vi.fn().mockReturnValue({ lean: vi.fn().mockResolvedValue([]) }),
+          }),
         }),
       })
       mockFns.countDocuments.mockResolvedValue(0)

--- a/server/src/controllers/__tests__/AdminShowcaseController.test.ts
+++ b/server/src/controllers/__tests__/AdminShowcaseController.test.ts
@@ -1,0 +1,189 @@
+import { NotFoundError } from 'routing-controllers'
+import { vi, describe, it, expect, beforeEach } from 'vitest'
+
+vi.mock('../../utils/logger', () => ({
+  default: { info: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}))
+
+vi.mock('fs/promises', () => ({
+  default: { unlink: vi.fn().mockResolvedValue(undefined) },
+}))
+
+vi.mock('../../utils/uploadsDir', () => ({
+  UPLOADS_DIR: '/tmp/uploads',
+}))
+
+const { mockFns } = vi.hoisted(() => ({
+  mockFns: {
+    findOneAndUpdate: vi.fn(),
+    findOneAndDelete: vi.fn(),
+    findOne: vi.fn(),
+    find: vi.fn(),
+    countDocuments: vi.fn(),
+    deleteMany: vi.fn(),
+  },
+}))
+
+vi.mock('../../db/models/Showcase', () => ({
+  ShowcaseModel: {
+    findOneAndUpdate: mockFns.findOneAndUpdate,
+    findOneAndDelete: mockFns.findOneAndDelete,
+    findOne: mockFns.findOne,
+    find: mockFns.find,
+    countDocuments: mockFns.countDocuments,
+  },
+}))
+
+vi.mock('../../db/models/Asset', () => ({
+  AssetModel: {
+    deleteMany: mockFns.deleteMany,
+  },
+}))
+
+import { AdminShowcaseController } from '../admin/AdminShowcaseController'
+
+const mockShowcase = {
+  _id: 'abc123',
+  name: 'student',
+  status: 'active',
+  deleted_at: null,
+  credentials: [],
+  introduction: [],
+  progressBar: [],
+  scenarios: [],
+}
+
+describe('AdminShowcaseController', () => {
+  let controller: AdminShowcaseController
+
+  beforeEach(() => {
+    controller = new AdminShowcaseController()
+    vi.clearAllMocks()
+  })
+
+  describe('deleteShowcase', () => {
+    it('soft-deletes by setting deleted_at', async () => {
+      mockFns.findOneAndUpdate.mockReturnValue({
+        lean: vi.fn().mockResolvedValue({ ...mockShowcase, deleted_at: new Date() }),
+      })
+      const result = await controller.deleteShowcase('student')
+      expect(mockFns.findOneAndUpdate).toHaveBeenCalledWith(
+        { name: 'student', deleted_at: null },
+        { deleted_at: expect.any(Date) },
+        { new: true },
+      )
+      expect(result).toEqual({ message: 'Showcase deleted successfully' })
+    })
+
+    it('throws NotFoundError when showcase not found or already deleted', async () => {
+      mockFns.findOneAndUpdate.mockReturnValue({ lean: vi.fn().mockResolvedValue(null) })
+      await expect(controller.deleteShowcase('ghost')).rejects.toThrow(NotFoundError)
+    })
+  })
+
+  describe('restoreShowcase', () => {
+    it('restores by clearing deleted_at and setting status to pending', async () => {
+      const restored = { ...mockShowcase, deleted_at: null, status: 'pending' }
+      mockFns.findOneAndUpdate.mockReturnValue({ lean: vi.fn().mockResolvedValue(restored) })
+      const result = await controller.restoreShowcase('student')
+      expect(mockFns.findOneAndUpdate).toHaveBeenCalledWith(
+        { name: 'student', deleted_at: { $ne: null } },
+        { deleted_at: null, status: 'pending' },
+        { new: true },
+      )
+      expect(result).toEqual(restored)
+    })
+
+    it('throws NotFoundError when showcase does not exist', async () => {
+      mockFns.findOneAndUpdate.mockReturnValue({ lean: vi.fn().mockResolvedValue(null) })
+      mockFns.findOne.mockReturnValue({ lean: vi.fn().mockResolvedValue(null) })
+      await expect(controller.restoreShowcase('ghost')).rejects.toThrow(NotFoundError)
+    })
+
+    it('throws 409 error when showcase exists but is not deleted', async () => {
+      mockFns.findOneAndUpdate.mockReturnValue({ lean: vi.fn().mockResolvedValue(null) })
+      mockFns.findOne.mockReturnValue({ lean: vi.fn().mockResolvedValue(mockShowcase) })
+      const err = await controller.restoreShowcase('student').catch((e) => e)
+      expect(err).toBeInstanceOf(Error)
+      expect((err as NodeJS.ErrnoException).code).toBe('SHOWCASE_NOT_DELETED')
+    })
+  })
+
+  describe('permanentDeleteShowcase', () => {
+    it('hard-deletes showcase when soft-deleted', async () => {
+      const deletedShowcase = {
+        _id: 'abc123',
+        name: 'student',
+        status: 'active',
+        deleted_at: new Date(),
+        credentials: [],
+        introduction: [{ screenId: 'TEST', name: 'Test', text: 'test', image: '/uploads/intro.svg', credentials: [] }],
+        progressBar: [],
+        scenarios: [],
+        persona: { name: 'Student', type: 'student', image: '/uploads/test.svg' },
+      } as any
+      mockFns.findOneAndDelete.mockReturnValue({ lean: vi.fn().mockResolvedValue(deletedShowcase) })
+      mockFns.countDocuments.mockResolvedValue(0) // no other showcases reference these files
+      mockFns.deleteMany.mockResolvedValue({ deletedCount: 2 })
+
+      await controller.permanentDeleteShowcase('student')
+
+      expect(mockFns.findOneAndDelete).toHaveBeenCalledWith({
+        name: 'student',
+        deleted_at: { $ne: null },
+      })
+      expect(mockFns.deleteMany).toHaveBeenCalledWith({ filename: { $in: ['test.svg', 'intro.svg'] } })
+    })
+
+    it('throws NotFoundError when showcase not found', async () => {
+      mockFns.findOneAndDelete.mockReturnValue({ lean: vi.fn().mockResolvedValue(null) })
+      mockFns.findOne.mockReturnValue({ lean: vi.fn().mockResolvedValue(null) })
+      await expect(controller.permanentDeleteShowcase('ghost')).rejects.toThrow(NotFoundError)
+    })
+
+    it('throws 409 error when showcase is not soft-deleted', async () => {
+      mockFns.findOneAndDelete.mockReturnValue({ lean: vi.fn().mockResolvedValue(null) })
+      mockFns.findOne.mockReturnValue({ lean: vi.fn().mockResolvedValue(mockShowcase) })
+      const err = await controller.permanentDeleteShowcase('student').catch((e) => e)
+      expect(err).toBeInstanceOf(Error)
+      expect((err as NodeJS.ErrnoException).code).toBe('SHOWCASE_NOT_DELETED')
+    })
+
+    it('skips AssetModel.deleteMany when no images found', async () => {
+      const noImagesShowcase = { ...mockShowcase, deleted_at: new Date() } as any
+      mockFns.findOneAndDelete.mockReturnValue({ lean: vi.fn().mockResolvedValue(noImagesShowcase) })
+
+      await controller.permanentDeleteShowcase('student')
+
+      expect(mockFns.deleteMany).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('getDeletedShowcases', () => {
+    it('returns items and total for soft-deleted showcases', async () => {
+      const deleted = [{ ...mockShowcase, deleted_at: new Date() }]
+      mockFns.find.mockReturnValue({
+        skip: vi.fn().mockReturnValue({
+          limit: vi.fn().mockReturnValue({ lean: vi.fn().mockResolvedValue(deleted) }),
+        }),
+      })
+      mockFns.countDocuments.mockResolvedValue(1)
+
+      const result = await controller.getDeletedShowcases(20, 0)
+      expect(result.items).toEqual(deleted)
+      expect(result.total).toBe(1)
+    })
+
+    it('uses default limit and skip', async () => {
+      mockFns.find.mockReturnValue({
+        skip: vi.fn().mockReturnValue({
+          limit: vi.fn().mockReturnValue({ lean: vi.fn().mockResolvedValue([]) }),
+        }),
+      })
+      mockFns.countDocuments.mockResolvedValue(0)
+
+      await controller.getDeletedShowcases()
+      expect(mockFns.find).toHaveBeenCalledWith({ deleted_at: { $ne: null } })
+    })
+  })
+})

--- a/server/src/controllers/__tests__/AdminShowcaseController.test.ts
+++ b/server/src/controllers/__tests__/AdminShowcaseController.test.ts
@@ -103,9 +103,9 @@ describe('AdminShowcaseController', () => {
     it('throws 409 error when showcase exists but is not deleted', async () => {
       mockFns.findOneAndUpdate.mockReturnValue({ lean: vi.fn().mockResolvedValue(null) })
       mockFns.findOne.mockReturnValue({ lean: vi.fn().mockResolvedValue(mockShowcase) })
+      const { ShowcaseNotDeletedError } = await import('../../errors')
       const err = await controller.restoreShowcase('student').catch((e) => e)
-      expect(err).toBeInstanceOf(Error)
-      expect((err as NodeJS.ErrnoException).code).toBe('SHOWCASE_NOT_DELETED')
+      expect(err).toBeInstanceOf(ShowcaseNotDeletedError)
     })
   })
 
@@ -142,11 +142,11 @@ describe('AdminShowcaseController', () => {
     })
 
     it('throws 409 error when showcase is not soft-deleted', async () => {
+      const { ShowcaseNotDeletedError } = await import('../../errors')
       mockFns.findOneAndDelete.mockReturnValue({ lean: vi.fn().mockResolvedValue(null) })
       mockFns.findOne.mockReturnValue({ lean: vi.fn().mockResolvedValue(mockShowcase) })
       const err = await controller.permanentDeleteShowcase('student').catch((e) => e)
-      expect(err).toBeInstanceOf(Error)
-      expect((err as NodeJS.ErrnoException).code).toBe('SHOWCASE_NOT_DELETED')
+      expect(err).toBeInstanceOf(ShowcaseNotDeletedError)
     })
 
     it('skips AssetModel.deleteMany when no images found', async () => {

--- a/server/src/controllers/admin/AdminShowcaseController.ts
+++ b/server/src/controllers/admin/AdminShowcaseController.ts
@@ -6,6 +6,7 @@ import { Service } from 'typedi'
 import { Showcase } from '../../content/types'
 import { AssetModel } from '../../db/models/Asset'
 import { ShowcaseModel } from '../../db/models/Showcase'
+import { ShowcaseNotDeletedError } from '../../errors'
 import logger from '../../utils/logger'
 import { UPLOADS_DIR } from '../../utils/uploadsDir'
 
@@ -102,9 +103,7 @@ export class AdminShowcaseController {
         const existing = await ShowcaseModel.findOne({ name: showcaseName }).lean()
         if (existing) {
           logger.warn({ showcaseName }, 'Showcase not deleted, cannot restore')
-          const err = new Error(`Showcase with name "${showcaseName}" is not deleted.`)
-          ;(err as NodeJS.ErrnoException).code = 'SHOWCASE_NOT_DELETED'
-          throw err
+          throw new ShowcaseNotDeletedError(showcaseName)
         }
         // Showcase doesn't exist at all
         logger.warn({ showcaseName }, 'Showcase not found for restore')
@@ -169,9 +168,7 @@ export class AdminShowcaseController {
         const exists = await ShowcaseModel.findOne({ name: showcaseName }).lean()
         if (exists) {
           logger.warn({ showcaseName }, 'Showcase not soft-deleted, cannot permanently delete')
-          const err = new Error(`Showcase "${showcaseName}" must be soft-deleted before permanent deletion.`)
-          ;(err as NodeJS.ErrnoException).code = 'SHOWCASE_NOT_DELETED'
-          throw err
+          throw new ShowcaseNotDeletedError(showcaseName)
         }
         logger.warn({ showcaseName }, 'Showcase not found for permanent deletion')
         throw new NotFoundError(`Showcase with name "${showcaseName}" not found.`)

--- a/server/src/controllers/admin/AdminShowcaseController.ts
+++ b/server/src/controllers/admin/AdminShowcaseController.ts
@@ -176,22 +176,24 @@ export class AdminShowcaseController {
         throw new NotFoundError(`Showcase with name "${showcaseName}" not found.`)
       }
 
-      // 2. Extract filenames from deleted showcase
-      const filenames = this.extractAssetFilenames(showcase)
+      // 2. Extract filenames from deleted showcase (dedupe to avoid repeated checks/unlinks)
+      const filenames = [...new Set(this.extractAssetFilenames(showcase))]
 
       // 3. Check which filenames are safe to delete (not used by other active showcases)
       // TODO: batch this into a single aggregation query if showcase count grows -- currently N regex scans per filename
       const safeFilenames = (
         await Promise.all(
           filenames.map(async (filename) => {
+            const escaped = filename.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+            const pattern = new RegExp(`${escaped}$`)
             const count = await ShowcaseModel.countDocuments({
               deleted_at: null,
               $or: [
-                { 'persona.image': { $regex: filename } },
-                { 'introduction.image': { $regex: filename } },
-                { 'progressBar.iconLight': { $regex: filename } },
-                { 'progressBar.iconDark': { $regex: filename } },
-                { 'revocationInfo.credentialIcon': { $regex: filename } },
+                { 'persona.image': { $regex: pattern } },
+                { 'introduction.image': { $regex: pattern } },
+                { 'progressBar.iconLight': { $regex: pattern } },
+                { 'progressBar.iconDark': { $regex: pattern } },
+                { 'revocationInfo.credentialIcon': { $regex: pattern } },
               ],
             })
             return count === 0 ? filename : null

--- a/server/src/controllers/admin/AdminShowcaseController.ts
+++ b/server/src/controllers/admin/AdminShowcaseController.ts
@@ -1,9 +1,13 @@
+import fs from 'fs/promises'
+import path from 'path'
 import { Body, Delete, JsonController, NotFoundError, Param, Post, Put } from 'routing-controllers'
 import { Service } from 'typedi'
 
 import { Showcase } from '../../content/types'
+import { AssetModel } from '../../db/models/Asset'
 import { ShowcaseModel } from '../../db/models/Showcase'
 import logger from '../../utils/logger'
+import { UPLOADS_DIR } from '../../utils/uploadsDir'
 
 @JsonController('/admin/showcases')
 @Service()
@@ -35,7 +39,7 @@ export class AdminShowcaseController {
   public async updateShowcase(@Param('showcaseName') showcaseName: string, @Body() body: Partial<Showcase>) {
     logger.debug({ showcaseName, body }, 'Updating showcase')
     try {
-      const showcase = await ShowcaseModel.findOneAndUpdate({ name: showcaseName }, body, {
+      const showcase = await ShowcaseModel.findOneAndUpdate({ name: showcaseName, deleted_at: null }, body, {
         new: true,
         runValidators: true,
       }).lean()
@@ -54,24 +58,172 @@ export class AdminShowcaseController {
   }
 
   /**
-   * Delete a showcase by name
+   * Soft-delete a showcase by name (set deleted_at, keep data intact)
    * Showcase name is unique, so this operation is deterministic and safe.
    */
   @Delete('/:showcaseName')
   public async deleteShowcase(@Param('showcaseName') showcaseName: string) {
-    logger.debug({ showcaseName }, 'Deleting showcase')
+    logger.debug({ showcaseName }, 'Soft-deleting showcase')
     try {
-      const result = await ShowcaseModel.findOneAndDelete({ name: showcaseName })
+      const result = await ShowcaseModel.findOneAndUpdate(
+        { name: showcaseName, deleted_at: null },
+        { deleted_at: new Date() },
+        { new: true },
+      ).lean()
 
       if (!result) {
-        logger.warn({ showcaseName }, 'Showcase not found for deletion')
+        logger.warn({ showcaseName }, 'Showcase not found for soft-deletion')
         throw new NotFoundError(`Showcase with name "${showcaseName}" not found.`)
       }
 
-      logger.debug({ showcaseName }, 'Showcase deleted successfully')
+      logger.debug({ showcaseName }, 'Showcase soft-deleted successfully')
       return { message: 'Showcase deleted successfully' }
     } catch (error) {
       logger.error(error, 'Error deleting showcase')
+      throw error
+    }
+  }
+
+  /**
+   * Restore a soft-deleted showcase by name
+   * Returns 409 if showcase is not currently deleted.
+   */
+  public async restoreShowcase(showcaseName: string) {
+    logger.debug({ showcaseName }, 'Restoring showcase')
+    try {
+      const result = await ShowcaseModel.findOneAndUpdate(
+        { name: showcaseName, deleted_at: { $ne: null } },
+        { deleted_at: null, status: 'pending' },
+        { new: true },
+      ).lean()
+
+      if (!result) {
+        // Check if showcase exists but isn't deleted
+        const existing = await ShowcaseModel.findOne({ name: showcaseName }).lean()
+        if (existing) {
+          logger.warn({ showcaseName }, 'Showcase not deleted, cannot restore')
+          const err = new Error(`Showcase with name "${showcaseName}" is not deleted.`)
+          ;(err as NodeJS.ErrnoException).code = 'SHOWCASE_NOT_DELETED'
+          throw err
+        }
+        // Showcase doesn't exist at all
+        logger.warn({ showcaseName }, 'Showcase not found for restore')
+        throw new NotFoundError(`Showcase with name "${showcaseName}" not found.`)
+      }
+
+      logger.debug({ showcaseName }, 'Showcase restored successfully')
+      return result
+    } catch (error) {
+      logger.error(error, 'Error restoring showcase')
+      throw error
+    }
+  }
+
+  /**
+   * List soft-deleted showcases with pagination
+   */
+  public async getDeletedShowcases(limit: number = 20, skip: number = 0) {
+    logger.debug({ limit, skip }, 'Fetching deleted showcases')
+    try {
+      const items = await ShowcaseModel.find({ deleted_at: { $ne: null } })
+        .skip(skip)
+        .limit(limit)
+        .lean()
+      const total = await ShowcaseModel.countDocuments({ deleted_at: { $ne: null } })
+      return { items, total }
+    } catch (error) {
+      logger.error(error, 'Error fetching deleted showcases')
+      throw error
+    }
+  }
+
+  /**
+   * Extract asset filenames from showcase image paths
+   */
+  private extractAssetFilenames(showcase: Showcase & { _id?: unknown }): string[] {
+    const paths: (string | undefined)[] = [
+      showcase.persona?.image,
+      ...showcase.introduction.map((s) => s.image),
+      ...showcase.progressBar.map((s) => s.iconLight),
+      ...showcase.progressBar.map((s) => s.iconDark),
+      ...(showcase.revocationInfo ?? []).map((r) => r.credentialIcon),
+    ]
+    return paths.filter((p): p is string => !!p).map((p) => path.basename(p))
+  }
+
+  /**
+   * Permanently delete a showcase (must already be soft-deleted)
+   * Removes document, embedded scenarios, asset files, and Asset DB records.
+   */
+  public async permanentDeleteShowcase(showcaseName: string) {
+    logger.debug({ showcaseName }, 'Permanently deleting showcase')
+    try {
+      // 1. Atomically delete -- only if soft-deleted
+      const showcase = await ShowcaseModel.findOneAndDelete({
+        name: showcaseName,
+        deleted_at: { $ne: null },
+      }).lean<Showcase & { _id?: unknown }>()
+
+      if (!showcase) {
+        // Distinguish 404 from 409
+        const exists = await ShowcaseModel.findOne({ name: showcaseName }).lean()
+        if (exists) {
+          logger.warn({ showcaseName }, 'Showcase not soft-deleted, cannot permanently delete')
+          const err = new Error(`Showcase "${showcaseName}" must be soft-deleted before permanent deletion.`)
+          ;(err as NodeJS.ErrnoException).code = 'SHOWCASE_NOT_DELETED'
+          throw err
+        }
+        logger.warn({ showcaseName }, 'Showcase not found for permanent deletion')
+        throw new NotFoundError(`Showcase with name "${showcaseName}" not found.`)
+      }
+
+      // 2. Extract filenames from deleted showcase
+      const filenames = this.extractAssetFilenames(showcase)
+
+      // 3. Check which filenames are safe to delete (not used by other active showcases)
+      // TODO: batch this into a single aggregation query if showcase count grows -- currently N regex scans per filename
+      const safeFilenames = (
+        await Promise.all(
+          filenames.map(async (filename) => {
+            const count = await ShowcaseModel.countDocuments({
+              deleted_at: null,
+              $or: [
+                { 'persona.image': { $regex: filename } },
+                { 'introduction.image': { $regex: filename } },
+                { 'progressBar.iconLight': { $regex: filename } },
+                { 'progressBar.iconDark': { $regex: filename } },
+                { 'revocationInfo.credentialIcon': { $regex: filename } },
+              ],
+            })
+            return count === 0 ? filename : null
+          }),
+        )
+      ).filter((f): f is string => f !== null)
+
+      // 4. Delete asset files from disk (best-effort, ignore missing files)
+      const uploadsBase = path.resolve(UPLOADS_DIR)
+      await Promise.all(
+        safeFilenames.map(async (filename) => {
+          const diskPath = path.resolve(UPLOADS_DIR, filename)
+          // Prevent path traversal: resolved path must stay inside UPLOADS_DIR
+          if (!diskPath.startsWith(uploadsBase + path.sep)) return
+          await fs.unlink(diskPath).catch((err: NodeJS.ErrnoException) => {
+            if (err.code !== 'ENOENT') throw err
+          })
+        }),
+      )
+      logger.debug({ count: safeFilenames.length }, 'Asset files deleted')
+
+      // 5. Delete Asset DB records for safe filenames only
+      if (safeFilenames.length > 0) {
+        await AssetModel.deleteMany({ filename: { $in: safeFilenames } })
+        logger.debug({ count: safeFilenames.length }, 'Asset DB records deleted')
+      }
+
+      logger.debug({ showcaseName }, 'Showcase permanently deleted successfully')
+      return { message: 'Showcase permanently deleted' }
+    } catch (error) {
+      logger.error(error, 'Error permanently deleting showcase')
       throw error
     }
   }

--- a/server/src/controllers/admin/AdminShowcaseController.ts
+++ b/server/src/controllers/admin/AdminShowcaseController.ts
@@ -40,11 +40,11 @@ export class AdminShowcaseController {
   public async updateShowcase(@Param('showcaseName') showcaseName: string, @Body() body: Partial<Showcase>) {
     logger.debug({ showcaseName, body }, 'Updating showcase')
     try {
-      const { deleted_at: _deletedAt, ...safeBody } = body
-      const showcase = await ShowcaseModel.findOneAndUpdate({ name: showcaseName, deleted_at: null }, safeBody, {
-        new: true,
-        runValidators: true,
-      }).lean()
+      const showcase = await ShowcaseModel.findOneAndUpdate(
+        { name: showcaseName, deleted_at: null },
+        { $set: { ...body, deleted_at: undefined } },
+        { new: true, runValidators: true },
+      ).lean()
 
       if (!showcase) {
         logger.warn({ showcaseName }, 'Showcase not found for update')

--- a/server/src/controllers/admin/AdminShowcaseController.ts
+++ b/server/src/controllers/admin/AdminShowcaseController.ts
@@ -40,7 +40,8 @@ export class AdminShowcaseController {
   public async updateShowcase(@Param('showcaseName') showcaseName: string, @Body() body: Partial<Showcase>) {
     logger.debug({ showcaseName, body }, 'Updating showcase')
     try {
-      const showcase = await ShowcaseModel.findOneAndUpdate({ name: showcaseName, deleted_at: null }, body, {
+      const { deleted_at: _deletedAt, ...safeBody } = body
+      const showcase = await ShowcaseModel.findOneAndUpdate({ name: showcaseName, deleted_at: null }, safeBody, {
         new: true,
         runValidators: true,
       }).lean()

--- a/server/src/controllers/admin/AdminShowcaseController.ts
+++ b/server/src/controllers/admin/AdminShowcaseController.ts
@@ -126,6 +126,7 @@ export class AdminShowcaseController {
     logger.debug({ limit, skip }, 'Fetching deleted showcases')
     try {
       const items = await ShowcaseModel.find({ deleted_at: { $ne: null } })
+        .sort({ deleted_at: -1, _id: 1 })
         .skip(skip)
         .limit(limit)
         .lean()

--- a/server/src/controllers/admin/AdminShowcaseController.ts
+++ b/server/src/controllers/admin/AdminShowcaseController.ts
@@ -209,7 +209,9 @@ export class AdminShowcaseController {
           // Prevent path traversal: resolved path must stay inside UPLOADS_DIR
           if (!diskPath.startsWith(uploadsBase + path.sep)) return
           await fs.unlink(diskPath).catch((err: NodeJS.ErrnoException) => {
-            if (err.code !== 'ENOENT') throw err
+            if (err.code !== 'ENOENT') {
+              logger.warn({ err, diskPath, showcaseName }, 'Permanent delete: failed to delete asset file')
+            }
           })
         }),
       )

--- a/server/src/db/__tests__/Showcase.test.ts
+++ b/server/src/db/__tests__/Showcase.test.ts
@@ -120,6 +120,49 @@ describe('RevocationInfoItem embedded schema', () => {
   })
 })
 
+describe('soft-delete: deleted_at field', () => {
+  it('defaults deleted_at to null', async () => {
+    const doc = await ShowcaseModel.create(minimal)
+    expect(doc.deleted_at).toBeNull()
+  })
+
+  it('stores a date when soft-deleted', async () => {
+    const before = new Date()
+    const doc = await ShowcaseModel.create(minimal)
+    await ShowcaseModel.updateOne({ _id: doc._id }, { deleted_at: new Date() })
+    const updated = await ShowcaseModel.findById(doc._id).lean()
+    expect(updated?.deleted_at).toBeDefined()
+    expect(updated?.deleted_at?.getTime()).toBeGreaterThanOrEqual(before.getTime())
+  })
+
+  it('excludes soft-deleted showcases from deleted_at: null queries', async () => {
+    await ShowcaseModel.create(minimal)
+    await ShowcaseModel.create({ ...minimal, name: 'Trashed Showcase', persona: undefined })
+    await ShowcaseModel.updateOne({ name: 'Trashed Showcase' }, { deleted_at: new Date() })
+
+    const active = await ShowcaseModel.find({ deleted_at: null }).lean()
+    expect(active.map((s) => s.name)).toContain('Student Showcase')
+    expect(active.map((s) => s.name)).not.toContain('Trashed Showcase')
+  })
+
+  it('returns soft-deleted showcases when querying deleted_at: { $ne: null }', async () => {
+    await ShowcaseModel.create(minimal)
+    await ShowcaseModel.create({ ...minimal, name: 'Trashed Showcase', persona: undefined })
+    await ShowcaseModel.updateOne({ name: 'Trashed Showcase' }, { deleted_at: new Date() })
+
+    const deleted = await ShowcaseModel.find({ deleted_at: { $ne: null } }).lean()
+    expect(deleted.map((s) => s.name)).toEqual(['Trashed Showcase'])
+  })
+
+  it('can clear deleted_at to restore a showcase', async () => {
+    const doc = await ShowcaseModel.create(minimal)
+    await ShowcaseModel.updateOne({ _id: doc._id }, { deleted_at: new Date() })
+    await ShowcaseModel.updateOne({ _id: doc._id }, { deleted_at: null })
+    const restored = await ShowcaseModel.findById(doc._id).lean()
+    expect(restored?.deleted_at).toBeNull()
+  })
+})
+
 describe('Scenario embedded in Showcase', () => {
   it('persists scenarios with screens', async () => {
     const doc = await ShowcaseModel.create({

--- a/server/src/db/models/Showcase.ts
+++ b/server/src/db/models/Showcase.ts
@@ -74,6 +74,7 @@ const ShowcaseSchema = new Schema<Showcase>(
     introduction: { type: [IntroductionStepSchema], required: true, default: [] },
     scenarios: [ScenarioSchema],
     revocationInfo: [RevocationInfoItemSchema],
+    deleted_at: { type: Date, default: null },
   },
   baseSchemaOptions,
 )
@@ -84,5 +85,8 @@ ShowcaseSchema.index({ name: 1 }, { unique: true })
 // Enforce uniqueness on persona.type so each showcase slug is distinct.
 // Use sparse index so showcases without persona don't conflict.
 ShowcaseSchema.index({ 'persona.type': 1 }, { unique: true, sparse: true })
+
+// Efficient filtering for active (non-deleted) showcase queries.
+ShowcaseSchema.index({ deleted_at: 1, status: 1 })
 
 export const ShowcaseModel = model<Showcase>('Showcase', ShowcaseSchema)

--- a/server/src/errors.ts
+++ b/server/src/errors.ts
@@ -1,0 +1,6 @@
+export class ShowcaseNotDeletedError extends Error {
+  public constructor(showcaseName: string) {
+    super(`Showcase "${showcaseName}" is not soft-deleted.`)
+    this.name = 'ShowcaseNotDeletedError'
+  }
+}

--- a/server/src/routes/__tests__/adminShowcasesRouter.test.ts
+++ b/server/src/routes/__tests__/adminShowcasesRouter.test.ts
@@ -22,6 +22,9 @@ const { mocks } = vi.hoisted(() => {
         createShowcase: vi.fn(),
         updateShowcase: vi.fn(),
         deleteShowcase: vi.fn(),
+        restoreShowcase: vi.fn(),
+        getDeletedShowcases: vi.fn(),
+        permanentDeleteShowcase: vi.fn(),
       },
     },
   }
@@ -73,6 +76,15 @@ describe('adminShowcasesRouter', () => {
       const res = await request(app).get('/admin/showcases')
       expect(res.status).toBe(500)
       expect(res.body).toHaveProperty('error', 'Failed to fetch showcases')
+    })
+
+    it('returns deleted showcases when ?deleted=true', async () => {
+      const deleted = { ...mockShowcase, deleted_at: new Date().toISOString() }
+      mocks.mockAdminShowcaseController.getDeletedShowcases.mockResolvedValue({ items: [deleted], total: 1 })
+      const res = await request(app).get('/admin/showcases?deleted=true')
+      expect(res.status).toBe(200)
+      expect(res.body).toHaveProperty('total', 1)
+      expect(res.body.items[0]).toHaveProperty('name', 'student')
     })
   })
 
@@ -136,6 +148,67 @@ describe('adminShowcasesRouter', () => {
     it('returns 500 on update error', async () => {
       mocks.mockAdminShowcaseController.updateShowcase.mockRejectedValue(new Error('Update failed'))
       const res = await request(app).put('/admin/showcases/student').send({ name: 'Updated' })
+      expect(res.status).toBe(500)
+    })
+  })
+
+  describe('POST /admin/showcases/:id/restore', () => {
+    it('returns 200 with restored showcase', async () => {
+      mocks.mockAdminShowcaseController.restoreShowcase.mockResolvedValue({ ...mockShowcase, status: 'pending' })
+      const res = await request(app).post('/admin/showcases/student/restore')
+      expect(res.status).toBe(200)
+      expect(res.body).toHaveProperty('status', 'pending')
+      expect(mocks.mockAdminShowcaseController.restoreShowcase).toHaveBeenCalledWith('student')
+    })
+
+    it('returns 404 when showcase not found', async () => {
+      const { NotFoundError } = await import('routing-controllers')
+      mocks.mockAdminShowcaseController.restoreShowcase.mockRejectedValue(new NotFoundError('Not found'))
+      const res = await request(app).post('/admin/showcases/ghost/restore')
+      expect(res.status).toBe(404)
+    })
+
+    it('returns 409 when showcase is not deleted', async () => {
+      const err = new Error('not deleted') as NodeJS.ErrnoException
+      err.code = 'SHOWCASE_NOT_DELETED'
+      mocks.mockAdminShowcaseController.restoreShowcase.mockRejectedValue(err)
+      const res = await request(app).post('/admin/showcases/student/restore')
+      expect(res.status).toBe(409)
+    })
+
+    it('returns 500 on unexpected error', async () => {
+      mocks.mockAdminShowcaseController.restoreShowcase.mockRejectedValue(new Error('DB error'))
+      const res = await request(app).post('/admin/showcases/student/restore')
+      expect(res.status).toBe(500)
+    })
+  })
+
+  describe('DELETE /admin/showcases/:id?permanent=true', () => {
+    it('calls permanentDeleteShowcase when ?permanent=true', async () => {
+      mocks.mockAdminShowcaseController.permanentDeleteShowcase.mockResolvedValue(undefined)
+      const res = await request(app).delete('/admin/showcases/student?permanent=true')
+      expect(res.status).toBe(204)
+      expect(mocks.mockAdminShowcaseController.permanentDeleteShowcase).toHaveBeenCalledWith('student')
+    })
+
+    it('returns 404 when showcase not found', async () => {
+      const { NotFoundError } = await import('routing-controllers')
+      mocks.mockAdminShowcaseController.permanentDeleteShowcase.mockRejectedValue(new NotFoundError('Not found'))
+      const res = await request(app).delete('/admin/showcases/ghost?permanent=true')
+      expect(res.status).toBe(404)
+    })
+
+    it('returns 409 when showcase is not soft-deleted', async () => {
+      const err = new Error('not deleted') as NodeJS.ErrnoException
+      err.code = 'SHOWCASE_NOT_DELETED'
+      mocks.mockAdminShowcaseController.permanentDeleteShowcase.mockRejectedValue(err)
+      const res = await request(app).delete('/admin/showcases/student?permanent=true')
+      expect(res.status).toBe(409)
+    })
+
+    it('returns 500 on unexpected error', async () => {
+      mocks.mockAdminShowcaseController.permanentDeleteShowcase.mockRejectedValue(new Error('DB error'))
+      const res = await request(app).delete('/admin/showcases/student?permanent=true')
       expect(res.status).toBe(500)
     })
   })

--- a/server/src/routes/__tests__/adminShowcasesRouter.test.ts
+++ b/server/src/routes/__tests__/adminShowcasesRouter.test.ts
@@ -169,9 +169,8 @@ describe('adminShowcasesRouter', () => {
     })
 
     it('returns 409 when showcase is not deleted', async () => {
-      const err = new Error('not deleted') as NodeJS.ErrnoException
-      err.code = 'SHOWCASE_NOT_DELETED'
-      mocks.mockAdminShowcaseController.restoreShowcase.mockRejectedValue(err)
+      const { ShowcaseNotDeletedError } = await import('../../errors')
+      mocks.mockAdminShowcaseController.restoreShowcase.mockRejectedValue(new ShowcaseNotDeletedError('student'))
       const res = await request(app).post('/admin/showcases/student/restore')
       expect(res.status).toBe(409)
     })
@@ -199,9 +198,10 @@ describe('adminShowcasesRouter', () => {
     })
 
     it('returns 409 when showcase is not soft-deleted', async () => {
-      const err = new Error('not deleted') as NodeJS.ErrnoException
-      err.code = 'SHOWCASE_NOT_DELETED'
-      mocks.mockAdminShowcaseController.permanentDeleteShowcase.mockRejectedValue(err)
+      const { ShowcaseNotDeletedError } = await import('../../errors')
+      mocks.mockAdminShowcaseController.permanentDeleteShowcase.mockRejectedValue(
+        new ShowcaseNotDeletedError('student'),
+      )
       const res = await request(app).delete('/admin/showcases/student?permanent=true')
       expect(res.status).toBe(409)
     })

--- a/server/src/routes/__tests__/adminShowcasesRouter.test.ts
+++ b/server/src/routes/__tests__/adminShowcasesRouter.test.ts
@@ -45,6 +45,10 @@ import adminShowcasesRouter from '../adminShowcasesRouter'
 
 const app = express()
 app.use(json())
+app.use((req, _res, next) => {
+  ;(req as any).auth = { realm_access: { roles: ['admin'] }, preferred_username: 'testuser', sub: 'test-sub' }
+  next()
+})
 app.use('/admin/showcases', adminShowcasesRouter)
 
 const mockShowcase = {

--- a/server/src/routes/adminShowcasesRouter.ts
+++ b/server/src/routes/adminShowcasesRouter.ts
@@ -18,13 +18,22 @@ const auditLogService = Container.get(AuditLogService)
 
 /**
  * GET /admin/showcases
- * List all showcases.
+ * List all active showcases, or deleted showcases if ?deleted=true.
  */
-router.get('/', requireRole(['admin', 'creator', 'viewer']), async (_req: Request, res: Response) => {
-  logger.debug('Admin: list showcases')
+router.get('/', requireRole(['admin', 'creator', 'viewer']), async (req: Request, res: Response) => {
+  logger.debug({ deleted: req.query.deleted }, 'Admin: list showcases')
   try {
-    const showcases = await showcaseController.getShowcases()
-    res.json(showcases)
+    if (req.query.deleted === 'true') {
+      // List soft-deleted showcases
+      const limit = Math.min(Math.max(Number(req.query.limit) || 20, 1), 100)
+      const skip = Math.max(Number(req.query.skip) || 0, 0)
+      const result = await adminShowcaseController.getDeletedShowcases(limit, skip)
+      res.json(result)
+    } else {
+      // List active showcases
+      const showcases = await showcaseController.getShowcases()
+      res.json(showcases)
+    }
   } catch (error) {
     logger.error(error, 'Error fetching showcases')
     res.status(500).json({ error: 'Failed to fetch showcases' })
@@ -113,13 +122,50 @@ router.put('/:id', requireRole(['admin', 'creator']), async (req: Request, res: 
 })
 
 /**
+ * POST /admin/showcases/:id/restore
+ * Restore a soft-deleted showcase.
+ */
+router.post('/:id/restore', requireRole(['admin']), async (req: Request, res: Response) => {
+  logger.debug({ id: req.params.id }, 'Admin: restore showcase')
+  try {
+    const showcase = await adminShowcaseController.restoreShowcase(req.params.id)
+    res.json(showcase)
+    void Promise.resolve()
+      .then(() =>
+        auditLogService.log({
+          user_id: req.auth?.sub ?? 'unknown',
+          action: 'updated',
+          resource_type: 'showcase',
+          resource_id: req.params.id,
+          details: { restored: true },
+        }),
+      )
+      .catch((err: unknown) => logger.error(err, 'Audit log: failed to write showcase restored event'))
+  } catch (error) {
+    logger.error(error, 'Error restoring showcase')
+    if (error instanceof NotFoundError) {
+      res.status(404).json({ error: 'Showcase not found' })
+    } else if (error instanceof Error && (error as NodeJS.ErrnoException).code === 'SHOWCASE_NOT_DELETED') {
+      res.status(409).json({ error: error.message })
+    } else {
+      res.status(500).json({ error: 'Failed to restore showcase' })
+    }
+  }
+})
+
+/**
  * DELETE /admin/showcases/:id
- * Delete a showcase.
+ * Soft-delete a showcase, or permanently delete if ?permanent=true.
  */
 router.delete('/:id', requireRole(['admin']), async (req: Request, res: Response) => {
-  logger.debug({ id: req.params.id }, 'Admin: delete showcase')
+  logger.debug({ id: req.params.id, permanent: req.query.permanent }, 'Admin: delete showcase')
   try {
-    await adminShowcaseController.deleteShowcase(req.params.id)
+    const isPermanent = req.query.permanent === 'true'
+    if (isPermanent) {
+      await adminShowcaseController.permanentDeleteShowcase(req.params.id)
+    } else {
+      await adminShowcaseController.deleteShowcase(req.params.id)
+    }
     res.status(204).send()
     void Promise.resolve()
       .then(() =>
@@ -128,7 +174,7 @@ router.delete('/:id', requireRole(['admin']), async (req: Request, res: Response
           action: 'deleted',
           resource_type: 'showcase',
           resource_id: req.params.id,
-          details: { id: req.params.id },
+          details: { id: req.params.id, permanent: isPermanent },
         }),
       )
       .catch((err: unknown) => logger.error(err, 'Audit log: failed to write showcase deleted event'))
@@ -136,6 +182,8 @@ router.delete('/:id', requireRole(['admin']), async (req: Request, res: Response
     logger.error(error, 'Error deleting showcase')
     if (error instanceof NotFoundError) {
       res.status(404).json({ error: 'Showcase not found' })
+    } else if (error instanceof Error && (error as NodeJS.ErrnoException).code === 'SHOWCASE_NOT_DELETED') {
+      res.status(409).json({ error: error.message })
     } else {
       res.status(500).json({ error: 'Failed to delete showcase' })
     }

--- a/server/src/routes/adminShowcasesRouter.ts
+++ b/server/src/routes/adminShowcasesRouter.ts
@@ -25,6 +25,11 @@ router.get('/', requireRole(['admin', 'creator', 'viewer']), async (req: Request
   logger.debug({ deleted: req.query.deleted }, 'Admin: list showcases')
   try {
     if (req.query.deleted === 'true') {
+      const roles = (req.auth as any)?.realm_access?.roles ?? []
+      if (!roles.includes('admin')) {
+        res.status(403).json({ error: 'Forbidden: insufficient role' })
+        return
+      }
       // List soft-deleted showcases
       const limit = Math.min(Math.max(Number(req.query.limit) || 20, 1), 100)
       const skip = Math.max(Number(req.query.skip) || 0, 0)

--- a/server/src/routes/adminShowcasesRouter.ts
+++ b/server/src/routes/adminShowcasesRouter.ts
@@ -6,6 +6,7 @@ import { Container } from 'typedi'
 
 import { ShowcaseController } from '../controllers/ShowcaseController'
 import { AdminShowcaseController } from '../controllers/admin/AdminShowcaseController'
+import { ShowcaseNotDeletedError } from '../errors'
 import { requireRole } from '../middleware/requireAdmin'
 import { AuditLogService } from '../services/AuditLogService'
 import logger from '../utils/logger'
@@ -145,7 +146,7 @@ router.post('/:id/restore', requireRole(['admin']), async (req: Request, res: Re
     logger.error(error, 'Error restoring showcase')
     if (error instanceof NotFoundError) {
       res.status(404).json({ error: 'Showcase not found' })
-    } else if (error instanceof Error && (error as NodeJS.ErrnoException).code === 'SHOWCASE_NOT_DELETED') {
+    } else if (error instanceof ShowcaseNotDeletedError) {
       res.status(409).json({ error: error.message })
     } else {
       res.status(500).json({ error: 'Failed to restore showcase' })
@@ -182,7 +183,7 @@ router.delete('/:id', requireRole(['admin']), async (req: Request, res: Response
     logger.error(error, 'Error deleting showcase')
     if (error instanceof NotFoundError) {
       res.status(404).json({ error: 'Showcase not found' })
-    } else if (error instanceof Error && (error as NodeJS.ErrnoException).code === 'SHOWCASE_NOT_DELETED') {
+    } else if (error instanceof ShowcaseNotDeletedError) {
       res.status(409).json({ error: error.message })
     } else {
       res.status(500).json({ error: 'Failed to delete showcase' })


### PR DESCRIPTION
This PR resolves #451, #452, #453,  #454, and #455

- deleted_at field + compound index on ShowcaseModel
- updateShowcase guards against editing soft-deleted records
- GET ?deleted=true lists trashed showcases with pagination
- POST /:id/restore resets deleted_at and sets status=pending
- DELETE /:id?permanent=true does atomic findOneAndDelete, skips assets referenced by other active showcases
- Trash tab in ShowcasesPanel with TrashShowcaseCard + UndoToast
- Admin API docs added to DEVELOPER/BC Wallet Showcase.md