### PR TITLE
fix: Clear connection state for multiple connections

### DIFF
--- a/frontend/src/client/pages/introduction/IntroductionContainer.tsx
+++ b/frontend/src/client/pages/introduction/IntroductionContainer.tsx
@@ -92,6 +92,10 @@ export const IntroductionContainer: React.FC<Props> = ({
         },
       },
     })
+    // Clear connection when moving to a new CONNECT screen to ensure fresh connection creation
+    if (introductionStep.startsWith('ACCEPT')) {
+      dispatch(clearConnection())
+    }
     addIntroductionProgress(dispatch, introductionStep, currentShowcase)
   }
 

--- a/frontend/src/client/pages/introduction/IntroductionContainer.tsx
+++ b/frontend/src/client/pages/introduction/IntroductionContainer.tsx
@@ -92,8 +92,10 @@ export const IntroductionContainer: React.FC<Props> = ({
         },
       },
     })
-    // Clear connection when moving to a new CONNECT screen to ensure fresh connection creation
-    if (introductionStep.startsWith('ACCEPT')) {
+    // Clear connection only when transitioning to a new CONNECT screen (between ACCEPT/CONNECT pairs)
+    const currentStepIndex = currentShowcase?.introduction.findIndex((step) => step.screenId === introductionStep) ?? -1
+    const nextStep = currentShowcase?.introduction[currentStepIndex + 1]
+    if (nextStep?.screenId.startsWith('CONNECT')) {
       dispatch(clearConnection())
     }
     addIntroductionProgress(dispatch, introductionStep, currentShowcase)


### PR DESCRIPTION
When doing multiple issuance the initial connection was never cleared and would use that connection id when trying to create a new credential. 