### PR TITLE
Use platform Secret showcase-traction for dev and PR deploys

### DIFF
--- a/.github/workflows/deploy-showcase-dev.yaml
+++ b/.github/workflows/deploy-showcase-dev.yaml
@@ -15,10 +15,9 @@
 #   Secret:
 #     SHOWCASE_DEV_OC_TOKEN      — Service account or user token with permission to
 #                                  helm upgrade/install resources in that namespace
-#   Optional secrets (Traction tenant and webhook; synced to OpenShift Secret `${release}-traction` before Helm):
-#     TRACTION_DEV_TENANT_ID     — Tenant UUID (maps to env TRACTION_TENANT_ID in the pod)
-#     TRACTION_DEV_TENANT_API_KEY — Tenant API key (maps to env TRACTION_TENANT_API_KEY)
-#     WEBHOOK_SECRET_DEV         — Secret for webhook signature verification (maps to env WEBHOOK_SECRET)
+#   Pre-create OpenShift Secret `showcase-traction` in the target namespace (keys TRACTION_TENANT_ID,
+#   TRACTION_TENANT_API_KEY, WEBHOOK_SECRET). Dev and PR deploys reference it via deploy/showcase values.
+#   CI does not create or update that Secret.
 #
 # If SHOWCASE_DEV_OC_URL or SHOWCASE_DEV_NAMESPACE is unset, the Helm deploy job is skipped while
 # image builds still run on bcgov. If both are set but SHOWCASE_DEV_OC_TOKEN is missing, the deploy
@@ -139,33 +138,19 @@ jobs:
         env:
           SHOWCASE_DEV_NAMESPACE: ${{ vars.SHOWCASE_DEV_NAMESPACE }}
           SHOWCASE_DEV_HELM_RELEASE: ${{ vars.SHOWCASE_DEV_HELM_RELEASE }}
-          TRACTION_DEV_TENANT_ID: ${{ secrets.TRACTION_DEV_TENANT_ID }}
-          TRACTION_DEV_TENANT_API_KEY: ${{ secrets.TRACTION_DEV_TENANT_API_KEY }}
-          WEBHOOK_SECRET_DEV: ${{ secrets.WEBHOOK_SECRET_DEV }}
         run: |
           set -euo pipefail
           release="${SHOWCASE_DEV_HELM_RELEASE:-showcase}"
           ns="${SHOWCASE_DEV_NAMESPACE}"
-          traction_secret="${release}-traction"
-          helm_args=(
-            -f ../../deploy/showcase/values-dev.yaml
-            --namespace "${ns}"
-            --wait
-            --timeout 15m
-            --atomic
-          )
-          if [[ -n "${TRACTION_DEV_TENANT_ID:-}" && -n "${TRACTION_DEV_TENANT_API_KEY:-}" && -n "${WEBHOOK_SECRET_DEV:-}" ]]; then
-            oc create secret generic "${traction_secret}" \
-              --from-literal=TRACTION_TENANT_ID="${TRACTION_DEV_TENANT_ID}" \
-              --from-literal=TRACTION_TENANT_API_KEY="${TRACTION_DEV_TENANT_API_KEY}" \
-              --from-literal=WEBHOOK_SECRET="${WEBHOOK_SECRET_DEV}" \
-              -n "${ns}" \
-              --dry-run=client -o yaml | oc apply -f -
-            helm_args+=(--set-string "showcase.server.traction.existingSecret=${traction_secret}")
-          else
-            echo '::notice::TRACTION_DEV_TENANT_ID / TRACTION_DEV_TENANT_API_KEY / WEBHOOK_SECRET_DEV not set — not creating traction Secret; set them in repo Actions secrets to enable Traction.'
+          if ! oc get secret showcase-traction -n "${ns}" >/dev/null 2>&1; then
+            echo '::warning::Secret showcase-traction not found in '"${ns}"' — create it before deploy (see deploy/showcase/values-dev.yaml).'
           fi
-          helm upgrade --install "${release}" . "${helm_args[@]}"
+          helm upgrade --install "${release}" . \
+            -f ../../deploy/showcase/values-dev.yaml \
+            --namespace "${ns}" \
+            --wait \
+            --timeout 15m \
+            --atomic
 
       # Same tag (`:main`) can point at a new digest; restart so workloads pull the image we just pushed.
       - name: Rollout restart (pick up new main digest)

--- a/.github/workflows/deploy-showcase-pr.yaml
+++ b/.github/workflows/deploy-showcase-pr.yaml
@@ -4,8 +4,7 @@
 #
 # Configure on bcgov/BC-Wallet-Demo (repository Actions secrets):
 #   Secrets: OPENSHIFT_SERVER, OPENSHIFT_TOKEN, OPENSHIFT_DEV_NAMESPACE
-#   Optional (Traction dev tenant and webhook; synced to Secret `pr-<N>-showcase-traction` before Helm when both set):
-#     TRACTION_DEV_TENANT_ID, TRACTION_DEV_TENANT_API_KEY, WEBHOOK_SECRET_DEV
+#   Pre-create OpenShift Secret `showcase-traction` in OPENSHIFT_DEV_NAMESPACE (shared with dev deploy).
 # Optional variable: SHOWCASE_PR_HOST_SUFFIX — hostname without scheme (overrides workflow default).
 #   Default is Silver dev ingress (see env.SHOWCASE_PR_HOST_SUFFIX). Public URL:
 #   https://pr-<N>-<suffix>/digital-trust/showcase
@@ -172,15 +171,14 @@ jobs:
           HOST_SUFFIX: ${{ env.SHOWCASE_PR_HOST_SUFFIX }}
           OWNER_LOWER: ${{ github.repository_owner }}
           OPENSHIFT_DEV_NAMESPACE: ${{ secrets.OPENSHIFT_DEV_NAMESPACE }}
-          TRACTION_DEV_TENANT_ID: ${{ secrets.TRACTION_DEV_TENANT_ID }}
-          TRACTION_DEV_TENANT_API_KEY: ${{ secrets.TRACTION_DEV_TENANT_API_KEY }}
-          WEBHOOK_SECRET_DEV: ${{ secrets.WEBHOOK_SECRET_DEV }}
         run: |
           set -euo pipefail
           origin="https://pr-${PR_NUM}-${HOST_SUFFIX}"
           owner_lc="$(echo "${OWNER_LOWER}" | tr '[:upper:]' '[:lower:]')"
           ns="${OPENSHIFT_DEV_NAMESPACE}"
-          traction_secret="pr-${PR_NUM}-showcase-traction"
+          if ! oc get secret showcase-traction -n "${ns}" >/dev/null 2>&1; then
+            echo '::warning::Secret showcase-traction not found in '"${ns}"' — create it before deploy (see deploy/showcase/values-pr.yaml).'
+          fi
           helm dependency update
           helm_args=(
             -f ../../deploy/showcase/values-pr.yaml
@@ -193,17 +191,6 @@ jobs:
             --wait
             --timeout 10m
           )
-          if [[ -n "${TRACTION_DEV_TENANT_ID:-}" && -n "${TRACTION_DEV_TENANT_API_KEY:-}" && -n "${WEBHOOK_SECRET_DEV:-}" ]]; then
-            oc create secret generic "${traction_secret}" \
-              --from-literal=TRACTION_TENANT_ID="${TRACTION_DEV_TENANT_ID}" \
-              --from-literal=TRACTION_TENANT_API_KEY="${TRACTION_DEV_TENANT_API_KEY}" \
-              --from-literal=WEBHOOK_SECRET="${WEBHOOK_SECRET_DEV}" \
-              -n "${ns}" \
-              --dry-run=client -o yaml | oc apply -f -
-            helm_args+=(--set-string "showcase.server.traction.existingSecret=${traction_secret}")
-          else
-            echo '::notice::TRACTION_DEV_TENANT_ID / TRACTION_DEV_TENANT_API_KEY / WEBHOOK_SECRET_DEV not set — PR deploy without Traction tenant Secret.'
-          fi
           if ! helm upgrade --install "pr-${PR_NUM}-showcase" . "${helm_args[@]}"; then
             echo '::error::helm upgrade failed; status and recent events follow.'
             helm status "pr-${PR_NUM}-showcase" -n "${OPENSHIFT_DEV_NAMESPACE}" 2>/dev/null || true

--- a/charts/showcase/README.md
+++ b/charts/showcase/README.md
@@ -88,7 +88,7 @@ With **`mongodb.enabled: true`**, the chart creates/reuses **`{{ release }}-show
 
 If you use **`showcase.server.existingSecret`** for a full env bundle, you can omit **`traction.existingSecret`** and include those keys (and **`TRACTION_URL`**) in that secret instead.
 
-On **bcgov**, GitHub Actions (**`deploy-showcase-dev.yaml`** / **`deploy-showcase-pr.yaml`**) can create **`${release}-traction`** / **`pr-<N>-showcase-traction`** from repository secrets **`TRACTION_DEV_TENANT_ID`**, **`TRACTION_DEV_TENANT_API_KEY`**, and optionally **`WEBHOOK_SECRET_DEV`** before **`helm upgrade`**.
+On **bcgov** dev and PR deploys, pre-create **`showcase-traction`** in the target namespace (keys **`TRACTION_TENANT_ID`**, **`TRACTION_TENANT_API_KEY`**, **`WEBHOOK_SECRET`**). **`deploy/showcase/values-dev.yaml`** and **`values-pr.yaml`** set **`showcase.server.traction.existingSecret: showcase-traction`**; CI does not create or update that Secret. PR uninstall only deletes chart-labeled resources and does not remove **`showcase-traction`**.
 
 ### Short OOB invitation URLs (QR)
 

--- a/deploy/showcase/values-dev.yaml
+++ b/deploy/showcase/values-dev.yaml
@@ -3,8 +3,7 @@
 ## Set `showcase.publicOrigin` to your HTTPS origin (no path). Ingress host is derived unless `ingress.frontend.hostname` is set.
 ## Secrets: chart always creates/reuses `{{ release }}-showcase-mongo-root` for Mongo root password. Set
 ## `showcase.server.existingSecret` to use a pre-created server env secret instead of chart-managed `MONGODB_URI`.
-## Traction: set `showcase.server.traction.url` here (non-secret); tenant id + API key from Secret `{{ release }}-traction`
-## when GitHub Actions secrets TRACTION_DEV_TENANT_* are set (see `.github/workflows/deploy-showcase-dev.yaml`).
+## Traction: `traction.url` here; tenant id, API key, and webhook from pre-created Secret `showcase-traction` in the namespace.
 ## Enable `showcase.networkPolicy` for deny-by-default namespaces. Route timeout matches bcgov demo web (Socket.IO long-poll).
 
 ingress:
@@ -27,9 +26,9 @@ showcase:
     existingSecret: ''
     image:
       pullPolicy: Always
-    ## Traction tenant proxy (non-secret). Tenant id + API key: GitHub Actions syncs secret `${release}-traction` from repo secrets TRACTION_DEV_TENANT_ID / TRACTION_DEV_TENANT_API_KEY when set.
     traction:
       url: 'https://traction-tenant-proxy-dev.apps.silver.devops.gov.bc.ca'
+      existingSecret: showcase-traction
     resources:
       requests:
         cpu: 25m

--- a/deploy/showcase/values-pr.yaml
+++ b/deploy/showcase/values-pr.yaml
@@ -26,6 +26,7 @@ showcase:
     existingSecret: ''
     traction:
       url: 'https://traction-tenant-proxy-dev.apps.silver.devops.gov.bc.ca'
+      existingSecret: showcase-traction
     image:
       pullPolicy: Always
     resources:


### PR DESCRIPTION
## Summary

- Set `showcase.server.traction.existingSecret: showcase-traction` in `deploy/showcase/values-dev.yaml` and `values-pr.yaml` (shared across dev and all `pr-*` releases).
- Remove CI `oc create secret` and `--set traction.existingSecret` from deploy workflows; add warn-only preflight when the secret is missing.
- Update chart README: platform pre-creates `showcase-traction`; PR uninstall does not delete it.

## Before merge

Ensure OpenShift Secret **`showcase-traction`** exists in the dev namespace with keys `TRACTION_TENANT_ID`, `TRACTION_TENANT_API_KEY`, and `WEBHOOK_SECRET` (copy from existing `showcase-traction` or `pr-*-showcase-traction` if needed).

GitHub Actions secrets `TRACTION_DEV_*` / `WEBHOOK_SECRET_DEV` are no longer used by deploy workflows after this lands.

## Test plan

- [ ] Confirm `oc get secret showcase-traction -n <dev-ns>` in Silver dev namespace
- [ ] Merge to main → dev deploy succeeds without creating traction secret in CI
- [ ] Open a PR → `deploy-showcase-pr` uses shared secret (no `pr-<N>-showcase-traction` created)
- [ ] Close PR → `undeploy-showcase-pr` leaves `showcase-traction` intact


Made with [Cursor](https://cursor.com)