### PR TITLE
fix(charts): force pod rollout on dev deploys to pick up rebuilt images

### DIFF
--- a/charts/showcase/templates/frontend/deployment.yaml
+++ b/charts/showcase/templates/frontend/deployment.yaml
@@ -25,6 +25,9 @@ spec:
         {{- end }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/frontend/configmap.yaml") . | sha256sum }}
+        {{- if .Values.showcase.rollme }}
+        rollme: {{ randAlphaNum 5 | quote }}
+        {{- end }}
         {{- with .Values.showcase.frontend.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/showcase/templates/server/deployment.yaml
+++ b/charts/showcase/templates/server/deployment.yaml
@@ -25,6 +25,9 @@ spec:
         {{- end }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/server/configmap.yaml") . | sha256sum }}
+        {{- if .Values.showcase.rollme }}
+        rollme: {{ randAlphaNum 5 | quote }}
+        {{- end }}
         {{- with .Values.showcase.server.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/showcase/values.yaml
+++ b/charts/showcase/values.yaml
@@ -65,6 +65,9 @@ mongodb:
 
 ## Showcase API (Express server)
 showcase:
+  ## When true, adds a random annotation to pod templates so every `helm upgrade` triggers a rollout
+  ## (useful with pullPolicy: Always + mutable tags like `main`). Enable in dev overlays only.
+  rollme: false
   baseRoute: /digital-trust/showcase
   ## First URL path segment under `{baseRoute}/admin/<segment>/...` served by the **admin SPA** (static + React Router).
   ## Any other segment is reverse_proxied to Express (wildcard). Add a segment here when adding a new client-only admin route.

--- a/deploy/showcase/values-dev.yaml
+++ b/deploy/showcase/values-dev.yaml
@@ -21,8 +21,12 @@ showcase:
   publicOrigin: 'https://bc-wallet-showcase-dev.apps.silver.devops.gov.bc.ca'
   networkPolicy:
     enabled: true
+  ## Force pod rollout on every helm upgrade so that Always-pull picks up rebuilt images behind the same tag.
+  rollme: true
   server:
     existingSecret: ''
+    image:
+      pullPolicy: Always
     ## Traction tenant proxy (non-secret). Tenant id + API key: GitHub Actions syncs secret `${release}-traction` from repo secrets TRACTION_DEV_TENANT_ID / TRACTION_DEV_TENANT_API_KEY when set.
     traction:
       url: 'https://traction-tenant-proxy-dev.apps.silver.devops.gov.bc.ca'
@@ -33,6 +37,8 @@ showcase:
       limits:
         memory: 512Mi
   frontend:
+    image:
+      pullPolicy: Always
     trustedProxies: '0.0.0.0/0'
     resources:
       requests:


### PR DESCRIPTION
Move imagePullPolicy: Always to values-dev overlay and default the main values.yaml to IfNotPresent. Add a conditional rollme annotation (randAlphaNum) to both deployment templates so that every helm upgrade in dev triggers a rolling update, ensuring pods always pull the latest image behind the mutable tag.