### PR TITLE
Remove credential id restriction / Better error handling

### DIFF
--- a/frontend/src/admin/components/showcase/modals/CreateConnectAndAcceptScreensModal.tsx
+++ b/frontend/src/admin/components/showcase/modals/CreateConnectAndAcceptScreensModal.tsx
@@ -183,9 +183,11 @@ export function CreateConnectAndAcceptScreensModal({
               {step.type === 'SET_CREDENTIAL_VALUES' && (
                 <DefineCredentialValuesStep
                   selectedSchema={selectedSchema}
+                  error={error}
                   onBack={() => {
                     setSelectedCredential(null)
                     setStep({ type: 'SELECTING_SCHEMA' })
+                    setError(null)
                   }}
                   onSelectCredential={async (values, icon) => {
                     // Create Credential object from schema and values
@@ -204,6 +206,7 @@ export function CreateConnectAndAcceptScreensModal({
                         }
                         const createdCredential = await createCredential(auth, credentialToCreate)
                         setSelectedCredential(createdCredential)
+                        setError(null)
                         setStep({ type: 'EDITING_CONNECT_SCREEN' })
                       } catch (err) {
                         setError(err instanceof Error ? err.message : 'Failed to create credential')

--- a/frontend/src/admin/components/showcase/modals/steps/DefineCredentialValuesStep.tsx
+++ b/frontend/src/admin/components/showcase/modals/steps/DefineCredentialValuesStep.tsx
@@ -10,12 +10,14 @@ interface DefineCredentialValuesStepProps {
   selectedSchema: Schema | null
   onBack: () => void
   onSelectCredential: (values: Record<string, string>, icon: string) => void
+  error?: string | null
 }
 
 export function DefineCredentialValuesStep({
   selectedSchema,
   onBack,
   onSelectCredential,
+  error,
 }: DefineCredentialValuesStepProps) {
   const [values, setValues] = useState<Record<string, string>>(
     selectedSchema
@@ -147,14 +149,20 @@ export function DefineCredentialValuesStep({
         </button>
       </div>
 
-      {!isFormValid() && (
+      {error && (
+        <div className="bg-red-50 border border-red-200 rounded-lg p-4">
+          <p className="text-sm font-semibold text-red-800">{error}</p>
+        </div>
+      )}
+
+      {!error && !isFormValid() && (
         <div className="bg-red-50 border border-red-200 rounded-lg p-4">
           <p className="text-sm font-semibold text-red-800 mb-2">Please complete the following:</p>
           <ul className="text-sm text-red-700 space-y-1">
-            {getValidationErrors().map((error, index) => (
+            {getValidationErrors().map((validationError, index) => (
               <li key={index} className="flex items-center gap-2">
                 <span className="w-1 h-1 bg-red-700 rounded-full" />
-                {error}
+                {validationError}
               </li>
             ))}
           </ul>

--- a/server/package.json
+++ b/server/package.json
@@ -38,6 +38,7 @@
     "routing-controllers": "^0.11.3",
     "socket.io": "^4.8.3",
     "typedi": "^0.10.0",
+    "uuid": "^14.0.0",
     "ws": "^8.20.0"
   },
   "devDependencies": {

--- a/server/src/controllers/admin/AdminCredentialController.ts
+++ b/server/src/controllers/admin/AdminCredentialController.ts
@@ -10,19 +10,6 @@ import logger from '../../utils/logger'
 // Only showcase-specific fields (icon, attributes values, status) remain editable.
 const LEDGER_LOCKED_FIELDS = ['name', 'version', 'schema_id', 'cred_def_id'] as const
 
-function generateSlug(name: string, version: string): string {
-  const nameSlug = name
-    .toLowerCase()
-    .trim()
-    .replace(/\s+/g, '-')
-    .replace(/[^a-z0-9-]/g, '')
-  const versionSlug = version
-    .toLowerCase()
-    .trim()
-    .replace(/\s+/g, '-')
-    .replace(/[^a-z0-9-]/g, '')
-  return `${nameSlug}-${versionSlug}`
-}
 @JsonController('/admin/credentials')
 @Service()
 export class AdminCredentialController {
@@ -37,19 +24,7 @@ export class AdminCredentialController {
   public async createCredential(@Body() body: CreateCredentialInput) {
     logger.debug({ body }, 'Creating new credential')
     try {
-      const credentialId = generateSlug(body.name, body.version)
-
-      // Check if credential with this ID already exists
-      const existing = await CredentialModel.findById(credentialId)
-      if (existing) {
-        logger.warn({ credentialId }, 'Credential with this ID already exists')
-        throw new Error(`Credential "${body.name}" version "${body.version}" already exists`)
-      }
-
-      const credential = new CredentialModel({
-        _id: credentialId,
-        ...body,
-      })
+      const credential = new CredentialModel(body)
       const saved = await credential.save()
       logger.debug({ credentialId: saved._id }, 'Credential created successfully')
       return toCredentialResponse(saved.toObject() as unknown as LeanCredentialDoc)

--- a/server/src/db/__tests__/Credential.test.ts
+++ b/server/src/db/__tests__/Credential.test.ts
@@ -80,9 +80,8 @@ describe('CredentialModel', () => {
     expect(json.status).toBe('active')
   })
 
-  it('persists a credential with a string id', async () => {
+  it('persists a credential with auto-generated UUID', async () => {
     const doc = await CredentialModel.create({
-      _id: 'student-card',
       name: 'Student Card',
       icon: '/icon.svg',
       version: '1.0.0',
@@ -90,7 +89,8 @@ describe('CredentialModel', () => {
     })
 
     const json = doc.toJSON()
-    expect(json.id).toBe('student-card')
+    expect(json.id).toBeDefined()
+    expect(typeof json.id).toBe('string')
     expect(json.attributes[0].name).toBe('student_id')
     expect(json.attributes[0].value).toBe('12345')
   })

--- a/server/src/db/models/Credential.ts
+++ b/server/src/db/models/Credential.ts
@@ -1,10 +1,11 @@
 import type { Credential } from '../../content/types'
 
 import { Schema, model } from 'mongoose'
+import { v4 as uuidv4 } from 'uuid'
 
 import { AttributeSchema, baseSchemaOptions } from '../baseSchema'
 
-/** Shape returned by CredentialModel queries with .lean(). Uses _id, not the id virtual. */
+/** Shape returned by CredentialModel queries with .lean(). Uses auto-generated UUID _id. */
 export interface LeanCredentialDoc {
   _id: string
   name: string
@@ -16,11 +17,11 @@ export interface LeanCredentialDoc {
   status?: 'active' | 'retired'
 }
 
-// Credential documents use a human-readable string _id (e.g. "student-card").
+// Credential documents use auto-generated UUID _id.
 // baseSchemaOptions exposes it as `id` in JSON output via the virtuals transform.
 const CredentialSchema = new Schema(
   {
-    _id: { type: String },
+    _id: { type: String, default: uuidv4 },
     name: { type: String, required: true },
     icon: { type: String, required: true },
     version: { type: String, required: true },

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -94,7 +94,7 @@ const run = async () => {
     next()
   })
 
-  app.use(json())
+  app.use(json({ limit: '10mb' }))
   app.use(
     pinoHttp({
       logger,
@@ -180,7 +180,9 @@ const run = async () => {
   // Error handler: map known errors to appropriate HTTP status codes.
   // - ServiceUnavailableError → 503 (service dependency unavailable)
   // - UnauthorizedError → 401 (Invalid/missing/expired JWT)
+  // - SyntaxError → 400 (JSON parsing or similar)
   // - All others → 500 (Internal server error)
+  // Returns error type and message for debugging while protecting sensitive details.
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   app.use((err: unknown, _req: Request, res: Response, _next: NextFunction) => {
     // If headers were already sent, we can't send another response.
@@ -191,15 +193,24 @@ const run = async () => {
     }
 
     if (err instanceof ServiceUnavailableError) {
-      res.status(503).json({ error: err.message })
+      res.status(503).json({ error: err.message, errorType: 'ServiceUnavailable' })
       return
     }
     if (err instanceof UnauthorizedError) {
-      res.status(401).json({ error: err.message })
+      res.status(401).json({ error: err.message, errorType: 'Unauthorized' })
       return
     }
-    logger.error({ err }, 'Unhandled server error')
-    res.status(500).json({ error: 'Internal server error' })
+    if (err instanceof SyntaxError) {
+      res.status(400).json({ error: 'Invalid request format', errorType: 'SyntaxError' })
+      return
+    }
+
+    // Provide error type and safe error message
+    const errorType = err?.constructor?.name || 'UnknownError'
+    const errorMessage = err instanceof Error ? err.message : 'An unexpected error occurred'
+
+    logger.error({ err, errorType }, 'Unhandled server error')
+    res.status(500).json({ error: errorMessage, errorType })
   })
 
   await new Promise<void>((resolve, reject) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -25,7 +25,7 @@
 
 "@asamuzakjp/css-color@^5.1.11":
   version "5.1.11"
-  resolved "https://registry.yarnpkg.com/@asamuzakjp/css-color/-/css-color-5.1.11.tgz#28a0aac8220a4cc19045ac3bd9a813d4060bd375"
+  resolved "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz"
   integrity sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==
   dependencies:
     "@asamuzakjp/generational-cache" "^1.0.1"
@@ -36,7 +36,7 @@
 
 "@asamuzakjp/dom-selector@^7.1.1":
   version "7.1.1"
-  resolved "https://registry.yarnpkg.com/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz#01880086bb2490098f167beb58555da1a6c9adbd"
+  resolved "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz"
   integrity sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==
   dependencies:
     "@asamuzakjp/generational-cache" "^1.0.1"
@@ -47,12 +47,12 @@
 
 "@asamuzakjp/generational-cache@^1.0.1":
   version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz#3d0bf6be4fc059851390a7070720c6007af793ec"
+  resolved "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz"
   integrity sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==
 
 "@asamuzakjp/nwsapi@^2.3.9":
   version "2.3.9"
-  resolved "https://registry.yarnpkg.com/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz#ad5549322dfe9d153d4b4dd6f7ff2ae234b06e24"
+  resolved "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz"
   integrity sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==
 
 "@babel/code-frame@^7.10.4", "@babel/code-frame@^7.28.6", "@babel/code-frame@^7.29.0":
@@ -225,12 +225,12 @@
 
 "@borewit/text-codec@^0.2.1":
   version "0.2.2"
-  resolved "https://registry.yarnpkg.com/@borewit/text-codec/-/text-codec-0.2.2.tgz#75025f735c0983b3a871668804a57387e3649375"
+  resolved "https://registry.npmjs.org/@borewit/text-codec/-/text-codec-0.2.2.tgz"
   integrity sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==
 
 "@bramus/specificity@^2.4.2":
   version "2.4.2"
-  resolved "https://registry.yarnpkg.com/@bramus/specificity/-/specificity-2.4.2.tgz#aa8db8eb173fdee7324f82284833106adeecc648"
+  resolved "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz"
   integrity sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==
   dependencies:
     css-tree "^3.0.0"
@@ -254,7 +254,7 @@
 
 "@csstools/color-helpers@^6.0.2":
   version "6.0.2"
-  resolved "https://registry.yarnpkg.com/@csstools/color-helpers/-/color-helpers-6.0.2.tgz#82c59fd30649cf0b4d3c82160489748666e6550b"
+  resolved "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz"
   integrity sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==
 
 "@csstools/css-calc@^2.1.3", "@csstools/css-calc@^2.1.4":
@@ -264,7 +264,7 @@
 
 "@csstools/css-calc@^3.2.0":
   version "3.2.0"
-  resolved "https://registry.yarnpkg.com/@csstools/css-calc/-/css-calc-3.2.0.tgz#15ca1a80a026ced0f6c4e12124c398e3db8e1617"
+  resolved "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.0.tgz"
   integrity sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==
 
 "@csstools/css-color-parser@^3.0.9":
@@ -277,7 +277,7 @@
 
 "@csstools/css-color-parser@^4.1.0":
   version "4.1.0"
-  resolved "https://registry.yarnpkg.com/@csstools/css-color-parser/-/css-color-parser-4.1.0.tgz#1d64ea09c548d3ed331648ea0b831e16b80c891c"
+  resolved "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.0.tgz"
   integrity sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ==
   dependencies:
     "@csstools/color-helpers" "^6.0.2"
@@ -290,12 +290,12 @@
 
 "@csstools/css-parser-algorithms@^4.0.0":
   version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz#e1c65dc09378b42f26a111fca7f7075fc2c26164"
+  resolved "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz"
   integrity sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==
 
 "@csstools/css-syntax-patches-for-csstree@^1.1.3":
   version "1.1.3"
-  resolved "https://registry.yarnpkg.com/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.3.tgz#3204cf40deb97db83e225b0baa9e37d9c3bd344d"
+  resolved "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.3.tgz"
   integrity sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==
 
 "@csstools/css-tokenizer@^3.0.3":
@@ -305,7 +305,7 @@
 
 "@csstools/css-tokenizer@^4.0.0":
   version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz#798a33950d11226a0ebb6acafa60f5594424967f"
+  resolved "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz"
   integrity sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==
 
 "@cypress/request@^3.0.6":
@@ -447,7 +447,7 @@
 
 "@exodus/bytes@^1.11.0", "@exodus/bytes@^1.15.0", "@exodus/bytes@^1.6.0":
   version "1.15.0"
-  resolved "https://registry.yarnpkg.com/@exodus/bytes/-/bytes-1.15.0.tgz#54479e0f406cbad024d6fe1c3190ecca4468df3b"
+  resolved "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz"
   integrity sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==
 
 "@hapi/bourne@^3.0.0":
@@ -900,7 +900,7 @@
 
 "@tokenizer/inflate@^0.4.1":
   version "0.4.1"
-  resolved "https://registry.yarnpkg.com/@tokenizer/inflate/-/inflate-0.4.1.tgz#fa6cdb8366151b3cc8426bf9755c1ea03a2fba08"
+  resolved "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.4.1.tgz"
   integrity sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==
   dependencies:
     debug "^4.4.3"
@@ -908,7 +908,7 @@
 
 "@tokenizer/token@^0.3.0":
   version "0.3.0"
-  resolved "https://registry.yarnpkg.com/@tokenizer/token/-/token-0.3.0.tgz#fe98a93fe789247e998c75e74e9c7c63217aa276"
+  resolved "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz"
   integrity sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==
 
 "@tsconfig/node10@^1.0.7":
@@ -932,9 +932,9 @@
   integrity sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==
 
 "@tybys/wasm-util@^0.10.0", "@tybys/wasm-util@^0.10.1":
-  version "0.10.1"
-  resolved "https://registry.yarnpkg.com/@tybys/wasm-util/-/wasm-util-0.10.1.tgz#ecddd3205cf1e2d5274649ff0eedd2991ed7f414"
-  integrity sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==
+  version "0.10.2"
+  resolved "https://registry.yarnpkg.com/@tybys/wasm-util/-/wasm-util-0.10.2.tgz#12b3a1b33db1f9cad4ddff1f604ab7dd00bf464e"
+  integrity sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==
   dependencies:
     tslib "^2.4.0"
 
@@ -1098,7 +1098,7 @@
 
 "@types/multer@^2.1.0":
   version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@types/multer/-/multer-2.1.0.tgz#c6ae866b9a3d9310b477d021a78b33feda092358"
+  resolved "https://registry.npmjs.org/@types/multer/-/multer-2.1.0.tgz"
   integrity sha512-zYZb0+nJhOHtPpGDb3vqPjwpdeGlGC157VpkqNQL+UU2qwoacoQ7MpsAmUptI/0Oa127X32JzWDqQVEXp2RcIA==
   dependencies:
     "@types/express" "*"
@@ -1233,7 +1233,7 @@
 
 "@types/trusted-types@^2.0.7":
   version "2.0.7"
-  resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-2.0.7.tgz#baccb07a970b91707df3a3e8ba6896c57ead2d11"
+  resolved "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz"
   integrity sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==
 
 "@types/use-sync-external-store@^0.0.6":
@@ -1587,7 +1587,7 @@ acorn@^8.11.0, acorn@^8.15.0, acorn@^8.4.1:
 
 agent-base@6:
   version "6.0.2"
-  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-6.0.2.tgz#49fff58577cfee3f37176feab4c22e00f86d7f77"
+  resolved "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz"
   integrity sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==
   dependencies:
     debug "4"
@@ -1872,7 +1872,7 @@ aws4@^1.8.0:
 
 axios@1.16.1:
   version "1.16.1"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-1.16.1.tgz#517e29291d19d6e8cf919ff264f4fe157261ba12"
+  resolved "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz"
   integrity sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==
   dependencies:
     follow-redirects "^1.16.0"
@@ -1962,7 +1962,7 @@ bcrypt-pbkdf@^1.0.0:
 
 bidi-js@^1.0.3:
   version "1.0.3"
-  resolved "https://registry.yarnpkg.com/bidi-js/-/bidi-js-1.0.3.tgz#6f8bcf3c877c4d9220ddf49b9bb6930c88f877d2"
+  resolved "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz"
   integrity sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==
   dependencies:
     require-from-string "^2.0.2"
@@ -2421,7 +2421,7 @@ css-mediaquery@^0.1.2:
 
 css-tree@^3.0.0, css-tree@^3.2.1:
   version "3.2.1"
-  resolved "https://registry.yarnpkg.com/css-tree/-/css-tree-3.2.1.tgz#86cac7011561272b30e6b1e042ba6ce047aa7518"
+  resolved "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz"
   integrity sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==
   dependencies:
     mdn-data "2.27.1"
@@ -2516,7 +2516,7 @@ data-urls@^5.0.0:
 
 data-urls@^7.0.0:
   version "7.0.0"
-  resolved "https://registry.yarnpkg.com/data-urls/-/data-urls-7.0.0.tgz#6dce8b63226a1ecfdd907ce18a8ccfb1eee506d3"
+  resolved "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz"
   integrity sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==
   dependencies:
     whatwg-mimetype "^5.0.0"
@@ -2721,7 +2721,7 @@ dom-accessibility-api@^0.6.3:
 
 dompurify@^3.4.2:
   version "3.4.2"
-  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.4.2.tgz#f0ff81be682c485505097ba8195a058d8f575218"
+  resolved "https://registry.npmjs.org/dompurify/-/dompurify-3.4.2.tgz"
   integrity sha512-lHeS9SA/IKeIFFyYciHBr2n0v1VMPlSj843HdLOwjb2OxNwdq9Xykxqhk+FE42MzAdHvInbAolSE4mhahPpjXA==
   optionalDependencies:
     "@types/trusted-types" "^2.0.7"
@@ -2836,7 +2836,7 @@ entities@^6.0.0:
 
 entities@^8.0.0:
   version "8.0.0"
-  resolved "https://registry.yarnpkg.com/entities/-/entities-8.0.0.tgz#c1df5fe3602429747fa233d0dd26f142f0ce4743"
+  resolved "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz"
   integrity sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==
 
 es-abstract@^1.23.2, es-abstract@^1.23.5, es-abstract@^1.23.9, es-abstract@^1.24.0:
@@ -3232,7 +3232,7 @@ express-jwt@*, express-jwt@^8.5.1:
 
 express-rate-limit@^8.5.1:
   version "8.5.1"
-  resolved "https://registry.yarnpkg.com/express-rate-limit/-/express-rate-limit-8.5.1.tgz#ee62473d7b3bdf3b27b7be3d7f25c6d13308479a"
+  resolved "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.1.tgz"
   integrity sha512-5O6KYmyJEpuPJV5hNTXKbAHWRqrzyu+OI3vUnSd2kXFubIVpG7ezpgxQy76Zo5GQZtrQBg86hF+CM/NX+cioiQ==
   dependencies:
     ip-address "^10.2.0"
@@ -3405,7 +3405,7 @@ file-entry-cache@^8.0.0:
 
 file-type@^22.0.1:
   version "22.0.1"
-  resolved "https://registry.yarnpkg.com/file-type/-/file-type-22.0.1.tgz#0184dbd6b6353bb25eb21a0c413a23885b6d1818"
+  resolved "https://registry.npmjs.org/file-type/-/file-type-22.0.1.tgz"
   integrity sha512-ww5Mhre0EE+jmBvOXTmXAbEMuZE7uX4a3+oRCQFNj8w++g3ev913N6tXQz0XTXbueQ5TWQfm6BdaViEHHn8bhA==
   dependencies:
     "@tokenizer/inflate" "^0.4.1"
@@ -3803,7 +3803,7 @@ html-encoding-sniffer@^4.0.0:
 
 html-encoding-sniffer@^6.0.0:
   version "6.0.0"
-  resolved "https://registry.yarnpkg.com/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz#f8d9390b3b348b50d4f61c16dd2ef5c05980a882"
+  resolved "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz"
   integrity sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==
   dependencies:
     "@exodus/bytes" "^1.6.0"
@@ -3862,7 +3862,7 @@ http-signature@~1.4.0:
 
 https-proxy-agent@^5.0.1:
   version "5.0.1"
-  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz#c59ef224a04fe8b754f3db0063a25ea30d0005d6"
+  resolved "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz"
   integrity sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==
   dependencies:
     agent-base "6"
@@ -3982,7 +3982,7 @@ internal-slot@^1.1.0:
 
 ip-address@^10.2.0:
   version "10.2.0"
-  resolved "https://registry.yarnpkg.com/ip-address/-/ip-address-10.2.0.tgz#805fc178b20c518bd4c8548b24fe30892d7f3206"
+  resolved "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz"
   integrity sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==
 
 ipaddr.js@1.9.1:
@@ -4250,7 +4250,7 @@ isexe@^2.0.0:
 
 isomorphic-dompurify@^3.12.0:
   version "3.12.0"
-  resolved "https://registry.yarnpkg.com/isomorphic-dompurify/-/isomorphic-dompurify-3.12.0.tgz#dbb9c7e9451f7f5ed84ee5e1b2e54d504785d6f9"
+  resolved "https://registry.npmjs.org/isomorphic-dompurify/-/isomorphic-dompurify-3.12.0.tgz"
   integrity sha512-8n+j+6ypTHvriJwFOQ2qusQ6bzGjZVcR3jbe1pBpLcGI1dn4WIl0ctLBngqE5QttquQBAlKXwJeTMw+X7x7qKw==
   dependencies:
     dompurify "^3.4.2"
@@ -4356,7 +4356,7 @@ jsdom@^25:
 
 jsdom@^29.1.1:
   version "29.1.1"
-  resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-29.1.1.tgz#5b9704906f3cd510c34aa941ae2f8f7f8179df01"
+  resolved "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz"
   integrity sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==
   dependencies:
     "@asamuzakjp/css-color" "^5.1.11"
@@ -4765,7 +4765,7 @@ lru-cache@^11.0.0:
 
 lru-cache@^11.3.5:
   version "11.3.6"
-  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-11.3.6.tgz#f0306ad6e9f0a5dc25b16aeba4e8f57b7ec2df55"
+  resolved "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.6.tgz"
   integrity sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==
 
 lru-cache@^5.1.1:
@@ -4829,7 +4829,7 @@ math-intrinsics@^1.1.0:
 
 mdn-data@2.27.1:
   version "2.27.1"
-  resolved "https://registry.yarnpkg.com/mdn-data/-/mdn-data-2.27.1.tgz#e37b9c50880b75366c4d40ac63d9bbcacdb61f0e"
+  resolved "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz"
   integrity sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==
 
 media-typer@0.3.0:
@@ -5345,7 +5345,7 @@ parse5@^7.1.2:
 
 parse5@^8.0.1:
   version "8.0.1"
-  resolved "https://registry.yarnpkg.com/parse5/-/parse5-8.0.1.tgz#f43bcd2cd683efe084075333e9ce0da7d06da31e"
+  resolved "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz"
   integrity sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==
   dependencies:
     entities "^8.0.0"
@@ -5892,7 +5892,7 @@ require-directory@^2.1.1:
 
 require-from-string@^2.0.2:
   version "2.0.2"
-  resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.2.tgz#89a7fdd938261267318eafe14f9c32e598c36909"
+  resolved "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz"
   integrity sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==
 
 reselect@^5.1.0:
@@ -6501,7 +6501,7 @@ strip-json-comments@^3.1.1:
 
 strtok3@^10.3.5:
   version "10.3.5"
-  resolved "https://registry.yarnpkg.com/strtok3/-/strtok3-10.3.5.tgz#7213285da0dc3dec0fc8ce5df4b8b7a733f14360"
+  resolved "https://registry.npmjs.org/strtok3/-/strtok3-10.3.5.tgz"
   integrity sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==
   dependencies:
     "@tokenizer/token" "^0.3.0"
@@ -6697,7 +6697,7 @@ tldts-core@^6.1.86:
 
 tldts-core@^7.0.30:
   version "7.0.30"
-  resolved "https://registry.yarnpkg.com/tldts-core/-/tldts-core-7.0.30.tgz#c495dba27778f2220bea94f3f6399005c7aca61c"
+  resolved "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.30.tgz"
   integrity sha512-uiHN8PIB1VmWyS98eZYja4xzlYqeFZVjb4OuYlJQnZAuJhMw4PbKQOKgHKhBdJR3FE/t5mUQ1Kd80++B+qhD1Q==
 
 tldts@^6.1.32:
@@ -6709,7 +6709,7 @@ tldts@^6.1.32:
 
 tldts@^7.0.5:
   version "7.0.30"
-  resolved "https://registry.yarnpkg.com/tldts/-/tldts-7.0.30.tgz#497cea8d610953222f9dcb3ceb07c7207efcd816"
+  resolved "https://registry.npmjs.org/tldts/-/tldts-7.0.30.tgz"
   integrity sha512-ELrFxuqsDdHUwoh0XxDbxuLD3Wnz49Z57IFvTtvWy1hJdcMZjXLIuonjilCiWHlT2GbE4Wlv1wKVTzDFnXH1aw==
   dependencies:
     tldts-core "^7.0.30"
@@ -6733,7 +6733,7 @@ toidentifier@1.0.1, toidentifier@~1.0.1:
 
 token-types@^6.1.1, token-types@^6.1.2:
   version "6.1.2"
-  resolved "https://registry.yarnpkg.com/token-types/-/token-types-6.1.2.tgz#18d0fd59b996d421f9f83914d6101c201bd08129"
+  resolved "https://registry.npmjs.org/token-types/-/token-types-6.1.2.tgz"
   integrity sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==
   dependencies:
     "@borewit/text-codec" "^0.2.1"
@@ -6749,7 +6749,7 @@ tough-cookie@^5.0.0:
 
 tough-cookie@^6.0.1:
   version "6.0.1"
-  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-6.0.1.tgz#a495f833836609ed983c19bc65639cfbceb54c76"
+  resolved "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz"
   integrity sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==
   dependencies:
     tldts "^7.0.5"
@@ -6763,7 +6763,7 @@ tr46@^5.1.0:
 
 tr46@^6.0.0:
   version "6.0.0"
-  resolved "https://registry.yarnpkg.com/tr46/-/tr46-6.0.0.tgz#f5a1ae546a0adb32a277a2278d0d17fa2f9093e6"
+  resolved "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz"
   integrity sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==
   dependencies:
     punycode "^2.3.1"
@@ -6978,7 +6978,7 @@ uid-safe@~2.1.5:
 
 uint8array-extras@^1.5.0:
   version "1.5.0"
-  resolved "https://registry.yarnpkg.com/uint8array-extras/-/uint8array-extras-1.5.0.tgz#10d2a85213de3ada304fea1c454f635c73839e86"
+  resolved "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.5.0.tgz"
   integrity sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==
 
 unbox-primitive@^1.1.0:
@@ -7003,7 +7003,7 @@ undici-types@~7.19.0:
 
 undici@^7.25.0:
   version "7.25.0"
-  resolved "https://registry.yarnpkg.com/undici/-/undici-7.25.0.tgz#7d72fc429a0421769ca2966fd07cac875c85b781"
+  resolved "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz"
   integrity sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==
 
 universalify@^2.0.0:
@@ -7077,6 +7077,11 @@ utils-merge@1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz"
   integrity sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==
+
+uuid@^14.0.0:
+  version "14.0.0"
+  resolved "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz"
+  integrity sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==
 
 uuid@^3.4.0:
   version "3.4.0"
@@ -7165,7 +7170,7 @@ webidl-conversions@^7.0.0:
 
 webidl-conversions@^8.0.1:
   version "8.0.1"
-  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-8.0.1.tgz#0657e571fe6f06fcb15ca50ed1fdbcb495cd1686"
+  resolved "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz"
   integrity sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==
 
 whatwg-encoding@^3.1.1:
@@ -7182,7 +7187,7 @@ whatwg-mimetype@^4.0.0:
 
 whatwg-mimetype@^5.0.0:
   version "5.0.0"
-  resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz#d8232895dbd527ceaee74efd4162008fb8a8cf48"
+  resolved "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz"
   integrity sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==
 
 whatwg-url@^14.0.0, whatwg-url@^14.1.0:
@@ -7195,7 +7200,7 @@ whatwg-url@^14.0.0, whatwg-url@^14.1.0:
 
 whatwg-url@^16.0.0, whatwg-url@^16.0.1:
   version "16.0.1"
-  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-16.0.1.tgz#047f7f4bd36ef76b7198c172d1b1cebc66f764dd"
+  resolved "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz"
   integrity sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==
   dependencies:
     "@exodus/bytes" "^1.11.0"


### PR DESCRIPTION
There was an issue with error messaging being hidden behind the active modal. Also the credential name/version id restriction should have been removed. The user should be able to create multiple credentials with the same name and version as they aren't creating the schemas anymore.