### PR TITLE
UX bug fixes

### DIFF
--- a/frontend/src/admin/components/showcase/modals/CreateConnectAndAcceptScreensModal.tsx
+++ b/frontend/src/admin/components/showcase/modals/CreateConnectAndAcceptScreensModal.tsx
@@ -6,6 +6,7 @@ import { useAuth } from 'react-oidc-context'
 
 import { getAvailableSchemas, updateShowcase, createCredential } from '../../../api/adminApi'
 import { CreateSchemaModal } from '../../schema/CreateSchemaModal'
+import { updateProgressBarForScreen } from '../../../utils/updateProgressBarForScreen'
 
 import { CreateOrEditScreenModal } from './CreateOrEditScreenModal'
 import { EnteringNameStep, SelectingSchemaStep, DefineCredentialValuesStep } from './steps'
@@ -281,11 +282,13 @@ export function CreateConnectAndAcceptScreensModal({
               ...showcase.introduction.slice(insertIdx),
             ]
 
-            // Build updated progress bar array
-            const updatedProgressBars = [...(showcase.progressBar || [])]
-            if (updatedAcceptProgressBar) {
-              updatedProgressBars.push(updatedAcceptProgressBar)
-            }
+            // Build updated progress bar array using the utility - handles ordering
+            const updatedProgressBars = updateProgressBarForScreen(
+              showcase.progressBar || [],
+              updatedAcceptProgressBar || undefined,
+              updatedAcceptScreen,
+              updatedIntroduction,
+            )
 
             // Add selected credential to showcase if not already present
             const updatedCredentials = [...(showcase.credentials || [])]

--- a/frontend/src/admin/components/showcase/modals/CreateConnectAndAcceptScreensModal.tsx
+++ b/frontend/src/admin/components/showcase/modals/CreateConnectAndAcceptScreensModal.tsx
@@ -5,8 +5,8 @@ import { useEffect, useState } from 'react'
 import { useAuth } from 'react-oidc-context'
 
 import { getAvailableSchemas, updateShowcase, createCredential } from '../../../api/adminApi'
-import { CreateSchemaModal } from '../../schema/CreateSchemaModal'
 import { updateProgressBarForScreen } from '../../../utils/updateProgressBarForScreen'
+import { CreateSchemaModal } from '../../schema/CreateSchemaModal'
 
 import { CreateOrEditScreenModal } from './CreateOrEditScreenModal'
 import { EnteringNameStep, SelectingSchemaStep, DefineCredentialValuesStep } from './steps'

--- a/frontend/src/admin/hooks/useIntroductionScreens.ts
+++ b/frontend/src/admin/hooks/useIntroductionScreens.ts
@@ -110,15 +110,25 @@ export function useIntroductionScreens({ showcase, onRefresh }: UseIntroductionS
       const acceptScreen = currentIntro[connectIdx + 1]
       const deletedScreenIds = [connectScreen?.screenId, acceptScreen?.screenId].filter(Boolean)
 
+      // Collect credential IDs from deleted screens
+      const credentialIdsToDelete = new Set<string>()
+      if (acceptScreen?.credentials) {
+        acceptScreen.credentials.forEach((cred) => credentialIdsToDelete.add(cred.id))
+      }
+
       const updatedIntro = currentIntro.filter((_, i) => i !== connectIdx && i !== connectIdx + 1)
 
       const updatedProgressBar = (showcase.progressBar || []).filter(
         (entry) => !deletedScreenIds.includes(entry.introductionStep),
       )
 
+      // Filter out deleted credentials from root showcase
+      const updatedCredentials = (showcase.credentials || []).filter((cred) => !credentialIdsToDelete.has(cred.id))
+
       await updateShowcase(auth, showcase.name, {
         introduction: updatedIntro,
         progressBar: updatedProgressBar,
+        credentials: updatedCredentials,
       })
       await onRefresh?.()
       setShowDeleteConfirm(false)

--- a/frontend/src/admin/utils/updateProgressBarForScreen.ts
+++ b/frontend/src/admin/utils/updateProgressBarForScreen.ts
@@ -38,30 +38,17 @@ export const updateProgressBarForScreen = (
         iconDark: progressBarWithCorrectId.iconDark,
       }
     } else {
-      // Add new progress bar at the correct position based on screen order
-      const screenIndex = updatedItems.findIndex(
-        (screen) => screen.screenId === progressBarWithCorrectId.introductionStep,
-      )
-
-      if (screenIndex !== -1) {
-        // Find the position to insert by checking other progress bars
-        let insertPos = updatedProgressBars.length
-        for (let i = 0; i < updatedProgressBars.length; i++) {
-          const existingPbScreenIndex = updatedItems.findIndex(
-            (screen) => screen.screenId === updatedProgressBars[i].introductionStep,
-          )
-          if (existingPbScreenIndex > screenIndex) {
-            insertPos = i
-            break
-          }
-        }
-        updatedProgressBars.splice(insertPos, 0, progressBarWithCorrectId)
-      } else {
-        // Fallback: just push if screen not found
-        updatedProgressBars.push(progressBarWithCorrectId)
-      }
+      // Add new progress bar
+      updatedProgressBars.push(progressBarWithCorrectId)
     }
   }
+
+  // Reorder progress bars to match introduction screen order
+  updatedProgressBars.sort((a, b) => {
+    const aScreenIndex = updatedItems.findIndex((screen) => screen.screenId === a.introductionStep)
+    const bScreenIndex = updatedItems.findIndex((screen) => screen.screenId === b.introductionStep)
+    return aScreenIndex - bScreenIndex
+  })
 
   return updatedProgressBars
 }

--- a/frontend/src/client/api/BaseUrl.ts
+++ b/frontend/src/client/api/BaseUrl.ts
@@ -9,7 +9,7 @@ export const baseUrl = (import.meta.env.VITE_HOST_BACKEND || '') + baseRoute
 export const baseWsUrl = import.meta.env.VITE_HOST_BACKEND || ''
 export const socketPath = `${baseRoute}/demo/socket/`
 
-// This warning is a false flag. THis is the way we want to import this.
+// This warning is a false flag. This is the way we want to import this.
 // eslint-disable-next-line import/no-named-as-default-member
 export const apiCall = axios.create({ baseURL: baseUrl })
 

--- a/frontend/src/client/api/BaseUrl.ts
+++ b/frontend/src/client/api/BaseUrl.ts
@@ -9,6 +9,8 @@ export const baseUrl = (import.meta.env.VITE_HOST_BACKEND || '') + baseRoute
 export const baseWsUrl = import.meta.env.VITE_HOST_BACKEND || ''
 export const socketPath = `${baseRoute}/demo/socket/`
 
+// This warning is a false flag. THis is the way we want to import this.
+// eslint-disable-next-line import/no-named-as-default-member
 export const apiCall = axios.create({ baseURL: baseUrl })
 
 apiCall.interceptors.request.use((config: InternalAxiosRequestConfig) => {


### PR DESCRIPTION
Fixes a couple UX bugs.

 - When the CONNECT/ACCEPT issuance screens were deleted it never removed the credential from the root of the showcase. If the user then went to create the verification screens the credential would appear as an option even though it no longer existed in an issuance.
 - The order of the progress bar icons matters, even though they have a screen id. This ensures they get re-ordered to match the screen order when they get added or changed.