### PR TITLE
Allow issuance exit / Clear state more aggressively

### DIFF
--- a/frontend/src/client/components/BackButton.tsx
+++ b/frontend/src/client/components/BackButton.tsx
@@ -7,9 +7,10 @@ import { FiArrowLeft } from 'react-icons/fi'
 export interface Props {
   disabled?: boolean
   onClick: MouseEventHandler<HTMLButtonElement>
+  label?: string
 }
 
-export const BackButton: React.FC<Props> = ({ onClick, disabled }) => {
+export const BackButton: React.FC<Props> = ({ onClick, disabled, label }) => {
   return (
     <motion.button
       whileHover={{ opacity: 0.8 }}
@@ -20,7 +21,7 @@ export const BackButton: React.FC<Props> = ({ onClick, disabled }) => {
       <p className="inline text-sm">
         <u></u>
         <FiArrowLeft className="inline h-4 w-6 mb-1" />
-        BACK
+        {label || 'BACK'}
       </p>
     </motion.button>
   )

--- a/frontend/src/client/pages/introduction/IntroductionContainer.tsx
+++ b/frontend/src/client/pages/introduction/IntroductionContainer.tsx
@@ -60,11 +60,14 @@ export const IntroductionContainer: React.FC<Props> = ({
   const credentials = introStep?.credentials
   const credentialsAccepted = credentials?.every((cred) => issuedCredentials.includes(cred.name))
 
-  const isBackDisabled = ['PICK_CHARACTER', 'ACCEPT_CREDENTIAL'].includes(introductionStep)
+  const isBackDisabled =
+    introductionStep === 'PICK_CHARACTER' ||
+    introductionStep.startsWith('CONNECT') ||
+    introductionStep.startsWith('ACCEPT')
   const isForwardDisabled =
     (introductionStep.startsWith('CONNECT') && !connectionCompleted) ||
-    (introductionStep === 'ACCEPT_CREDENTIAL' && !credentialsAccepted) ||
-    (introductionStep === 'ACCEPT_CREDENTIAL' && credentials?.length === 0) ||
+    (introductionStep.startsWith('ACCEPT_') && !credentialsAccepted) ||
+    (introductionStep.startsWith('ACCEPT_') && credentials?.length === 0) ||
     (introductionStep === 'PICK_CHARACTER' && !currentShowcase)
 
   const jumpIntroductionPage = () => {
@@ -272,6 +275,8 @@ export const IntroductionContainer: React.FC<Props> = ({
           forwardDisabled={isForwardDisabled}
           backDisabled={isBackDisabled}
           introductionCompleted={introductionCompleted}
+          onExit={leave}
+          showExitButton={introductionStep.startsWith('CONNECT') || introductionStep.startsWith('ACCEPT_')}
         />
       </div>
       {!isMobile && (

--- a/frontend/src/client/pages/introduction/IntroductionPage.tsx
+++ b/frontend/src/client/pages/introduction/IntroductionPage.tsx
@@ -52,6 +52,7 @@ export const IntroductionPage: React.FC = () => {
       dispatch(clearConnection())
       navigate(`${basePath}/dashboard`)
     } else {
+      dispatch({ type: 'demo/RESET' })
       dispatch(fetchWallets())
       dispatch(fetchAllShowcases())
       setMounted(true)

--- a/frontend/src/client/pages/introduction/components/IntroductionBottomNav.tsx
+++ b/frontend/src/client/pages/introduction/components/IntroductionBottomNav.tsx
@@ -4,6 +4,7 @@ import React, { useEffect, useState } from 'react'
 import { fadeDelay, fadeExit } from '../../../FramerAnimations'
 import { BackButton } from '../../../components/BackButton'
 import { Button } from '../../../components/Button'
+import { Modal } from '../../../components/Modal'
 
 export interface Props {
   introductionStep: string
@@ -12,6 +13,8 @@ export interface Props {
   forwardDisabled: boolean
   backDisabled: boolean
   introductionCompleted(): void
+  onExit(): void
+  showExitButton: boolean
 }
 
 export const IntroductionBottomNav: React.FC<Props> = ({
@@ -21,8 +24,11 @@ export const IntroductionBottomNav: React.FC<Props> = ({
   forwardDisabled,
   backDisabled,
   introductionCompleted,
+  onExit,
+  showExitButton,
 }) => {
   const [label, setLabel] = useState('NEXT')
+  const [showExitConfirm, setShowExitConfirm] = useState(false)
   const isCompleted = introductionStep === 'SETUP_COMPLETED'
 
   useEffect(() => {
@@ -44,7 +50,11 @@ export const IntroductionBottomNav: React.FC<Props> = ({
       className="flex w-full justify-between mb-4 h-8 self-end select-none"
     >
       <div className="flex self-center">
-        <BackButton onClick={removeIntroductionStep} disabled={backDisabled} data-cy="prev-introduction-step" />
+        {showExitButton ? (
+          <BackButton onClick={() => setShowExitConfirm(true)} label="EXIT" />
+        ) : (
+          <BackButton onClick={removeIntroductionStep} disabled={backDisabled} data-cy="prev-introduction-step" />
+        )}
       </div>
       <AnimatePresence mode="wait">
         <motion.div variants={fadeExit} initial="hidden" animate="show" exit="exit" data-cy="next-introduction-step">
@@ -55,6 +65,14 @@ export const IntroductionBottomNav: React.FC<Props> = ({
           />
         </motion.div>
       </AnimatePresence>
+      {showExitConfirm && (
+        <Modal
+          title="Exit Credential Flow?"
+          description="You will be returned to the landing page. Your progress will be lost."
+          onOk={onExit}
+          onCancel={() => setShowExitConfirm(false)}
+        />
+      )}
     </motion.div>
   )
 }


### PR DESCRIPTION
This is how I'm trying to reduce these state problems and getting stuck on the issuance page.

 - Change the back button to an exit button for these connection/issuance pages. Exit will warn the user and then return to the landing page and clear the state.
 - Clear state when entering the introduction screens.

That's basically it. I think we should do more cypress testing work now that the UI/UX of the showcase and builder is closer to being finalized. Not doing any additional testing here.