### PR TITLE
Register PR webhooks with Traction in CI

### DIFF
--- a/.github/scripts/showcase-traction-webhook.sh
+++ b/.github/scripts/showcase-traction-webhook.sh
@@ -82,7 +82,7 @@ fi
 
 case "${action}" in
   add)
-    if jq -e --arg url "${pr_webhook_url}" --argjson current "${current_urls}" \
+    if jq -en --arg url "${pr_webhook_url}" --argjson current "${current_urls}" \
       '($current | index($url)) != null' >/dev/null; then
       echo "PR webhook already registered: ${public_origin}${SHOWCASE_BASE_ROUTE}/demo/whook#***"
       exit 0

--- a/.github/scripts/showcase-traction-webhook.sh
+++ b/.github/scripts/showcase-traction-webhook.sh
@@ -95,7 +95,7 @@ case "${action}" in
   remove)
     # Drop only this PR's exact callback URL; other PRs and dev webhooks stay registered.
     removed_count="$(
-      jq --arg url "${pr_webhook_url}" --argjson current "${current_urls}" \
+      jq -n --arg url "${pr_webhook_url}" --argjson current "${current_urls}" \
         '[ $current[] | select(. == $url) ] | length'
     )"
     if [[ "${removed_count}" -eq 0 ]]; then

--- a/.github/scripts/showcase-traction-webhook.sh
+++ b/.github/scripts/showcase-traction-webhook.sh
@@ -33,8 +33,11 @@ TRACTION_SECRET_NAME="${TRACTION_SECRET_NAME:-showcase-traction}"
 
 read_secret_key() {
   local key="$1"
-  oc get secret "${TRACTION_SECRET_NAME}" -n "${OPENSHIFT_DEV_NAMESPACE}" \
-    -o "jsonpath={.data.${key}}" 2>/dev/null | base64 -d
+  (
+    oc get secret "${TRACTION_SECRET_NAME}" -n "${OPENSHIFT_DEV_NAMESPACE}" \
+      -o "jsonpath={.data.${key}}" 2>/dev/null \
+      | base64 -d 2>/dev/null
+  ) || true
 }
 
 TRACTION_TENANT_ID="$(read_secret_key TRACTION_TENANT_ID)"

--- a/.github/scripts/showcase-traction-webhook.sh
+++ b/.github/scripts/showcase-traction-webhook.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# Register or remove a PR-specific Traction webhook without disturbing other URLs.
+#
+# Usage:
+#   showcase-traction-webhook.sh add
+#   showcase-traction-webhook.sh remove
+#
+# Required environment:
+#   TRACTION_URL              — tenant proxy base (no trailing slash)
+#   OPENSHIFT_DEV_NAMESPACE   — namespace containing showcase-traction Secret
+#   PR_NUM                    — pull request number
+#   SHOWCASE_PR_HOST_SUFFIX   — host fragment after pr-<N>- (no scheme)
+#
+# Optional:
+#   SHOWCASE_BASE_ROUTE       — default /digital-trust/showcase
+#   TRACTION_SECRET_NAME      — default showcase-traction
+
+set -euo pipefail
+
+action="${1:-}"
+if [[ "${action}" != "add" && "${action}" != "remove" ]]; then
+  echo "Usage: $0 add|remove" >&2
+  exit 2
+fi
+
+: "${TRACTION_URL:?TRACTION_URL is required}"
+: "${OPENSHIFT_DEV_NAMESPACE:?OPENSHIFT_DEV_NAMESPACE is required}"
+: "${PR_NUM:?PR_NUM is required}"
+: "${SHOWCASE_PR_HOST_SUFFIX:?SHOWCASE_PR_HOST_SUFFIX is required}"
+
+SHOWCASE_BASE_ROUTE="${SHOWCASE_BASE_ROUTE:-/digital-trust/showcase}"
+TRACTION_SECRET_NAME="${TRACTION_SECRET_NAME:-showcase-traction}"
+
+read_secret_key() {
+  local key="$1"
+  oc get secret "${TRACTION_SECRET_NAME}" -n "${OPENSHIFT_DEV_NAMESPACE}" \
+    -o "jsonpath={.data.${key}}" 2>/dev/null | base64 -d
+}
+
+TRACTION_TENANT_ID="$(read_secret_key TRACTION_TENANT_ID)"
+TRACTION_TENANT_API_KEY="$(read_secret_key TRACTION_TENANT_API_KEY)"
+WEBHOOK_SECRET="$(read_secret_key WEBHOOK_SECRET)"
+
+if [[ -z "${TRACTION_TENANT_ID}" || -z "${TRACTION_TENANT_API_KEY}" || -z "${WEBHOOK_SECRET}" ]]; then
+  echo "::error::Secret ${TRACTION_SECRET_NAME} in ${OPENSHIFT_DEV_NAMESPACE} must contain TRACTION_TENANT_ID, TRACTION_TENANT_API_KEY, and WEBHOOK_SECRET."
+  exit 1
+fi
+
+traction_url="${TRACTION_URL%/}"
+public_origin="https://pr-${PR_NUM}-${SHOWCASE_PR_HOST_SUFFIX}"
+# ACA-Py appends /topic/{topic}/ to the URL before the # fragment.
+pr_webhook_url="${public_origin}${SHOWCASE_BASE_ROUTE}/demo/whook#${WEBHOOK_SECRET}"
+
+tenant_jwt="$(
+  curl -sfS -X POST "${traction_url}/multitenancy/tenant/${TRACTION_TENANT_ID}/token" \
+    -H "Content-Type: application/json" \
+    -d "{\"api_key\":\"${TRACTION_TENANT_API_KEY}\"}" \
+    | jq -r '.token // empty'
+)"
+
+if [[ -z "${tenant_jwt}" ]]; then
+  echo "::error::Failed to obtain tenant JWT from ${traction_url}/multitenancy/tenant/${TRACTION_TENANT_ID}/token"
+  exit 1
+fi
+
+wallet_json="$(
+  curl -sfS "${traction_url}/tenant/wallet" \
+    -H "Authorization: Bearer ${tenant_jwt}"
+)"
+
+current_urls="$(
+  echo "${wallet_json}" | jq -c '.settings["wallet.webhook_urls"] // .wallet_webhook_urls // []'
+)"
+
+if ! echo "${current_urls}" | jq -e 'type == "array"' >/dev/null 2>&1; then
+  echo "::error::Unexpected wallet.webhook_urls shape from GET /tenant/wallet"
+  exit 1
+fi
+
+case "${action}" in
+  add)
+    if jq -e --arg url "${pr_webhook_url}" --argjson current "${current_urls}" \
+      '($current | index($url)) != null' >/dev/null; then
+      echo "PR webhook already registered: ${public_origin}${SHOWCASE_BASE_ROUTE}/demo/whook#***"
+      exit 0
+    fi
+    next_urls="$(
+      jq -cn --arg url "${pr_webhook_url}" --argjson current "${current_urls}" \
+        '$current + [$url]'
+    )"
+    ;;
+  remove)
+    # Drop only this PR's exact callback URL; other PRs and dev webhooks stay registered.
+    removed_count="$(
+      jq --arg url "${pr_webhook_url}" --argjson current "${current_urls}" \
+        '[ $current[] | select(. == $url) ] | length'
+    )"
+    if [[ "${removed_count}" -eq 0 ]]; then
+      echo "No webhook registered for pr-${PR_NUM} (${public_origin}); nothing to remove."
+      exit 0
+    fi
+    next_urls="$(
+      jq -cn --arg url "${pr_webhook_url}" --argjson current "${current_urls}" \
+        '[ $current[] | select(. != $url) ]'
+    )"
+    ;;
+esac
+
+put_body="$(jq -cn --argjson urls "${next_urls}" '{ wallet_webhook_urls: $urls }')"
+
+curl -sfS -X PUT "${traction_url}/tenant/wallet" \
+  -H "Authorization: Bearer ${tenant_jwt}" \
+  -H "Content-Type: application/json" \
+  -d "${put_body}" >/dev/null
+
+case "${action}" in
+  add)
+    echo "Registered PR webhook for pr-${PR_NUM}: ${public_origin}${SHOWCASE_BASE_ROUTE}/demo/whook#***"
+    ;;
+  remove)
+    echo "Removed webhook for pr-${PR_NUM} only; ${removed_count} URL(s) deleted, other webhooks unchanged."
+    ;;
+esac

--- a/.github/workflows/deploy-showcase-pr.yaml
+++ b/.github/workflows/deploy-showcase-pr.yaml
@@ -1,4 +1,4 @@
-# Build showcase images (tag pr-<number>), Helm install/upgrade per PR, optional URL comment.
+# Build showcase images (tag pr-<number>), Helm install/upgrade per PR, register PR webhook with Traction, optional URL comment.
 #
 # Shared Docker steps live under `.github/actions/showcase-build-*` (also used by deploy-showcase-dev).
 #
@@ -33,6 +33,7 @@ on:
       - '.github/actions/showcase-build-frontend/**'
       - '.github/actions/showcase-setup-oc-helm/**'
       - '.github/actions/showcase-helm-lint/**'
+      - '.github/scripts/showcase-traction-webhook.sh'
     types: [opened, synchronize, reopened, ready_for_review]
 
 concurrency:
@@ -54,6 +55,8 @@ env:
   # PR Route host fragment (no scheme): https://pr-<N>-<SHOWCASE_PR_HOST_SUFFIX>/…
   # Override per-repo with Actions variable SHOWCASE_PR_HOST_SUFFIX if your cluster DNS differs.
   SHOWCASE_PR_HOST_SUFFIX: ${{ vars.SHOWCASE_PR_HOST_SUFFIX != '' && vars.SHOWCASE_PR_HOST_SUFFIX || 'bc-wallet-showcase-dev.apps.silver.devops.gov.bc.ca' }}
+  # Traction tenant proxy for PR webhook registration (matches deploy/showcase/values-pr.yaml).
+  TRACTION_URL: 'https://traction-tenant-proxy-dev.apps.silver.devops.gov.bc.ca'
 
 jobs:
   ready:
@@ -224,6 +227,15 @@ jobs:
           oc rollout status "deployment/pr-${PR_NUM}-showcase-server" -n "${ns}" --timeout=10m
           oc rollout restart "deployment/pr-${PR_NUM}-showcase-frontend" -n "${ns}"
           oc rollout status "deployment/pr-${PR_NUM}-showcase-frontend" -n "${ns}" --timeout=10m
+
+      # Append this PR's webhook to the shared Traction tenant; other registered URLs are preserved.
+      - name: Register PR webhook with Traction
+        env:
+          PR_NUM: ${{ github.event.pull_request.number }}
+          SHOWCASE_PR_HOST_SUFFIX: ${{ env.SHOWCASE_PR_HOST_SUFFIX }}
+          TRACTION_URL: ${{ env.TRACTION_URL }}
+          OPENSHIFT_DEV_NAMESPACE: ${{ secrets.OPENSHIFT_DEV_NAMESPACE }}
+        run: .github/scripts/showcase-traction-webhook.sh add
 
   pr_urls_comment:
     name: PR deployment comment

--- a/.github/workflows/undeploy-showcase-pr.yaml
+++ b/.github/workflows/undeploy-showcase-pr.yaml
@@ -1,4 +1,4 @@
-# Remove Helm release and chart-scoped secrets/PVC when a PR is closed (traction-style cleanup).
+# Remove PR webhook from Traction, then Helm release and chart-scoped secrets/PVC when a PR is closed (traction-style cleanup).
 #
 # Requires bcgov repo + OPENSHIFT_SERVER, OPENSHIFT_TOKEN, OPENSHIFT_DEV_NAMESPACE (same as deploy-showcase-pr).
 
@@ -16,12 +16,17 @@ on:
       - 'yarn.lock'
       - '.github/workflows/deploy-showcase-pr.yaml'
       - '.github/workflows/undeploy-showcase-pr.yaml'
+      - '.github/scripts/showcase-traction-webhook.sh'
     types: [closed]
 
 permissions:
   contents: read
   # Delete GHCR package versions tagged pr-<N> after uninstall (same token scope as PR image push).
   packages: write
+
+env:
+  SHOWCASE_PR_HOST_SUFFIX: ${{ vars.SHOWCASE_PR_HOST_SUFFIX != '' && vars.SHOWCASE_PR_HOST_SUFFIX || 'bc-wallet-showcase-dev.apps.silver.devops.gov.bc.ca' }}
+  TRACTION_URL: 'https://traction-tenant-proxy-dev.apps.silver.devops.gov.bc.ca'
 
 jobs:
   uninstall:
@@ -56,6 +61,17 @@ jobs:
           openshift_server_url: ${{ secrets.OPENSHIFT_SERVER }}
           openshift_token: ${{ secrets.OPENSHIFT_TOKEN }}
           namespace: ${{ secrets.OPENSHIFT_DEV_NAMESPACE }}
+
+      # Remove only this PR's webhook URL from the shared Traction tenant; dev and other PR URLs stay.
+      - name: Remove PR webhook from Traction
+        if: steps.openshift.outputs.continue == 'true'
+        continue-on-error: true
+        env:
+          PR_NUM: ${{ github.event.pull_request.number }}
+          SHOWCASE_PR_HOST_SUFFIX: ${{ env.SHOWCASE_PR_HOST_SUFFIX }}
+          TRACTION_URL: ${{ env.TRACTION_URL }}
+          OPENSHIFT_DEV_NAMESPACE: ${{ secrets.OPENSHIFT_DEV_NAMESPACE }}
+        run: .github/scripts/showcase-traction-webhook.sh remove
 
       - name: Helm release storage RBAC (uninstall)
         if: steps.openshift.outputs.continue == 'true'

--- a/charts/showcase/README.md
+++ b/charts/showcase/README.md
@@ -90,6 +90,8 @@ If you use **`showcase.server.existingSecret`** for a full env bundle, you can o
 
 On **bcgov** dev and PR deploys, pre-create **`showcase-traction`** in the target namespace (keys **`TRACTION_TENANT_ID`**, **`TRACTION_TENANT_API_KEY`**, **`WEBHOOK_SECRET`**). **`deploy/showcase/values-dev.yaml`** and **`values-pr.yaml`** set **`showcase.server.traction.existingSecret: showcase-traction`**; CI does not create or update that Secret. PR uninstall only deletes chart-labeled resources and does not remove **`showcase-traction`**.
 
+**PR webhooks (CI):** **`deploy-showcase-pr`** appends this PR’s callback URL to the shared tenant via **`PUT /tenant/wallet`** (script **`.github/scripts/showcase-traction-webhook.sh add`**). **`undeploy-showcase-pr`** removes **only that PR’s exact URL** (matched by `https://pr-<N>-<host>/…`) and leaves dev and other open PR webhooks on the tenant.
+
 ### Short OOB invitation URLs (QR)
 
 - **`showcase.server.shortInvitationUrls.enabled`** (default **`true`**) sets **`SHOWCASE_SHORT_INVITATION_URLS_ENABLED`** on the server. When **`true`**, connection and OOB proof invites get **`short_url`** for QR codes; wallets resolve **`GET {baseRoute}/i/{oobId}`** to the stored invitation JSON. Set to **`false`** to encode the full Traction **`invitation_url`** in QR codes instead (legacy behaviour).


### PR DESCRIPTION
## Summary

- Add `.github/scripts/showcase-traction-webhook.sh` to register or remove a PR-specific Traction callback via `PUT /tenant/wallet`
- **`deploy-showcase-pr`**: after rollout, append this PR's webhook URL (other registered URLs preserved)
- **`undeploy-showcase-pr`**: on PR close, remove only this PR's exact URL; dev and other open PR webhooks stay registered

Closes #469 (partial — PR deploy path; dev still manual unless we add a follow-up).

## Test plan

- [ ] Open a PR → deploy job runs `showcase-traction-webhook.sh add` successfully
- [ ] `GET /tenant/wallet` shows PR URL alongside any existing dev webhook
- [ ] Wallet connection/credential events reach the PR showcase instance
- [ ] Close PR → undeploy removes only `https://pr-<N>-…/digital-trust/showcase/demo/whook#…`
- [ ] With two PRs open, closing one leaves the other's webhook registered


Made with [Cursor](https://cursor.com)