### PR TITLE
Fix GHCR image platform metadata and add multi-arch builds

### DIFF
--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -11,7 +11,7 @@ runs:
   using: composite
   steps:
     - name: Setup node v${{ inputs.node-version }}
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         node-version: ${{ inputs.node-version }}
         cache: yarn

--- a/.github/actions/showcase-build-frontend/action.yml
+++ b/.github/actions/showcase-build-frontend/action.yml
@@ -21,19 +21,21 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     # ghcr.io org packages: use repository owner (lowercase) with GITHUB_TOKEN — not github.actor
-    - uses: docker/login-action@v3
+    - uses: docker/login-action@v4
       with:
         registry: ghcr.io
         username: ${{ github.repository_owner }}
         password: ${{ inputs.github_token }}
 
-    - uses: docker/setup-buildx-action@v3
+    - uses: docker/setup-qemu-action@v4
+
+    - uses: docker/setup-buildx-action@v4
 
     - id: meta
-      uses: docker/metadata-action@v5
+      uses: docker/metadata-action@v6
       with:
         images: ${{ inputs.image }}
         tags: |
@@ -44,10 +46,14 @@ runs:
         context: .
         file: ./frontend/Dockerfile
         push: true
+        platforms: linux/amd64,linux/arm64
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
+        annotations: ${{ steps.meta.outputs.annotations }}
         provenance: mode=min
         sbom: true
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
         build-args: |
           REACT_APP_INSIGHTS_PROJECT_ID=${{ inputs.react_app_insights_project_id }}
           REACT_APP_HOST_BACKEND=${{ inputs.react_app_host_backend }}

--- a/.github/actions/showcase-build-frontend/action.yml
+++ b/.github/actions/showcase-build-frontend/action.yml
@@ -21,27 +21,27 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
     # ghcr.io org packages: use repository owner (lowercase) with GITHUB_TOKEN — not github.actor
-    - uses: docker/login-action@v4
+    - uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
       with:
         registry: ghcr.io
         username: ${{ github.repository_owner }}
         password: ${{ inputs.github_token }}
 
-    - uses: docker/setup-qemu-action@v4
+    - uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
 
-    - uses: docker/setup-buildx-action@v4
+    - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
     - id: meta
-      uses: docker/metadata-action@v6
+      uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
       with:
         images: ${{ inputs.image }}
         tags: |
           type=raw,value=${{ inputs.tag }}
 
-    - uses: docker/build-push-action@v7
+    - uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
       with:
         context: .
         file: ./frontend/Dockerfile

--- a/.github/actions/showcase-build-server/action.yml
+++ b/.github/actions/showcase-build-server/action.yml
@@ -14,28 +14,28 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
     # ghcr.io org packages: use repository owner (lowercase) with GITHUB_TOKEN — not github.actor
     # (avoids "denied: installation not allowed to Write organization package"). See GitHub Packages docs.
-    - uses: docker/login-action@v4
+    - uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
       with:
         registry: ghcr.io
         username: ${{ github.repository_owner }}
         password: ${{ inputs.github_token }}
 
-    - uses: docker/setup-qemu-action@v4
+    - uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
 
-    - uses: docker/setup-buildx-action@v4
+    - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
     - id: meta
-      uses: docker/metadata-action@v6
+      uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
       with:
         images: ${{ inputs.image }}
         tags: |
           type=raw,value=${{ inputs.tag }}
 
-    - uses: docker/build-push-action@v7
+    - uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
       with:
         context: .
         file: ./server/Dockerfile

--- a/.github/actions/showcase-build-server/action.yml
+++ b/.github/actions/showcase-build-server/action.yml
@@ -14,20 +14,22 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     # ghcr.io org packages: use repository owner (lowercase) with GITHUB_TOKEN — not github.actor
     # (avoids "denied: installation not allowed to Write organization package"). See GitHub Packages docs.
-    - uses: docker/login-action@v3
+    - uses: docker/login-action@v4
       with:
         registry: ghcr.io
         username: ${{ github.repository_owner }}
         password: ${{ inputs.github_token }}
 
-    - uses: docker/setup-buildx-action@v3
+    - uses: docker/setup-qemu-action@v4
+
+    - uses: docker/setup-buildx-action@v4
 
     - id: meta
-      uses: docker/metadata-action@v5
+      uses: docker/metadata-action@v6
       with:
         images: ${{ inputs.image }}
         tags: |
@@ -38,7 +40,11 @@ runs:
         context: .
         file: ./server/Dockerfile
         push: true
+        platforms: linux/amd64,linux/arm64
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
+        annotations: ${{ steps.meta.outputs.annotations }}
         provenance: mode=min
         sbom: true
+        cache-from: type=gha
+        cache-to: type=gha,mode=max

--- a/.github/actions/showcase-helm-lint/action.yml
+++ b/.github/actions/showcase-helm-lint/action.yml
@@ -22,10 +22,10 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       if: ${{ inputs.skip_checkout != 'true' }}
 
-    - uses: azure/setup-helm@v5
+    - uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
       if: ${{ inputs.skip_helm_install != 'true' }}
       with:
         version: ${{ inputs.helm_version }}

--- a/.github/actions/showcase-helm-lint/action.yml
+++ b/.github/actions/showcase-helm-lint/action.yml
@@ -22,10 +22,10 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       if: ${{ inputs.skip_checkout != 'true' }}
 
-    - uses: azure/setup-helm@v4
+    - uses: azure/setup-helm@v5
       if: ${{ inputs.skip_helm_install != 'true' }}
       with:
         version: ${{ inputs.helm_version }}

--- a/.github/actions/showcase-setup-oc-helm/action.yml
+++ b/.github/actions/showcase-setup-oc-helm/action.yml
@@ -8,6 +8,6 @@ runs:
       with:
         oc: '4.15.63'
 
-    - uses: azure/setup-helm@v4
+    - uses: azure/setup-helm@v5
       with:
         version: v3.16.3

--- a/.github/actions/showcase-setup-oc-helm/action.yml
+++ b/.github/actions/showcase-setup-oc-helm/action.yml
@@ -4,10 +4,10 @@ runs:
   using: composite
   steps:
     # Pin patch version so the installer does not ambiguously pick among many 4.15.* tarballs (and cache keys stay stable).
-    - uses: redhat-actions/openshift-tools-installer@v1
+    - uses: redhat-actions/openshift-tools-installer@144527c7d98999f2652264c048c7a9bd103f8a82 # v1.13.1
       with:
         oc: '4.15.63'
 
-    - uses: azure/setup-helm@v5
+    - uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
       with:
         version: v3.16.3

--- a/.github/workflows/build_packages.yml
+++ b/.github/workflows/build_packages.yml
@@ -30,7 +30,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup NodeJS
         uses: ./.github/actions/setup-node
@@ -55,7 +55,7 @@ jobs:
         shell: bash
 
       - name: Cypress run
-        uses: cypress-io/github-action@v6
+        uses: cypress-io/github-action@f790eee7a50d9505912f50c2095510be7de06aa7 # v6.10.9
         with:
           install: false
           # Only record to Cypress Cloud when the repo/org secret is configured.
@@ -86,29 +86,29 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Log in to the Container registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
         with:
           images: ${{ env.SHOWCASE_SERVER_IMAGE }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: .
           file: ./server/Dockerfile
@@ -134,29 +134,29 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Log in to the Container registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
         with:
           images: ${{ env.SHOWCASE_FRONTEND_IMAGE }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: .
           file: ./frontend/Dockerfile

--- a/.github/workflows/build_packages.yml
+++ b/.github/workflows/build_packages.yml
@@ -30,7 +30,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup NodeJS
         uses: ./.github/actions/setup-node
@@ -86,21 +86,24 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Log in to the Container registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.SHOWCASE_SERVER_IMAGE }}
 
@@ -110,10 +113,14 @@ jobs:
           context: .
           file: ./server/Dockerfile
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          annotations: ${{ steps.meta.outputs.annotations }}
           provenance: mode=min
           sbom: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
   build-and-push-image-frontend:
     runs-on: ubuntu-latest
@@ -127,21 +134,24 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Log in to the Container registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.SHOWCASE_FRONTEND_IMAGE }}
 
@@ -151,10 +161,14 @@ jobs:
           context: .
           file: ./frontend/Dockerfile
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          annotations: ${{ steps.meta.outputs.annotations }}
           provenance: mode=min
           sbom: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           build-args: |
             REACT_APP_INSIGHTS_PROJECT_ID=${{ vars.REACT_APP_INSIGHTS_PROJECT_ID || secrets.REACT_APP_INSIGHTS_PROJECT_ID }}
             REACT_APP_HOST_BACKEND=${{ vars.REACT_APP_HOST_BACKEND || secrets.REACT_APP_HOST_BACKEND }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -21,7 +21,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup NodeJS
         uses: ./.github/actions/setup-node
@@ -40,7 +40,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup NodeJS
         uses: ./.github/actions/setup-node
@@ -59,7 +59,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup NodeJS
         uses: ./.github/actions/setup-node

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -21,7 +21,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup NodeJS
         uses: ./.github/actions/setup-node
@@ -40,7 +40,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup NodeJS
         uses: ./.github/actions/setup-node
@@ -59,7 +59,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup NodeJS
         uses: ./.github/actions/setup-node
@@ -81,7 +81,7 @@ jobs:
       # Cypress: only the Vite dev server is started. cypress.config.ts sets apiUrl to :5000 for
       # specs that hit the API—if CI runs those, also start the server (e.g. concurrently) or align with build_packages.yml (yarn dev).
       - name: Cypress run
-        uses: cypress-io/github-action@v6
+        uses: cypress-io/github-action@f790eee7a50d9505912f50c2095510be7de06aa7 # v6.10.9
         with:
           install: false
           start: yarn workspace frontend start

--- a/.github/workflows/delete_images.yml
+++ b/.github/workflows/delete_images.yml
@@ -16,7 +16,7 @@ jobs:
     if: github.repository_owner == 'bcgov'
     steps:
       - name: Delete container images older than a Month
-        uses: snok/container-retention-policy@v3.1.0
+        uses: snok/container-retention-policy@d3bdcf5ce9b05f685154e4a16c39233b245e3d53 # v3.1.0
         with:
           account: bcgov
           image-names: bc-wallet-showcase-frontend, bc-wallet-showcase-server

--- a/.github/workflows/deploy-showcase-dev.yaml
+++ b/.github/workflows/deploy-showcase-dev.yaml
@@ -66,7 +66,7 @@ jobs:
       packages: write
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/showcase-build-server
         with:
           image: ${{ env.SHOWCASE_SERVER_IMAGE }}
@@ -83,7 +83,7 @@ jobs:
       packages: write
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/showcase-build-frontend
         with:
           image: ${{ env.SHOWCASE_FRONTEND_IMAGE }}
@@ -109,7 +109,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Verify OpenShift token is configured
         env:

--- a/.github/workflows/deploy-showcase-dev.yaml
+++ b/.github/workflows/deploy-showcase-dev.yaml
@@ -66,7 +66,7 @@ jobs:
       packages: write
       id-token: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: ./.github/actions/showcase-build-server
         with:
           image: ${{ env.SHOWCASE_SERVER_IMAGE }}
@@ -83,7 +83,7 @@ jobs:
       packages: write
       id-token: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: ./.github/actions/showcase-build-frontend
         with:
           image: ${{ env.SHOWCASE_FRONTEND_IMAGE }}
@@ -109,7 +109,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Verify OpenShift token is configured
         env:

--- a/.github/workflows/deploy-showcase-pr.yaml
+++ b/.github/workflows/deploy-showcase-pr.yaml
@@ -77,7 +77,7 @@ jobs:
       packages: write
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/showcase-build-server
         with:
           image: ${{ env.SHOWCASE_SERVER_IMAGE }}
@@ -95,7 +95,7 @@ jobs:
       packages: write
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/showcase-build-frontend
         with:
           image: ${{ env.SHOWCASE_FRONTEND_IMAGE }}
@@ -112,7 +112,7 @@ jobs:
     # Job-level `if` cannot use `secrets` (GitHub restriction). Verify OpenShift secrets in-step.
     if: ${{ always() && needs.ready.outputs.deploy == 'true' && needs.build_server.result == 'success' && needs.build_frontend.result == 'success' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Verify OpenShift secrets for deploy
         env:
@@ -231,7 +231,7 @@ jobs:
     needs: [ready, deploy]
     if: ${{ always() && needs.ready.outputs.deploy == 'true' && needs.deploy.result == 'success' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: peter-evans/find-comment@v3
         id: fc

--- a/.github/workflows/deploy-showcase-pr.yaml
+++ b/.github/workflows/deploy-showcase-pr.yaml
@@ -77,7 +77,7 @@ jobs:
       packages: write
       id-token: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: ./.github/actions/showcase-build-server
         with:
           image: ${{ env.SHOWCASE_SERVER_IMAGE }}
@@ -95,7 +95,7 @@ jobs:
       packages: write
       id-token: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: ./.github/actions/showcase-build-frontend
         with:
           image: ${{ env.SHOWCASE_FRONTEND_IMAGE }}
@@ -112,7 +112,7 @@ jobs:
     # Job-level `if` cannot use `secrets` (GitHub restriction). Verify OpenShift secrets in-step.
     if: ${{ always() && needs.ready.outputs.deploy == 'true' && needs.build_server.result == 'success' && needs.build_frontend.result == 'success' }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Verify OpenShift secrets for deploy
         env:
@@ -127,7 +127,7 @@ jobs:
 
       - uses: ./.github/actions/showcase-setup-oc-helm
 
-      - uses: redhat-actions/oc-login@v1
+      - uses: redhat-actions/oc-login@5eb45e848b168b6bf6b8fe7f1561003c12e3c99d # v1.3
         with:
           openshift_server_url: ${{ secrets.OPENSHIFT_SERVER }}
           openshift_token: ${{ secrets.OPENSHIFT_TOKEN }}
@@ -231,9 +231,9 @@ jobs:
     needs: [ready, deploy]
     if: ${{ always() && needs.ready.outputs.deploy == 'true' && needs.deploy.result == 'success' }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-      - uses: peter-evans/find-comment@v3
+      - uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e # v3.1.0
         id: fc
         with:
           issue-number: ${{ github.event.pull_request.number }}
@@ -242,7 +242,7 @@ jobs:
 
       - name: Create PR deployment comment
         if: steps.fc.outputs.comment-id == ''
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
         with:
           issue-number: ${{ github.event.pull_request.number }}
           body: |
@@ -255,7 +255,7 @@ jobs:
 
       - name: Update PR deployment comment
         if: steps.fc.outputs.comment-id != ''
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
         with:
           issue-number: ${{ github.event.pull_request.number }}
           comment-id: ${{ steps.fc.outputs.comment-id }}

--- a/.github/workflows/helm-lint-showcase.yaml
+++ b/.github/workflows/helm-lint-showcase.yaml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Local composite actions require the repo on disk before `uses: ./.github/actions/...` resolves.
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: ./.github/actions/showcase-helm-lint
         with:

--- a/.github/workflows/helm-lint-showcase.yaml
+++ b/.github/workflows/helm-lint-showcase.yaml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Local composite actions require the repo on disk before `uses: ./.github/actions/...` resolves.
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - uses: ./.github/actions/showcase-helm-lint
         with:

--- a/.github/workflows/helm-publish-showcase.yaml
+++ b/.github/workflows/helm-publish-showcase.yaml
@@ -23,7 +23,7 @@ jobs:
     name: Package and push to ghcr.io (OCI)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - uses: ./.github/actions/showcase-helm-lint
         with:
@@ -41,7 +41,7 @@ jobs:
           helm package . --destination "$GITHUB_WORKSPACE/dist"
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/helm-publish-showcase.yaml
+++ b/.github/workflows/helm-publish-showcase.yaml
@@ -23,7 +23,7 @@ jobs:
     name: Package and push to ghcr.io (OCI)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: ./.github/actions/showcase-helm-lint
         with:
@@ -41,7 +41,7 @@ jobs:
           helm package . --destination "$GITHUB_WORKSPACE/dist"
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/on_pr_opened.yaml
+++ b/.github/workflows/on_pr_opened.yaml
@@ -39,7 +39,7 @@ jobs:
       DOCKER_BUILDKIT: '1'
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Build server image
         run: docker build -f server/Dockerfile .

--- a/.github/workflows/on_pr_opened.yaml
+++ b/.github/workflows/on_pr_opened.yaml
@@ -39,7 +39,7 @@ jobs:
       DOCKER_BUILDKIT: '1'
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Build server image
         run: docker build -f server/Dockerfile .

--- a/.github/workflows/undeploy-showcase-pr.yaml
+++ b/.github/workflows/undeploy-showcase-pr.yaml
@@ -31,7 +31,7 @@ jobs:
     # Job-level `if` cannot use `secrets`. Skip uninstall steps when secrets are unset (notice only).
     if: github.repository_owner == 'bcgov'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - id: openshift
         name: Preflight OpenShift secrets
@@ -50,7 +50,7 @@ jobs:
       - uses: ./.github/actions/showcase-setup-oc-helm
         if: steps.openshift.outputs.continue == 'true'
 
-      - uses: redhat-actions/oc-login@v1
+      - uses: redhat-actions/oc-login@5eb45e848b168b6bf6b8fe7f1561003c12e3c99d # v1.3
         if: steps.openshift.outputs.continue == 'true'
         with:
           openshift_server_url: ${{ secrets.OPENSHIFT_SERVER }}
@@ -107,7 +107,7 @@ jobs:
       - name: Delete GHCR images tagged pr-${{ github.event.pull_request.number }}
         if: always()
         continue-on-error: true
-        uses: snok/container-retention-policy@v3.1.0
+        uses: snok/container-retention-policy@d3bdcf5ce9b05f685154e4a16c39233b245e3d53 # v3.1.0
         with:
           account: ${{ github.repository_owner }}
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/undeploy-showcase-pr.yaml
+++ b/.github/workflows/undeploy-showcase-pr.yaml
@@ -31,7 +31,7 @@ jobs:
     # Job-level `if` cannot use `secrets`. Skip uninstall steps when secrets are unset (notice only).
     if: github.repository_owner == 'bcgov'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - id: openshift
         name: Preflight OpenShift secrets


### PR DESCRIPTION
Fixes #480 — container images pushed to GHCR now display correct OS/architecture metadata and carry full OCI image labels.

## Changes:
- Added `docker/setup-qemu-action@v4` — provides user-space CPU emulation so the `amd64` GitHub runners can cross-compile `arm64` layers
- Added `platforms: linux/amd64,linux/arm64` to every `docker/build-push-action` step
- Added `annotations: ${{ steps.meta.outputs.annotations }}` to every `docker/build-push-action` step — propagates OCI standard labels (`org.opencontainers.image.*`) to the manifest index
- Added `cache-from/cache-to: type=gha` — multi-arch builds are ~2× slower; GHA layer cache significantly reduces rebuild time on repeated pushes
- Bumped action versions: `actions/checkout@v6`, `docker/login-action@v4`, `docker/setup-buildx-action@v4`, `docker/metadata-action@v6`

- Pinned GitHub actions to SHAs with `pinact`

## NOTES:
- After this change, `unknown/unknown` entries will still appear in GHCR alongside `linux/amd64` and `linux/arm64`. These are the provenance and SBOM attestation manifests — they are intentional, spec-compliant OCI artifacts, not broken platform builds.

