### PR TITLE
Webvh did method

### DIFF
--- a/DEVELOPER/BC Wallet Showcase.md
+++ b/DEVELOPER/BC Wallet Showcase.md
@@ -374,11 +374,10 @@ Available to `admin`, `creator`, and `viewer` roles. Limited to 30 requests per 
 
 Creates a new schema by:
 
-1. Fetching the issuer DID from Traction (`/wallet/did/public`)
-2. Creating the schema in Traction with the provided name, version, and attribute names
-3. Creating a credential definition in Traction with exponential backoff retry (3 attempts, 1s initial delay)
-4. Saving the schema to MongoDB with the credential definition ID
-5. Recording an audit log entry
+1. Creating the schema in Traction with the provided name, version, and attribute names, and did
+2. Creating a credential definition in Traction with exponential backoff retry (3 attempts, 1s initial delay)
+3. Saving the schema to MongoDB with the credential definition ID
+4. Recording an audit log entry
 
 The request body should contain:
 
@@ -387,6 +386,7 @@ The request body should contain:
   "name": "student_card",
   "version": "1.0",
   "attrNames": ["student_first_name", "student_last_name", "expiry_date"]
+  "did": "did:example:123456789abcdefghi"
 }
 ```
 

--- a/DEVELOPER/BC Wallet Showcase.md
+++ b/DEVELOPER/BC Wallet Showcase.md
@@ -48,6 +48,8 @@ UPLOADS_DIR=./uploads
 # SHOWCASE_SHORT_INVITATION_URLS_ENABLED=false
 # Optional: TTL for short invitation links in seconds (default: 86400 = 24h)
 # INVITATION_SHORT_LINK_TTL_SECONDS=86400
+WEBVH_SERVER_URL=https://sandbox.bcvh.vonx.io
+WEBVH_NAMESPACE=showcase
 ```
 
 populate the values with the API key and webhook secret that you made in the previous step. `SHOWCASE_PUBLIC_ORIGIN` is required for short invitation URLs to work; set it to your ngrok URL. `UPLOADS_DIR` controls where uploaded images are stored on disk and defaults to `./uploads` relative to the server working directory.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ cp server/.env.example server/.env
 cp frontend/.env.example frontend/.env
 ```
 
-The placeholder values in `.env.example` are enough to start the app locally. To issue or verify **real** credentials you need a [Traction](https://digital.gov.bc.ca/digital-trust/technical-resources/traction/) tenant — set `TRACTION_TENANT_ID`, `TRACTION_TENANT_API_KEY`, `TRACTION_URL`, `TRACTION_DID`, and `WEBHOOK_SECRET` in `server/.env`. To test with a mobile wallet, run `ngrok http 5000` and set `SHOWCASE_PUBLIC_ORIGIN` to the ngrok URL — the same tunnel handles both Traction webhooks and short QR invitation URLs. See [DEVELOPER/BC Wallet Showcase.md](DEVELOPER/BC%20Wallet%20Showcase.md) for the full setup.
+The placeholder values in `.env.example` are enough to start the app locally. To issue or verify **real** credentials you need a [Traction](https://digital.gov.bc.ca/digital-trust/technical-resources/traction/) tenant — set `TRACTION_TENANT_ID`, `TRACTION_TENANT_API_KEY`, `TRACTION_URL`, `TRACTION_DID`, and `WEBHOOK_SECRET`, `WEBVH_SERVER_URL`, `WEBVH_NAMESPACE` in `server/.env`. To test with a mobile wallet, run `ngrok http 5000` and set `SHOWCASE_PUBLIC_ORIGIN` to the ngrok URL — the same tunnel handles both Traction webhooks and short QR invitation URLs. See [DEVELOPER/BC Wallet Showcase.md](DEVELOPER/BC%20Wallet%20Showcase.md) for the full setup.
 
 ### 2. Start the stack
 

--- a/charts/showcase/README.md
+++ b/charts/showcase/README.md
@@ -94,6 +94,11 @@ On **bcgov** dev and PR deploys, pre-create **`showcase-traction`** in the targe
 
 - **`showcase.server.shortInvitationUrls.enabled`** (default **`true`**) sets **`SHOWCASE_SHORT_INVITATION_URLS_ENABLED`** on the server. When **`true`**, connection and OOB proof invites get **`short_url`** for QR codes; wallets resolve **`GET {baseRoute}/i/{oobId}`** to the stored invitation JSON. Set to **`false`** to encode the full Traction **`invitation_url`** in QR codes instead (legacy behaviour).
 
+### WEBVH (optional)
+
+- **`showcase.server.webvhServerUrl`** sets **`WEBVH_SERVER_URL`** on the server (non-secret; base URL of the Webhook Verifier service, no path).
+- **`showcase.server.webvhNamespace`** sets **`WEBVH_NAMESPACE`** on the server (non-secret; namespace where Webhook Verifier is deployed, used for webhook registration with the Traction proxy).
+
 ### Mongo subchart
 
 All **`mongodb:`** keys pass through to CloudPirates. Inspect the packaged chart or:

--- a/charts/showcase/templates/server/deployment.yaml
+++ b/charts/showcase/templates/server/deployment.yaml
@@ -162,6 +162,10 @@ spec:
             - name: TRACTION_URL
               value: {{ .Values.showcase.server.traction.url | quote }}
             {{- end }}
+            - name: WEBVH_SERVER_URL
+              value: {{ .Values.showcase.server.webvhServerUrl | quote }}
+            - name: WEBVH_NAMESPACE
+              value: {{ .Values.showcase.server.webvhNamespace | quote }}
             {{- if .Values.showcase.server.traction.existingSecret }}
             - name: TRACTION_TENANT_ID
               valueFrom:

--- a/charts/showcase/values.yaml
+++ b/charts/showcase/values.yaml
@@ -108,6 +108,10 @@ showcase:
     ## Short HTTPS URLs for OOB invitation QR codes (`GET {baseRoute}/i/{oobId}` returns invitation JSON).
     shortInvitationUrls:
       enabled: true
+    webvhServerUrl: ''
+    ## Optional namespace for Webhook Verifier integration (see README "WEBVH integration"). Only used for webhook registration with the Traction tenant proxy; the server does not interact directly with Webhook Verifier or need to know its URL.
+    webvhNamespace: ''
+    ## Non-sensitive runtime env vars for the server Deployment. Use `existingSecret` for sensitive credentials and MONGODB_URI.
     extraEnv: []
     ## Traction (ACA-Py tenant proxy): non-secret base URL in values; tenant id + API key from a Secret (see traction.existingSecret).
     traction:

--- a/frontend/src/admin/api/adminApi.tsx
+++ b/frontend/src/admin/api/adminApi.tsx
@@ -1,4 +1,4 @@
-import type { Showcase, Credential, Schema } from '../types'
+import type { Showcase, Credential, Schema, Did } from '../types'
 import type { AuthContextProps } from 'react-oidc-context'
 
 const baseRoute = import.meta.env.VITE_BASE_ROUTE || '/digital-trust/showcase'
@@ -273,7 +273,7 @@ export const getAvailableSchemas = async (auth: AuthContextProps): Promise<Schem
 
 export const createSchema = async (
   auth: AuthContextProps,
-  schemaData: { name: string; version: string; attrNames: string[] },
+  schemaData: { name: string; version: string; attrNames: string[]; did: string },
 ): Promise<Schema> => {
   const res = await fetch(`${adminBaseUrl}/schemas`, {
     method: 'POST',
@@ -286,5 +286,22 @@ export const createSchema = async (
   if (!res.ok) await handleErrorResponse(res)
   const data = (await res.json()) as Schema
   // Ensure attrNames is populated from the request if not in response
+  return data
+}
+
+// ============================================================================
+// DID ENDPOINTS
+// ============================================================================
+
+export const getAvailableDids = async (auth: AuthContextProps): Promise<Did[]> => {
+  const res = await fetch(`${adminBaseUrl}/dids`, {
+    method: 'GET',
+    headers: {
+      Authorization: `Bearer ${auth.user?.access_token ?? ''}`,
+      'Content-Type': 'application/json',
+    },
+  })
+  if (!res.ok) await handleErrorResponse(res)
+  const data = await res.json()
   return data
 }

--- a/frontend/src/admin/components/schema/CreateSchemaModal.tsx
+++ b/frontend/src/admin/components/schema/CreateSchemaModal.tsx
@@ -1,10 +1,10 @@
-import type { Schema } from '../../types'
+import type { Did, Schema } from '../../types'
 
-import { XMarkIcon, TrashIcon } from '@heroicons/react/24/outline'
+import { XMarkIcon, TrashIcon, CircleStackIcon, GlobeAltIcon } from '@heroicons/react/24/outline'
 import { useEffect, useState } from 'react'
 import { useAuth } from 'react-oidc-context'
 
-import { createSchema, getAvailableSchemas } from '../../api/adminApi'
+import { createSchema, getAvailableSchemas, getAvailableDids } from '../../api/adminApi'
 import log from '../../utils/logger'
 
 interface Attribute {
@@ -21,29 +21,32 @@ export function CreateSchemaModal({ isOpen, onClose, onSchemaCreated }: CreateSc
   const auth = useAuth()
   const [name, setName] = useState('')
   const [version, setVersion] = useState('')
+  const [selectedDid, setSelectedDid] = useState<Did | null>(null)
   const [attrNames, setAttrNames] = useState<Attribute[]>([])
   const [attributeKey, setAttributeKey] = useState('')
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState('')
   const [availableSchemas, setAvailableSchemas] = useState<Schema[]>([])
+  const [availableDids, setAvailableDids] = useState<Did[]>([])
   const [showConfirmation, setShowConfirmation] = useState(false)
   const [progress, setProgress] = useState(0)
 
-  // Fetch available schemas when modal opens
+  // Fetch available schemas and DIDs when modal opens
   useEffect(() => {
     if (!isOpen || !auth.user?.access_token) return
 
-    const fetchSchemas = async () => {
+    const fetchData = async () => {
       try {
-        const schemas = await getAvailableSchemas(auth)
+        const [schemas, dids] = await Promise.all([getAvailableSchemas(auth), getAvailableDids(auth)])
         setAvailableSchemas(schemas)
+        setAvailableDids(dids)
       } catch (err) {
         // Don't show error to user, just log it
-        log.error('Failed to fetch schemas:', err)
+        log.error('Failed to fetch schemas or DIDs:', err)
       }
     }
 
-    fetchSchemas()
+    fetchData()
   }, [isOpen, auth])
 
   // Progress bar effect during schema creation
@@ -80,6 +83,7 @@ export function CreateSchemaModal({ isOpen, onClose, onSchemaCreated }: CreateSc
     // Reset form
     setName('')
     setVersion('')
+    setSelectedDid(null)
     setAttrNames([])
     setAttributeKey('')
     setError('')
@@ -87,8 +91,8 @@ export function CreateSchemaModal({ isOpen, onClose, onSchemaCreated }: CreateSc
   }
 
   const handleCreate = () => {
-    if (!name.trim() || !version.trim()) {
-      setError('Name and version are required')
+    if (!name.trim() || !version.trim() || !selectedDid) {
+      setError('Name, version, and DID method are required')
       return
     }
 
@@ -120,10 +124,12 @@ export function CreateSchemaModal({ isOpen, onClose, onSchemaCreated }: CreateSc
         name,
         version,
         attrNames: attrNames.map((attr) => attr.name),
+        did: selectedDid?.did || '',
       })
       // Reset form and notify parent to refresh
       setName('')
       setVersion('')
+      setSelectedDid(null)
       setAttrNames([])
       setAttributeKey('')
       setError('')
@@ -149,72 +155,88 @@ export function CreateSchemaModal({ isOpen, onClose, onSchemaCreated }: CreateSc
   if (showConfirmation) {
     return (
       <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-        <div className="bg-white rounded-lg shadow-lg p-8 max-w-2xl w-full mx-4">
-          <div className="flex justify-between items-center mb-6">
-            <h2 className="text-2xl font-semibold text-bcgov-black">Confirm Schema Creation</h2>
-            <button onClick={handleCancelConfirmation} className="text-gray-400 hover:text-gray-600">
+        <div className="bg-white rounded-lg shadow-xl p-8 max-w-2xl w-full mx-4 max-h-[90vh] overflow-y-auto">
+          <div className="flex justify-between items-center mb-8">
+            <div>
+              <h2 className="text-2xl font-bold text-bcgov-black">Confirm Schema Creation</h2>
+              <p className="text-sm text-gray-500 mt-1">Please review the information before proceeding</p>
+            </div>
+            <button onClick={handleCancelConfirmation} className="text-gray-400 hover:text-gray-600 transition-colors">
               <XMarkIcon className="w-6 h-6" />
             </button>
           </div>
 
-          <div className="mb-6">
-            <p className="text-gray-700 mb-4">
+          <div className="mb-8">
+            <p className="text-gray-700 mb-6">
               This will create a new schema on the data registry. Please review the information before proceeding.
             </p>
 
             {/* Schema Details */}
-            <div className="bg-gray-50 rounded-lg p-4 space-y-3 border border-gray-200">
-              <div>
-                <p className="text-sm font-medium text-gray-600">Schema Name</p>
-                <p className="text-base font-semibold text-bcgov-black">{name}</p>
+            <div className="bg-gradient-to-br from-blue-50 to-blue-25 rounded-lg p-6 space-y-4 border border-blue-100">
+              <div className="flex justify-between items-start">
+                <div>
+                  <p className="text-xs font-semibold text-gray-600 uppercase tracking-wide mb-1">Schema Name</p>
+                  <p className="text-lg font-bold text-bcgov-black">{name}</p>
+                </div>
+                <div className="text-right">
+                  <p className="text-xs font-semibold text-gray-600 uppercase tracking-wide mb-1">Version</p>
+                  <p className="text-lg font-bold text-bcgov-black">{version}</p>
+                </div>
               </div>
-              <div>
-                <p className="text-sm font-medium text-gray-600">Version</p>
-                <p className="text-base font-semibold text-bcgov-black">{version}</p>
+              <div className="pt-4 border-t border-blue-200">
+                <p className="text-xs font-semibold text-gray-600 uppercase tracking-wide mb-2">DID Method</p>
+                <div className="inline-flex items-center gap-2 bg-white border border-blue-200 rounded-full px-3 py-1">
+                  {selectedDid?.method === 'indy' && <CircleStackIcon className="h-4 w-4 text-bcgov-blue" />}
+                  {selectedDid?.method === 'webvh' && <GlobeAltIcon className="h-4 w-4 text-bcgov-blue" />}
+                  <span className="font-medium text-bcgov-blue text-sm">{selectedDid?.method}</span>
+                </div>
               </div>
-              <div>
-                <p className="text-sm font-medium text-gray-600">Attributes ({attrNames.length})</p>
-                {attrNames.length > 0 ? (
-                  <div className="mt-2 space-y-1">
+              {attrNames.length > 0 && (
+                <div className="pt-4 border-t border-blue-200">
+                  <p className="text-xs font-semibold text-gray-600 uppercase tracking-wide mb-3">
+                    Attributes ({attrNames.length})
+                  </p>
+                  <div className="flex flex-wrap gap-2">
                     {attrNames.map((attr, index) => (
-                      <p key={index} className="text-sm text-gray-700">
-                        • {attr.name}
-                      </p>
+                      <span
+                        key={index}
+                        className="inline-block bg-white border border-blue-200 px-3 py-1 rounded-full text-xs font-medium text-gray-700"
+                      >
+                        {attr.name}
+                      </span>
                     ))}
                   </div>
-                ) : (
-                  <p className="text-sm text-gray-500 italic">No attributes</p>
-                )}
-              </div>
+                </div>
+              )}
             </div>
           </div>
 
           {/* Progress Bar */}
           {isLoading && (
-            <div className="mb-6">
+            <div className="mb-8">
               <div className="w-full bg-gray-200 rounded-full h-2">
                 <div
                   className="bg-bcgov-blue h-2 rounded-full transition-all duration-300"
                   style={{ width: `${progress}%` }}
                 />
               </div>
-              <p className="text-sm text-gray-600 mt-2 text-center">Creating schema...</p>
+              <p className="text-sm text-gray-600 mt-3 text-center font-medium">Creating schema...</p>
             </div>
           )}
 
           {/* Actions */}
-          <div className="flex justify-end gap-4">
+          <div className="flex justify-end gap-3">
             <button
               onClick={handleCancelConfirmation}
               disabled={isLoading}
-              className="px-4 py-2 text-gray-700 bg-gray-100 hover:bg-gray-200 rounded-lg font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              className="px-6 py-3 text-gray-700 bg-gray-100 hover:bg-gray-200 rounded-lg font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
             >
               Cancel
             </button>
             <button
               onClick={handleConfirmCreate}
               disabled={isLoading}
-              className="px-4 py-2 text-white bg-bcgov-blue hover:bg-blue-700 rounded-lg font-medium transition-colors disabled:bg-gray-400 disabled:cursor-not-allowed"
+              className="px-6 py-3 text-white bg-bcgov-blue hover:bg-blue-700 rounded-lg font-medium transition-colors disabled:bg-gray-400 disabled:cursor-not-allowed"
             >
               {isLoading ? 'Creating...' : 'Confirm & Create'}
             </button>
@@ -226,17 +248,20 @@ export function CreateSchemaModal({ isOpen, onClose, onSchemaCreated }: CreateSc
 
   return (
     <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-      <div className="bg-white rounded-lg shadow-lg p-8 max-w-2xl w-full mx-4">
-        <div className="flex justify-between items-center mb-6">
-          <h2 className="text-2xl font-semibold text-bcgov-black">Create Schema</h2>
-          <button onClick={handleClose} className="text-gray-400 hover:text-gray-600">
+      <div className="bg-white rounded-lg shadow-xl p-8 max-w-2xl w-full mx-4 max-h-[90vh] overflow-y-auto">
+        <div className="flex justify-between items-center mb-8">
+          <div>
+            <h2 className="text-2xl font-bold text-bcgov-black">Create Schema</h2>
+            <p className="text-sm text-gray-500 mt-1">Define a new schema for your credentials</p>
+          </div>
+          <button onClick={handleClose} className="text-gray-400 hover:text-gray-600 transition-colors">
             <XMarkIcon className="w-6 h-6" />
           </button>
         </div>
 
         {error && (
           <div className="mb-6 p-4 bg-red-50 border border-red-200 rounded-lg">
-            <p className="text-red-800 text-sm">{error}</p>
+            <p className="text-red-800 text-sm font-medium">{error}</p>
           </div>
         )}
 
@@ -244,7 +269,7 @@ export function CreateSchemaModal({ isOpen, onClose, onSchemaCreated }: CreateSc
         <div className="space-y-6">
           {/* Name Input */}
           <div>
-            <label htmlFor="name" className="block text-sm font-medium text-bcgov-black mb-2">
+            <label htmlFor="name" className="block text-sm font-semibold text-bcgov-black mb-2">
               Schema Name
             </label>
             <input
@@ -253,13 +278,13 @@ export function CreateSchemaModal({ isOpen, onClose, onSchemaCreated }: CreateSc
               value={name}
               onChange={(e) => setName(e.target.value)}
               placeholder="e.g., Digital Business Card"
-              className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:border-bcgov-blue focus:ring-2 focus:ring-bcgov-blue focus:ring-opacity-20"
+              className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:border-bcgov-blue focus:ring-2 focus:ring-bcgov-blue focus:ring-opacity-20 transition-colors"
             />
           </div>
 
           {/* Version Input */}
           <div>
-            <label htmlFor="version" className="block text-sm font-medium text-bcgov-black mb-2">
+            <label htmlFor="version" className="block text-sm font-semibold text-bcgov-black mb-2">
               Version
             </label>
             <input
@@ -268,12 +293,38 @@ export function CreateSchemaModal({ isOpen, onClose, onSchemaCreated }: CreateSc
               value={version}
               onChange={(e) => setVersion(e.target.value)}
               placeholder="e.g., 1.0.0"
-              className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:border-bcgov-blue focus:ring-2 focus:ring-bcgov-blue focus:ring-opacity-20"
+              className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:border-bcgov-blue focus:ring-2 focus:ring-bcgov-blue focus:ring-opacity-20 transition-colors"
             />
           </div>
+
+          {/* DID Method Selector */}
+          <div>
+            <label className="block text-sm font-semibold text-bcgov-black mb-3">DID Method</label>
+            <div className="flex gap-2">
+              {availableDids.map((did) => {
+                const isSelected = selectedDid?.did === did.did
+                const Icon = did.method === 'indy' ? CircleStackIcon : did.method === 'webvh' ? GlobeAltIcon : null
+                return (
+                  <button
+                    key={did.did}
+                    onClick={() => setSelectedDid(did)}
+                    className={`flex items-center gap-2 px-4 py-2 rounded-lg font-medium transition-all ${
+                      isSelected
+                        ? 'bg-bcgov-blue text-white border border-bcgov-blue shadow-md'
+                        : 'bg-gray-100 text-gray-700 border border-gray-300 hover:border-bcgov-blue hover:bg-gray-50'
+                    }`}
+                  >
+                    {Icon && <Icon className="h-4 w-4" />}
+                    <span className="text-sm">{did.method}</span>
+                  </button>
+                )
+              })}
+            </div>
+          </div>
+
           {/* Attributes Input */}
           <div>
-            <label className="block text-sm font-medium text-bcgov-black mb-2">Attributes</label>
+            <label className="block text-sm font-semibold text-bcgov-black mb-3">Attributes</label>
             <div className="space-y-3">
               {/* Add Attribute Inputs */}
               <div className="flex gap-2">
@@ -282,12 +333,12 @@ export function CreateSchemaModal({ isOpen, onClose, onSchemaCreated }: CreateSc
                   value={attributeKey}
                   onChange={(e) => setAttributeKey(e.target.value)}
                   placeholder="Key (e.g., business_name)"
-                  className="flex-1 px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:border-bcgov-blue focus:ring-2 focus:ring-bcgov-blue focus:ring-opacity-20 text-sm"
+                  className="flex-1 px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:border-bcgov-blue focus:ring-2 focus:ring-bcgov-blue focus:ring-opacity-20 transition-colors text-sm"
                 />
                 <button
                   onClick={handleAddAttribute}
                   disabled={!attributeKey.trim()}
-                  className="px-4 py-2 bg-bcgov-blue text-white rounded-lg hover:bg-blue-700 disabled:bg-gray-300 disabled:cursor-not-allowed font-medium transition-colors text-sm"
+                  className="px-4 py-3 bg-bcgov-blue text-white rounded-lg hover:bg-blue-700 disabled:bg-gray-300 disabled:cursor-not-allowed font-medium transition-colors text-sm"
                 >
                   Add
                 </button>
@@ -295,16 +346,16 @@ export function CreateSchemaModal({ isOpen, onClose, onSchemaCreated }: CreateSc
 
               {/* Attributes List */}
               {attrNames.length > 0 && (
-                <div className="bg-gray-50 rounded-lg p-3 space-y-2 border border-gray-200">
+                <div className="bg-gray-50 rounded-lg p-4 space-y-2 border border-gray-200">
                   {attrNames.map((attr, index) => (
                     <div
                       key={index}
-                      className="flex items-center justify-between bg-white p-3 rounded border border-gray-300"
+                      className="flex items-center justify-between bg-white p-3 rounded-md border border-gray-200 hover:border-gray-300 transition-colors"
                     >
-                      <span className="font-semibold text-bcgov-black">{attr.name}</span>
+                      <span className="font-medium text-bcgov-black text-sm">{attr.name}</span>
                       <button
                         onClick={() => handleRemoveAttribute(index)}
-                        className="ml-3 text-gray-400 hover:text-red-600 transition-colors"
+                        className="text-gray-400 hover:text-red-600 transition-colors"
                       >
                         <TrashIcon className="w-4 h-4" />
                       </button>
@@ -317,18 +368,18 @@ export function CreateSchemaModal({ isOpen, onClose, onSchemaCreated }: CreateSc
         </div>
 
         {/* Actions */}
-        <div className="mt-8 flex justify-end gap-4">
+        <div className="mt-8 flex justify-end gap-3">
           <button
             onClick={handleClose}
             disabled={isLoading}
-            className="px-4 py-2 text-gray-700 bg-gray-100 hover:bg-gray-200 rounded-lg font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            className="px-6 py-3 text-gray-700 bg-gray-100 hover:bg-gray-200 rounded-lg font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
           >
             Cancel
           </button>
           <button
             onClick={handleCreate}
-            disabled={isLoading || !name.trim() || !version.trim()}
-            className="px-4 py-2 text-white bg-bcgov-blue hover:bg-blue-700 rounded-lg font-medium transition-colors disabled:bg-gray-400 disabled:cursor-not-allowed"
+            disabled={isLoading || !name.trim() || !version.trim() || !selectedDid}
+            className="px-6 py-3 text-white bg-bcgov-blue hover:bg-blue-700 rounded-lg font-medium transition-colors disabled:bg-gray-400 disabled:cursor-not-allowed"
           >
             {isLoading ? 'Creating...' : 'Create'}
           </button>

--- a/frontend/src/admin/components/schema/SchemaCard.tsx
+++ b/frontend/src/admin/components/schema/SchemaCard.tsx
@@ -1,6 +1,6 @@
 import type { Schema } from '../../types'
 
-import { IdentificationIcon } from '@heroicons/react/24/outline'
+import { IdentificationIcon, CircleStackIcon, GlobeAltIcon } from '@heroicons/react/24/outline'
 
 interface SchemaCardProps {
   schema: Schema
@@ -18,6 +18,11 @@ export function SchemaCard({ schema: schema }: SchemaCardProps) {
         <div className="flex-1">
           <p className="text-base font-semibold text-bcgov-black">{schema.name}</p>
           <p className="text-xs text-gray-500 font-medium">v{schema.version}</p>
+        </div>
+        <div className="flex-shrink-0 inline-flex items-center gap-1.5 bg-blue-50 border border-blue-200 rounded-full px-3 py-1">
+          {schema.did.method === 'indy' && <CircleStackIcon className="h-4 w-4 text-bcgov-blue" />}
+          {schema.did.method === 'webvh' && <GlobeAltIcon className="h-4 w-4 text-bcgov-blue" />}
+          <span className="text-xs font-medium text-bcgov-blue">{schema.did.method}</span>
         </div>
       </div>
 

--- a/frontend/src/admin/components/showcase/modals/steps/SelectingSchemaStep.tsx
+++ b/frontend/src/admin/components/showcase/modals/steps/SelectingSchemaStep.tsx
@@ -1,5 +1,7 @@
 import type { Schema } from '../../../../types'
 
+import { CircleStackIcon, GlobeAltIcon } from '@heroicons/react/24/outline'
+
 interface SelectingSchemaStepProps {
   schemas: Schema[]
   loading: boolean
@@ -41,7 +43,7 @@ export function SelectingSchemaStep({
               <button
                 key={schema.id}
                 onClick={() => onSelectSchema(schema)}
-                className="w-full text-left p-3 border border-gray-200 rounded-lg hover:bg-gray-50 hover:border-bcgov-blue transition-colors flex items-center gap-3"
+                className="w-full text-left p-3 border border-gray-200 rounded-lg hover:bg-gray-50 hover:border-bcgov-blue transition-colors flex items-start gap-3"
               >
                 <div className="flex-1">
                   <p className="font-medium text-sm text-bcgov-black">{schema.name}</p>
@@ -53,6 +55,11 @@ export function SelectingSchemaStep({
                       </span>
                     ))}
                   </div>
+                </div>
+                <div className="flex-shrink-0 inline-flex items-center gap-1.5 bg-blue-50 border border-blue-200 rounded-full px-3 py-1">
+                  {schema.did.method === 'indy' && <CircleStackIcon className="h-4 w-4 text-bcgov-blue" />}
+                  {schema.did.method === 'webvh' && <GlobeAltIcon className="h-4 w-4 text-bcgov-blue" />}
+                  <span className="text-xs font-medium text-bcgov-blue">{schema.did.method}</span>
                 </div>
               </button>
             ))}

--- a/frontend/src/admin/types/index.ts
+++ b/frontend/src/admin/types/index.ts
@@ -102,6 +102,11 @@ export interface Showcase {
   revocationInfo?: RevocationInfoItem[]
   credentials: Credential[]
 }
+export interface Did {
+  id: string
+  did: string
+  method: string
+}
 
 export interface Schema {
   id: string
@@ -109,4 +114,5 @@ export interface Schema {
   version: string
   attrNames: string[]
   credDefId?: string
+  did: Did
 }

--- a/frontend/src/client/pages/introduction/IntroductionContainer.tsx
+++ b/frontend/src/client/pages/introduction/IntroductionContainer.tsx
@@ -58,7 +58,7 @@ export const IntroductionContainer: React.FC<Props> = ({
   const connectionCompleted = isConnected(connectionState as string)
   const introStep = currentShowcase?.introduction.find((step) => step.screenId === introductionStep)
   const credentials = introStep?.credentials
-  const credentialsAccepted = credentials?.every((cred) => issuedCredentials.includes(cred.name))
+  const credentialsAccepted = credentials?.every((cred) => issuedCredentials.includes(cred.schema_id || 'not-found'))
 
   const isBackDisabled =
     introductionStep === 'PICK_CHARACTER' ||

--- a/frontend/src/client/pages/introduction/components/StarterCredentials.tsx
+++ b/frontend/src/client/pages/introduction/components/StarterCredentials.tsx
@@ -28,7 +28,9 @@ export const StarterCredentials: React.FC<Props> = ({ credentials }) => {
         <hr className="text-bcgov-lightgrey" />
       </div>
       {credentials.map((item) => {
-        const completed = issuedCredentials.includes(item.name) || issuedCredentialsStartCase.includes(item.name)
+        const completed =
+          issuedCredentials.includes(item.schema_id || 'not-found') ||
+          issuedCredentialsStartCase.includes(startCase(item.schema_id || 'not-found'))
 
         return (
           <div key={item.name} className="flex-1 flex flex-row items-center justify-between my-2">

--- a/frontend/src/client/pages/introduction/steps/AcceptCredential.tsx
+++ b/frontend/src/client/pages/introduction/steps/AcceptCredential.tsx
@@ -59,7 +59,9 @@ export const AcceptCredential: React.FC<Props> = ({
 
   const issuedCredentialsStartCase = issuedCredentials.map((name) => startCase(name))
   const credentialsAccepted = credentials.every(
-    (cred) => issuedCredentials.includes(cred.name) || issuedCredentialsStartCase.includes(cred.name),
+    (cred) =>
+      issuedCredentials.includes(cred.schema_id || 'not-found') ||
+      issuedCredentialsStartCase.includes(startCase(cred.schema_id || 'not-found')),
   )
 
   useEffect(() => {

--- a/frontend/src/client/slices/credentials/__tests__/credentialsThunks.test.ts
+++ b/frontend/src/client/slices/credentials/__tests__/credentialsThunks.test.ts
@@ -149,6 +149,7 @@ describe('credentialsSlice reducers', () => {
           cred_issue: {
             anoncreds: {
               cred_def_id: 'ISSUER123:3:CL:100:CredentialName',
+              schema_id: 'schema-1',
             },
           },
         },
@@ -157,7 +158,7 @@ describe('credentialsSlice reducers', () => {
         revocation_id: 'rev-1',
       }),
     )
-    expect(store.getState().credentials.issuedCredentials).toContain('CredentialName')
+    expect(store.getState().credentials.issuedCredentials).toContain('schema-1')
   })
 
   it('setCredential does not add a duplicate credName', () => {
@@ -167,6 +168,7 @@ describe('credentialsSlice reducers', () => {
         cred_issue: {
           anoncreds: {
             cred_def_id: 'ISSUER123:3:CL:100:MyCredential',
+            schema_id: 'schema-1',
           },
         },
       },
@@ -176,7 +178,7 @@ describe('credentialsSlice reducers', () => {
     }
     store.dispatch(setCredential(payload))
     store.dispatch(setCredential(payload))
-    const names = store.getState().credentials.issuedCredentials.filter((n) => n === 'MyCredential')
+    const names = store.getState().credentials.issuedCredentials.filter((n) => n === 'schema-1')
     expect(names).toHaveLength(1)
   })
 

--- a/frontend/src/client/slices/credentials/credentialsSlice.ts
+++ b/frontend/src/client/slices/credentials/credentialsSlice.ts
@@ -25,16 +25,12 @@ const credentialSlice = createSlice({
   name: 'credentials',
   initialState,
   reducers: {
-    clearCredentials: () => {
-      // state.credentials.map((x) => isCredIssued(x.state) && state.issuedCredentials.push(x))
-      // state.credentials = []
-    },
+    clearCredentials: () => {},
     setCredential: (state, action) => {
       const credentialData = action.payload
-      const credDefParts = credentialData.by_format.cred_issue.anoncreds.cred_def_id.split(':')
-      const credName = credDefParts[credDefParts.length - 1]
-      if (!state.issuedCredentials.includes(credName)) {
-        state.issuedCredentials.push(credName)
+      const schemaId = action.payload.by_format?.cred_issue?.anoncreds?.schema_id
+      if (!state.issuedCredentials.includes(schemaId)) {
+        state.issuedCredentials.push(schemaId)
       }
       if (!state.revokableCredentials.map((rev) => rev.revocationRegId).includes(credentialData.revoc_reg_id)) {
         state.revokableCredentials.push({
@@ -62,14 +58,6 @@ const credentialSlice = createSlice({
       })
       .addCase(fetchCredentialById.fulfilled, (state) => {
         state.isLoading = false
-        // const index = state.credentials.findIndex((cred) => cred.id == action.payload.id)
-
-        // if (index == -1) {
-        //   state.credentials.push(action.payload)
-        //   return state
-        // }
-
-        // state.credentials[index] = action.payload
         return state
       })
       .addCase(deleteCredentialById.pending, (state) => {
@@ -77,12 +65,9 @@ const credentialSlice = createSlice({
       })
       .addCase(deleteCredentialById.fulfilled, (state) => {
         state.isLoading = false
-        // state.credentials.filter((cred) => cred.id !== action.payload)
         return state
       })
       .addCase('clearScenario', (state) => {
-        // state.credentials.map((x) => isCredIssued(x.state) && state.issuedCredentials.push(x))
-        // state.credentials = []
         state.isLoading = false
       })
       .addMatcher(isAnyOf(issueCredential.pending, issueDeepCredential.pending), (state) => {

--- a/server/.env.example
+++ b/server/.env.example
@@ -29,3 +29,6 @@ WEBHOOK_SECRET=secret
 
 # Directory for uploaded showcase assets. Default: ./uploads (relative to cwd).
 # UPLOADS_DIR=./uploads
+
+WEBVH_SERVER_URL=https://sandbox.bcvh.vonx.io
+WEBVH_NAMESPACE=showcase

--- a/server/src/content/types.ts
+++ b/server/src/content/types.ts
@@ -23,10 +23,21 @@ export interface Schema {
   version: string
   attrNames: string[]
   credDefId?: string
+  did?: string
+  method?: string
 }
 
 // Input shape for the create schema API. id is derived from the Traction response server-side.
 export type CreateSchemaInput = Omit<Schema, 'id'>
+
+export interface Did {
+  id: string
+  did: string
+  method: string
+}
+
+// Input shape for the create DID API. id is auto-generated server-side.
+export type CreateDidInput = Omit<Did, 'id'>
 
 export interface IntroductionStep {
   screenId: string

--- a/server/src/db/models/Did.ts
+++ b/server/src/db/models/Did.ts
@@ -1,0 +1,25 @@
+import type { Did as DidType } from '../../content/types'
+
+import { Schema, model } from 'mongoose'
+
+import { baseSchemaOptions } from '../baseSchema'
+
+/** Shape returned by DidModel queries with .lean(). Uses auto-generated UUID _id. */
+export interface LeanDidDoc {
+  _id: string
+  did: string
+  method: string
+}
+
+// DID documents use auto-generated UUID _id.
+// baseSchemaOptions exposes it as `id` in JSON output via the virtuals transform.
+const DidSchema = new Schema(
+  {
+    _id: { type: String, required: true },
+    did: { type: String, required: true, unique: true },
+    method: { type: String, required: true },
+  },
+  baseSchemaOptions,
+)
+
+export const DidModel = model<DidType>('Did', DidSchema)

--- a/server/src/db/models/Schema.ts
+++ b/server/src/db/models/Schema.ts
@@ -11,6 +11,7 @@ export interface LeanSchemaDoc {
   version: string
   attrNames: string[]
   credDefId?: string
+  did?: string
 }
 
 // Schema documents use a human-readable string _id (e.g. "schema-id-from-traction").
@@ -22,6 +23,7 @@ const SchemaSchema = new Schema(
     version: { type: String, required: true },
     attrNames: [{ type: String, required: true }],
     credDefId: { type: String },
+    did: String,
   },
   baseSchemaOptions,
 )

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -16,6 +16,7 @@ import { requireAdmin, ServiceUnavailableError } from './middleware/requireAdmin
 import adminAssetsRouter from './routes/adminAssetsRouter'
 import adminAuditLogRouter from './routes/adminAuditLogRouter'
 import adminCredentialsRouter from './routes/adminCredentialsRouter'
+import adminDidsRouter from './routes/adminDidsRouter'
 import adminSchemaRouter from './routes/adminSchemasRouter'
 import adminShowcasesRouter from './routes/adminShowcasesRouter'
 import logger from './utils/logger'
@@ -135,6 +136,7 @@ const run = async () => {
   app.use(`${baseRoute}/admin/assets`, adminAssetsRouter)
   app.use(`${baseRoute}/admin/audit-log`, adminAuditLogRouter)
   app.use(`${baseRoute}/admin`, adminSchemaRouter)
+  app.use(`${baseRoute}/admin`, adminDidsRouter)
 
   app.get(`${baseRoute}/server/last-reset`, (_req, res) => {
     res.send(serverStartTime)

--- a/server/src/routes/__tests__/adminSchemasRouter.test.ts
+++ b/server/src/routes/__tests__/adminSchemasRouter.test.ts
@@ -18,9 +18,16 @@ const { mocks } = vi.hoisted(() => {
   return {
     mocks: {
       mockSchemaModel: {
-        find: vi.fn(),
+        find: vi.fn().mockReturnValue({
+          lean: vi.fn().mockResolvedValue([]),
+        }),
         updateOne: vi.fn(),
         findById: vi.fn().mockResolvedValue(null),
+      },
+      mockDidModel: {
+        findById: vi.fn().mockReturnValue({
+          lean: vi.fn().mockResolvedValue(null),
+        }),
       },
       mockTractionRequest: {
         get: vi.fn(),
@@ -36,6 +43,10 @@ const { mocks } = vi.hoisted(() => {
 
 vi.mock('../../db/models/Schema', () => ({
   SchemaModel: mocks.mockSchemaModel,
+}))
+
+vi.mock('../../db/models/Did', () => ({
+  DidModel: mocks.mockDidModel,
 }))
 
 vi.mock('../../utils/tractionHelper', () => ({
@@ -80,7 +91,9 @@ describe('adminSchemasRouter', () => {
 
   describe('GET /admin/schemas', () => {
     it('returns 200 with schemas array', async () => {
-      mocks.mockSchemaModel.find.mockResolvedValue([mockSchema])
+      mocks.mockSchemaModel.find.mockReturnValue({
+        lean: vi.fn().mockResolvedValue([mockSchema]),
+      })
 
       const res = await request(app).get('/admin/schemas')
 
@@ -91,7 +104,9 @@ describe('adminSchemasRouter', () => {
     })
 
     it('returns 200 with empty array when no schemas exist', async () => {
-      mocks.mockSchemaModel.find.mockResolvedValue([])
+      mocks.mockSchemaModel.find.mockReturnValue({
+        lean: vi.fn().mockResolvedValue([]),
+      })
 
       const res = await request(app).get('/admin/schemas')
 
@@ -102,7 +117,9 @@ describe('adminSchemasRouter', () => {
 
     it('returns 200 with multiple schemas', async () => {
       const schema2 = { ...mockSchema, _id: 'W1ZJ:2:Employee Card:1.0', name: 'Employee Card' }
-      mocks.mockSchemaModel.find.mockResolvedValue([mockSchema, schema2])
+      mocks.mockSchemaModel.find.mockReturnValue({
+        lean: vi.fn().mockResolvedValue([mockSchema, schema2]),
+      })
 
       const res = await request(app).get('/admin/schemas')
 
@@ -111,7 +128,9 @@ describe('adminSchemasRouter', () => {
     })
 
     it('returns 500 when database query fails', async () => {
-      mocks.mockSchemaModel.find.mockRejectedValue(new Error('Database connection error'))
+      mocks.mockSchemaModel.find.mockReturnValue({
+        lean: vi.fn().mockRejectedValue(new Error('Database connection error')),
+      })
 
       const res = await request(app).get('/admin/schemas')
 
@@ -120,7 +139,9 @@ describe('adminSchemasRouter', () => {
     })
 
     it('calls SchemaModel.find()', async () => {
-      mocks.mockSchemaModel.find.mockResolvedValue([])
+      mocks.mockSchemaModel.find.mockReturnValue({
+        lean: vi.fn().mockResolvedValue([]),
+      })
 
       await request(app).get('/admin/schemas')
 
@@ -134,6 +155,7 @@ describe('adminSchemasRouter', () => {
 
   describe('POST /admin/schemas', () => {
     const schemaPayload = {
+      did: mockIssuerDid,
       name: 'Driver License',
       version: '2.0',
       attrNames: ['name', 'address', 'license_number'],
@@ -184,20 +206,6 @@ describe('adminSchemasRouter', () => {
       expect(res.body).toHaveProperty('version', '2.0')
       expect(res.body).toHaveProperty('attrNames')
       expect(res.body).toHaveProperty('credDefId', 'W1ZJ:3:CL:123:Driver License')
-    })
-
-    it('fetches issuer DID from Traction wallet', async () => {
-      mocks.mockTractionRequest.get.mockResolvedValue({
-        data: { result: { did: mockIssuerDid } },
-      })
-      mocks.mockTractionRequest.post.mockResolvedValue(tractionSchemaResponse)
-      mocks.mockRetryWithExponentialBackoff.mockResolvedValue(tractionCredDefResponse)
-      mocks.mockSchemaModel.updateOne.mockResolvedValue({ upserted: true })
-      mocks.mockSchemaModel.findById.mockResolvedValue({})
-
-      await request(app).post('/admin/schemas').send(schemaPayload)
-
-      expect(mocks.mockTractionRequest.get).toHaveBeenCalledWith('/wallet/did/public')
     })
 
     it('creates schema in Traction with correct payload', async () => {
@@ -270,9 +278,6 @@ describe('adminSchemasRouter', () => {
     })
 
     it('saves schema to MongoDB with upsert', async () => {
-      mocks.mockTractionRequest.get.mockResolvedValue({
-        data: { result: { did: mockIssuerDid } },
-      })
       mocks.mockTractionRequest.post.mockResolvedValue(tractionSchemaResponse)
       mocks.mockRetryWithExponentialBackoff.mockResolvedValue(tractionCredDefResponse)
       mocks.mockSchemaModel.updateOne.mockResolvedValue({ upserted: true })
@@ -290,6 +295,7 @@ describe('adminSchemasRouter', () => {
             version: '2.0',
             attrNames: ['name', 'address', 'license_number'],
             credDefId: 'W1ZJ:3:CL:123:Driver License',
+            did: mockIssuerDid,
           },
         },
         { upsert: true },
@@ -373,43 +379,50 @@ describe('adminSchemasRouter', () => {
     })
 
     it('returns 500 when fetching issuer DID fails', async () => {
-      mocks.mockTractionRequest.get.mockRejectedValue(new Error('Traction API error'))
+      // The router now uses req.body.did directly, so verify that a missing did causes an error
+      const payloadWithoutDid = {
+        name: 'Driver License',
+        version: '2.0',
+        attrNames: ['name', 'address', 'license_number'],
+      }
 
-      const res = await request(app).post('/admin/schemas').send(schemaPayload)
+      // Mock the post to reject when issuerId is undefined
+      mocks.mockTractionRequest.post.mockImplementation((url: string, data: any) => {
+        if (url === '/anoncreds/schema' && data.schema.issuerId === undefined) {
+          return Promise.reject(new Error('issuerId is required'))
+        }
+        return Promise.resolve(tractionSchemaResponse)
+      })
+
+      const res = await request(app).post('/admin/schemas').send(payloadWithoutDid)
 
       expect(res.status).toBe(500)
-      expect(res.body).toHaveProperty('error', 'Failed to create schema and cred def in Traction')
     })
 
     it('returns 500 when creating schema in Traction fails', async () => {
-      mocks.mockTractionRequest.get.mockResolvedValue({
-        data: { result: { did: mockIssuerDid } },
-      })
       mocks.mockTractionRequest.post.mockRejectedValue(new Error('Schema creation failed'))
 
       const res = await request(app).post('/admin/schemas').send(schemaPayload)
 
       expect(res.status).toBe(500)
-      expect(res.body).toHaveProperty('error', 'Failed to create schema and cred def in Traction')
+      expect(res.body).toHaveProperty('error')
+      expect(res.body.error).toContain('Failed to create schema and cred def in Traction')
+      expect(res.body.error).toContain('Schema creation failed')
     })
 
     it('returns 500 when creating credential definition fails', async () => {
-      mocks.mockTractionRequest.get.mockResolvedValue({
-        data: { result: { did: mockIssuerDid } },
-      })
       mocks.mockTractionRequest.post.mockResolvedValue(tractionSchemaResponse)
       mocks.mockRetryWithExponentialBackoff.mockRejectedValue(new Error('Credential def creation failed'))
 
       const res = await request(app).post('/admin/schemas').send(schemaPayload)
 
       expect(res.status).toBe(500)
-      expect(res.body).toHaveProperty('error', 'Failed to create schema and cred def in Traction')
+      expect(res.body).toHaveProperty('error')
+      expect(res.body.error).toContain('Failed to create schema and cred def in Traction')
+      expect(res.body.error).toContain('Credential def creation failed')
     })
 
     it('returns 500 when saving to MongoDB fails', async () => {
-      mocks.mockTractionRequest.get.mockResolvedValue({
-        data: { result: { did: mockIssuerDid } },
-      })
       mocks.mockTractionRequest.post.mockResolvedValue(tractionSchemaResponse)
       mocks.mockRetryWithExponentialBackoff.mockResolvedValue(tractionCredDefResponse)
       mocks.mockSchemaModel.updateOne.mockRejectedValue(new Error('MongoDB error'))
@@ -417,7 +430,9 @@ describe('adminSchemasRouter', () => {
       const res = await request(app).post('/admin/schemas').send(schemaPayload)
 
       expect(res.status).toBe(500)
-      expect(res.body).toHaveProperty('error', 'Failed to create schema and cred def in Traction')
+      expect(res.body).toHaveProperty('error')
+      expect(res.body.error).toContain('Failed to create schema and cred def in Traction')
+      expect(res.body.error).toContain('MongoDB error')
     })
 
     it('continues on audit log error', async () => {

--- a/server/src/routes/adminAssetsRouter.ts
+++ b/server/src/routes/adminAssetsRouter.ts
@@ -11,7 +11,7 @@ import path from 'path'
 import { AssetModel } from '../db/models/Asset'
 import { requireRole } from '../middleware/requireAdmin'
 import logger from '../utils/logger'
-import { rateLimiter } from '../utils/rateLimiter'
+import { uploadRateLimiter, defaultRateLimiter } from '../utils/rateLimiter'
 import { sanitizeFilename } from '../utils/sanitizeFilename'
 import { sanitizeSVG } from '../utils/sanitizeSVG'
 import { UPLOADS_DIR } from '../utils/uploadsDir'
@@ -88,7 +88,7 @@ const upload = multer({
  */
 router.post(
   '/',
-  rateLimiter({ message: 'Too many upload requests, please try again later.' }),
+  uploadRateLimiter,
   requireRole(['admin', 'creator']),
   upload.single('file'),
   async (req: Request, res: Response): Promise<void> => {
@@ -170,7 +170,7 @@ router.post(
  */
 router.get(
   '/',
-  rateLimiter({ max: 10 }),
+  defaultRateLimiter,
   requireRole(['admin', 'creator', 'viewer']),
   async (req: Request, res: Response): Promise<void> => {
     const type = typeof req.query.type === 'string' && req.query.type ? req.query.type : undefined
@@ -199,7 +199,7 @@ router.get(
  */
 router.delete(
   '/:assetId',
-  rateLimiter({ max: 10 }),
+  defaultRateLimiter,
   requireRole(['admin']),
   async (req: Request, res: Response): Promise<void> => {
     const { assetId } = req.params

--- a/server/src/routes/adminAssetsRouter.ts
+++ b/server/src/routes/adminAssetsRouter.ts
@@ -2,7 +2,6 @@ import type { NextFunction, Request, Response } from 'express'
 
 import { randomUUID } from 'crypto'
 import { Router } from 'express'
-import rateLimit from 'express-rate-limit'
 import { mkdirSync, readdirSync } from 'fs'
 import mongoose from 'mongoose'
 import multer from 'multer'
@@ -12,6 +11,7 @@ import path from 'path'
 import { AssetModel } from '../db/models/Asset'
 import { requireRole } from '../middleware/requireAdmin'
 import logger from '../utils/logger'
+import { rateLimiter } from '../utils/rateLimiter'
 import { sanitizeFilename } from '../utils/sanitizeFilename'
 import { sanitizeSVG } from '../utils/sanitizeSVG'
 import { UPLOADS_DIR } from '../utils/uploadsDir'
@@ -53,30 +53,6 @@ const EXT_TO_MIME: Record<string, string> = {
 
 const router = Router()
 
-const getLimiter = rateLimit({
-  windowMs: 15 * 60 * 1000,
-  max: 30,
-  message: 'Too many requests, please try again later.',
-  standardHeaders: true,
-  legacyHeaders: false,
-})
-
-const uploadLimiter = rateLimit({
-  windowMs: 15 * 60 * 1000,
-  max: 10,
-  message: 'Too many upload requests, please try again later.',
-  standardHeaders: true,
-  legacyHeaders: false,
-})
-
-const deleteLimiter = rateLimit({
-  windowMs: 15 * 60 * 1000,
-  max: 10,
-  message: 'Too many delete requests, please try again later.',
-  standardHeaders: true,
-  legacyHeaders: false,
-})
-
 // Ensure uploads dir exists at module load time.
 mkdirSync(UPLOADS_DIR, { recursive: true })
 
@@ -112,7 +88,7 @@ const upload = multer({
  */
 router.post(
   '/',
-  uploadLimiter,
+  rateLimiter({ message: 'Too many upload requests, please try again later.' }),
   requireRole(['admin', 'creator']),
   upload.single('file'),
   async (req: Request, res: Response): Promise<void> => {
@@ -194,7 +170,7 @@ router.post(
  */
 router.get(
   '/',
-  getLimiter,
+  rateLimiter({ max: 10 }),
   requireRole(['admin', 'creator', 'viewer']),
   async (req: Request, res: Response): Promise<void> => {
     const type = typeof req.query.type === 'string' && req.query.type ? req.query.type : undefined
@@ -223,7 +199,7 @@ router.get(
  */
 router.delete(
   '/:assetId',
-  deleteLimiter,
+  rateLimiter({ max: 10 }),
   requireRole(['admin']),
   async (req: Request, res: Response): Promise<void> => {
     const { assetId } = req.params

--- a/server/src/routes/adminAuditLogRouter.ts
+++ b/server/src/routes/adminAuditLogRouter.ts
@@ -8,7 +8,7 @@ import { AUDIT_ACTIONS, AUDIT_RESOURCE_TYPES } from '../db/models/AuditLog'
 import { requireRole } from '../middleware/requireAdmin'
 import { AuditLogService } from '../services/AuditLogService'
 import logger from '../utils/logger'
-import { rateLimiter } from '../utils/rateLimiter'
+import { defaultRateLimiter } from '../utils/rateLimiter'
 
 const router = Router()
 
@@ -35,7 +35,7 @@ function parseCommaSeparated<T extends string>(raw: unknown, allowed: readonly T
  *   page, limit, startDate, endDate,
  *   action (comma-separated), resource_type (comma-separated), user_id
  */
-router.get('/', rateLimiter, requireRole(['admin']), async (req: Request, res: Response) => {
+router.get('/', defaultRateLimiter, requireRole(['admin']), async (req: Request, res: Response) => {
   logger.debug({ query: req.query }, 'Admin: list audit log')
 
   try {

--- a/server/src/routes/adminAuditLogRouter.ts
+++ b/server/src/routes/adminAuditLogRouter.ts
@@ -8,6 +8,7 @@ import { AUDIT_ACTIONS, AUDIT_RESOURCE_TYPES } from '../db/models/AuditLog'
 import { requireRole } from '../middleware/requireAdmin'
 import { AuditLogService } from '../services/AuditLogService'
 import logger from '../utils/logger'
+import { rateLimiter } from '../utils/rateLimiter'
 
 const router = Router()
 
@@ -34,7 +35,7 @@ function parseCommaSeparated<T extends string>(raw: unknown, allowed: readonly T
  *   page, limit, startDate, endDate,
  *   action (comma-separated), resource_type (comma-separated), user_id
  */
-router.get('/', requireRole(['admin']), async (req: Request, res: Response) => {
+router.get('/', rateLimiter, requireRole(['admin']), async (req: Request, res: Response) => {
   logger.debug({ query: req.query }, 'Admin: list audit log')
 
   try {

--- a/server/src/routes/adminCredentialsRouter.ts
+++ b/server/src/routes/adminCredentialsRouter.ts
@@ -9,6 +9,7 @@ import { AdminCredentialController } from '../controllers/admin/AdminCredentialC
 import { requireRole } from '../middleware/requireAdmin'
 import { AuditLogService } from '../services/AuditLogService'
 import logger from '../utils/logger'
+import { rateLimiter } from '../utils/rateLimiter'
 
 const router = Router()
 
@@ -22,7 +23,7 @@ const auditLogService = Container.get(AuditLogService)
  * Supports ?status=active|retired and ?schema_name= filters.
  * Requires: admin or creator or viewer role
  */
-router.get('/', requireRole(['admin', 'creator', 'viewer']), async (req: Request, res: Response) => {
+router.get('/', rateLimiter, requireRole(['admin', 'creator', 'viewer']), async (req: Request, res: Response) => {
   logger.debug('Admin: list credentials')
   try {
     let credentials = await credentialController.getAllCredentials()
@@ -48,7 +49,7 @@ router.get('/', requireRole(['admin', 'creator', 'viewer']), async (req: Request
  * Get a single credential by id.
  * Requires: admin or creator or viewer role
  */
-router.get('/:id', requireRole(['admin', 'creator', 'viewer']), async (req: Request, res: Response) => {
+router.get('/:id', rateLimiter, requireRole(['admin', 'creator', 'viewer']), async (req: Request, res: Response) => {
   logger.debug({ id: req.params.id }, 'Admin: get credential')
   try {
     const credential = await credentialController.getCredentialById(req.params.id)
@@ -68,7 +69,7 @@ router.get('/:id', requireRole(['admin', 'creator', 'viewer']), async (req: Requ
  * Create a new credential.
  * Requires: admin role
  */
-router.post('/', requireRole(['admin']), async (req: Request, res: Response) => {
+router.post('/', rateLimiter({ max: 10 }), requireRole(['admin']), async (req: Request, res: Response) => {
   logger.debug({ body: req.body }, 'Admin: create credential')
   try {
     const credential = await adminCredentialController.createCredential(req.body)
@@ -95,7 +96,7 @@ router.post('/', requireRole(['admin']), async (req: Request, res: Response) => 
  * Update a credential. Ledger-registered credentials may only update showcase fields.
  * Requires: admin role
  */
-router.put('/:id', requireRole(['admin']), async (req: Request, res: Response) => {
+router.put('/:id', rateLimiter({ max: 10 }), requireRole(['admin']), async (req: Request, res: Response) => {
   logger.debug({ id: req.params.id, body: req.body }, 'Admin: update credential')
   try {
     const credential = await adminCredentialController.updateCredential(req.params.id, req.body)
@@ -128,7 +129,7 @@ router.put('/:id', requireRole(['admin']), async (req: Request, res: Response) =
  * Soft-delete: marks credential as retired. Document is preserved.
  * Requires: admin role
  */
-router.delete('/:id', requireRole(['admin']), async (req: Request, res: Response) => {
+router.delete('/:id', rateLimiter({ max: 10 }), requireRole(['admin']), async (req: Request, res: Response) => {
   logger.debug({ id: req.params.id }, 'Admin: retire credential')
   try {
     const credential = await adminCredentialController.deleteCredential(req.params.id)

--- a/server/src/routes/adminCredentialsRouter.ts
+++ b/server/src/routes/adminCredentialsRouter.ts
@@ -9,7 +9,7 @@ import { AdminCredentialController } from '../controllers/admin/AdminCredentialC
 import { requireRole } from '../middleware/requireAdmin'
 import { AuditLogService } from '../services/AuditLogService'
 import logger from '../utils/logger'
-import { rateLimiter } from '../utils/rateLimiter'
+import { defaultRateLimiter, createRateLimiter } from '../utils/rateLimiter'
 
 const router = Router()
 
@@ -23,53 +23,63 @@ const auditLogService = Container.get(AuditLogService)
  * Supports ?status=active|retired and ?schema_name= filters.
  * Requires: admin or creator or viewer role
  */
-router.get('/', rateLimiter, requireRole(['admin', 'creator', 'viewer']), async (req: Request, res: Response) => {
-  logger.debug('Admin: list credentials')
-  try {
-    let credentials = await credentialController.getAllCredentials()
+router.get(
+  '/',
+  defaultRateLimiter,
+  requireRole(['admin', 'creator', 'viewer']),
+  async (req: Request, res: Response) => {
+    logger.debug('Admin: list credentials')
+    try {
+      let credentials = await credentialController.getAllCredentials()
 
-    // Local filtering
-    const { status, schema_name } = req.query
-    if (status && typeof status === 'string') {
-      credentials = credentials.filter((c: any) => c.status === status)
-    }
-    if (schema_name && typeof schema_name === 'string') {
-      credentials = credentials.filter((c: any) => c.name === schema_name)
-    }
+      // Local filtering
+      const { status, schema_name } = req.query
+      if (status && typeof status === 'string') {
+        credentials = credentials.filter((c: any) => c.status === status)
+      }
+      if (schema_name && typeof schema_name === 'string') {
+        credentials = credentials.filter((c: any) => c.name === schema_name)
+      }
 
-    res.json(credentials)
-  } catch (error) {
-    logger.error(error, 'Error fetching credentials')
-    res.status(500).json({ error: 'Failed to fetch credentials' })
-  }
-})
+      res.json(credentials)
+    } catch (error) {
+      logger.error(error, 'Error fetching credentials')
+      res.status(500).json({ error: 'Failed to fetch credentials' })
+    }
+  },
+)
 
 /**
  * GET /admin/credentials/:id
  * Get a single credential by id.
  * Requires: admin or creator or viewer role
  */
-router.get('/:id', rateLimiter, requireRole(['admin', 'creator', 'viewer']), async (req: Request, res: Response) => {
-  logger.debug({ id: req.params.id }, 'Admin: get credential')
-  try {
-    const credential = await credentialController.getCredentialById(req.params.id)
-    res.json(credential)
-  } catch (error) {
-    logger.error(error, 'Error fetching credential')
-    if (error instanceof NotFoundError) {
-      res.status(404).json({ error: 'Credential not found' })
-    } else {
-      res.status(500).json({ error: 'Failed to fetch credential' })
+router.get(
+  '/:id',
+  defaultRateLimiter,
+  requireRole(['admin', 'creator', 'viewer']),
+  async (req: Request, res: Response) => {
+    logger.debug({ id: req.params.id }, 'Admin: get credential')
+    try {
+      const credential = await credentialController.getCredentialById(req.params.id)
+      res.json(credential)
+    } catch (error) {
+      logger.error(error, 'Error fetching credential')
+      if (error instanceof NotFoundError) {
+        res.status(404).json({ error: 'Credential not found' })
+      } else {
+        res.status(500).json({ error: 'Failed to fetch credential' })
+      }
     }
-  }
-})
+  },
+)
 
 /**
  * POST /admin/credentials
  * Create a new credential.
  * Requires: admin role
  */
-router.post('/', rateLimiter({ max: 10 }), requireRole(['admin']), async (req: Request, res: Response) => {
+router.post('/', createRateLimiter, requireRole(['admin']), async (req: Request, res: Response) => {
   logger.debug({ body: req.body }, 'Admin: create credential')
   try {
     const credential = await adminCredentialController.createCredential(req.body)
@@ -96,7 +106,7 @@ router.post('/', rateLimiter({ max: 10 }), requireRole(['admin']), async (req: R
  * Update a credential. Ledger-registered credentials may only update showcase fields.
  * Requires: admin role
  */
-router.put('/:id', rateLimiter({ max: 10 }), requireRole(['admin']), async (req: Request, res: Response) => {
+router.put('/:id', defaultRateLimiter, requireRole(['admin']), async (req: Request, res: Response) => {
   logger.debug({ id: req.params.id, body: req.body }, 'Admin: update credential')
   try {
     const credential = await adminCredentialController.updateCredential(req.params.id, req.body)
@@ -129,7 +139,7 @@ router.put('/:id', rateLimiter({ max: 10 }), requireRole(['admin']), async (req:
  * Soft-delete: marks credential as retired. Document is preserved.
  * Requires: admin role
  */
-router.delete('/:id', rateLimiter({ max: 10 }), requireRole(['admin']), async (req: Request, res: Response) => {
+router.delete('/:id', defaultRateLimiter, requireRole(['admin']), async (req: Request, res: Response) => {
   logger.debug({ id: req.params.id }, 'Admin: retire credential')
   try {
     const credential = await adminCredentialController.deleteCredential(req.params.id)

--- a/server/src/routes/adminDidsRouter.ts
+++ b/server/src/routes/adminDidsRouter.ts
@@ -5,7 +5,7 @@ import { Router } from 'express'
 import { DidModel } from '../db/models/Did'
 import { requireRole } from '../middleware/requireAdmin'
 import logger from '../utils/logger'
-import { rateLimiter } from '../utils/rateLimiter'
+import { defaultRateLimiter } from '../utils/rateLimiter'
 
 const router = Router()
 
@@ -13,7 +13,7 @@ const router = Router()
  * GET /admin/dids
  * Get all DIDs from MongoDB.
  */
-router.get('/dids', rateLimiter, requireRole(['admin', 'creator']), async (_req: Request, res: Response) => {
+router.get('/dids', defaultRateLimiter, requireRole(['admin', 'creator']), async (_req: Request, res: Response) => {
   logger.debug('Admin: fetching DIDs from MongoDB')
   try {
     const dids = await DidModel.find().lean()

--- a/server/src/routes/adminDidsRouter.ts
+++ b/server/src/routes/adminDidsRouter.ts
@@ -1,27 +1,19 @@
 import type { Request, Response } from 'express'
 
 import { Router } from 'express'
-import rateLimit from 'express-rate-limit'
 
 import { DidModel } from '../db/models/Did'
 import { requireRole } from '../middleware/requireAdmin'
 import logger from '../utils/logger'
+import { rateLimiter } from '../utils/rateLimiter'
 
 const router = Router()
-
-const getLimiter = rateLimit({
-  windowMs: 15 * 60 * 1000,
-  max: 30,
-  message: 'Too many requests, please try again later.',
-  standardHeaders: true,
-  legacyHeaders: false,
-})
 
 /**
  * GET /admin/dids
  * Get all DIDs from MongoDB.
  */
-router.get('/dids', getLimiter, requireRole(['admin', 'creator']), async (_req: Request, res: Response) => {
+router.get('/dids', rateLimiter, requireRole(['admin', 'creator']), async (_req: Request, res: Response) => {
   logger.debug('Admin: fetching DIDs from MongoDB')
   try {
     const dids = await DidModel.find().lean()

--- a/server/src/routes/adminDidsRouter.ts
+++ b/server/src/routes/adminDidsRouter.ts
@@ -1,0 +1,35 @@
+import type { Request, Response } from 'express'
+
+import { Router } from 'express'
+import rateLimit from 'express-rate-limit'
+
+import { DidModel } from '../db/models/Did'
+import { requireRole } from '../middleware/requireAdmin'
+import logger from '../utils/logger'
+
+const router = Router()
+
+const getLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 30,
+  message: 'Too many requests, please try again later.',
+  standardHeaders: true,
+  legacyHeaders: false,
+})
+
+/**
+ * GET /admin/dids
+ * Get all DIDs from MongoDB.
+ */
+router.get('/dids', getLimiter, requireRole(['admin', 'creator']), async (_req: Request, res: Response) => {
+  logger.debug('Admin: fetching DIDs from MongoDB')
+  try {
+    const dids = await DidModel.find().lean()
+    res.json(dids)
+  } catch (error) {
+    logger.error(error, 'Error fetching DIDs from MongoDB')
+    res.status(500).json({ error: 'Failed to fetch DIDs from MongoDB' })
+  }
+})
+
+export default router

--- a/server/src/routes/adminSchemasRouter.ts
+++ b/server/src/routes/adminSchemasRouter.ts
@@ -4,15 +4,16 @@ import { Router } from 'express'
 import rateLimit from 'express-rate-limit'
 import { Container } from 'typedi'
 
+import { DidModel } from '../db/models/Did'
 import { SchemaModel } from '../db/models/Schema'
 import { requireRole } from '../middleware/requireAdmin'
 import { AuditLogService } from '../services/AuditLogService'
 import logger from '../utils/logger'
 import { tractionRequest, retryWithExponentialBackoff } from '../utils/tractionHelper'
 
-const router = Router()
-
 const auditLogService = Container.get(AuditLogService)
+
+const router = Router()
 
 const getLimiter = rateLimit({
   windowMs: 15 * 60 * 1000,
@@ -30,6 +31,15 @@ const createLimiter = rateLimit({
   legacyHeaders: false,
 })
 
+const transformSchemaResponse = async (schema: any) => {
+  const did = await DidModel.findById(schema.did).lean()
+  return {
+    ...schema,
+    id: schema._id, // Expose _id as id for frontend consistency
+    did,
+  }
+}
+
 /**
  * GET /admin/schemas
  * Get all anoncreds schemas from MongoDB.
@@ -37,8 +47,9 @@ const createLimiter = rateLimit({
 router.get('/schemas', getLimiter, requireRole(['admin', 'creator']), async (_req: Request, res: Response) => {
   logger.debug('Admin: fetching anoncreds schemas from MongoDB')
   try {
-    const schemas = await SchemaModel.find()
-    res.json(schemas)
+    const schemas = await SchemaModel.find().lean()
+    const response = await Promise.all(schemas.map(async (schema) => transformSchemaResponse(schema)))
+    res.json(response)
   } catch (error) {
     logger.error(error, 'Error fetching schemas from MongoDB')
     res.status(500).json({ error: 'Failed to fetch schemas from MongoDB' })
@@ -52,12 +63,11 @@ router.get('/schemas', getLimiter, requireRole(['admin', 'creator']), async (_re
 router.post('/schemas', createLimiter, requireRole(['admin', 'creator']), async (req: Request, res: Response) => {
   logger.debug('Admin: creating anoncreds schema and cred def in Traction')
   try {
-    const issuerDid = (await tractionRequest.get('/wallet/did/public')).data.result.did
     const createSchemaPayload = {
       name: req.body.name,
       version: req.body.version,
       attrNames: req.body.attrNames,
-      issuerId: issuerDid,
+      issuerId: req.body.did,
     }
     logger.debug({ createSchemaPayload }, 'Creating schema with payload')
     const response = await tractionRequest.post('/anoncreds/schema', { schema: createSchemaPayload })
@@ -65,7 +75,7 @@ router.post('/schemas', createLimiter, requireRole(['admin', 'creator']), async 
       () =>
         tractionRequest.post('/anoncreds/credential-definition', {
           credential_definition: {
-            issuerId: issuerDid,
+            issuerId: req.body.did,
             schemaId: response.data.schema_state.schema_id,
             tag: response.data.schema_state.schema.name,
           },
@@ -88,6 +98,7 @@ router.post('/schemas', createLimiter, requireRole(['admin', 'creator']), async 
           version: req.body.version,
           attrNames: req.body.attrNames,
           credDefId,
+          did: req.body.did,
         },
       },
       { upsert: true },
@@ -109,7 +120,7 @@ router.post('/schemas', createLimiter, requireRole(['admin', 'creator']), async 
       .catch((err: unknown) => logger.error(err, 'Audit log: failed to write schema created event'))
   } catch (error) {
     logger.error(error, 'Error creating schema and cred def in Traction')
-    res.status(500).json({ error: `Failed to create schema and cred def in Traction` })
+    res.status(500).json({ error: `Failed to create schema and cred def in Traction: ${error}` })
   }
 })
 

--- a/server/src/routes/adminSchemasRouter.ts
+++ b/server/src/routes/adminSchemasRouter.ts
@@ -1,7 +1,6 @@
 import type { Request, Response } from 'express'
 
 import { Router } from 'express'
-import rateLimit from 'express-rate-limit'
 import { Container } from 'typedi'
 
 import { DidModel } from '../db/models/Did'
@@ -9,27 +8,12 @@ import { SchemaModel } from '../db/models/Schema'
 import { requireRole } from '../middleware/requireAdmin'
 import { AuditLogService } from '../services/AuditLogService'
 import logger from '../utils/logger'
+import { rateLimiter } from '../utils/rateLimiter'
 import { tractionRequest, retryWithExponentialBackoff } from '../utils/tractionHelper'
 
 const auditLogService = Container.get(AuditLogService)
 
 const router = Router()
-
-const getLimiter = rateLimit({
-  windowMs: 15 * 60 * 1000,
-  max: 30,
-  message: 'Too many requests, please try again later.',
-  standardHeaders: true,
-  legacyHeaders: false,
-})
-
-const createLimiter = rateLimit({
-  windowMs: 15 * 60 * 1000,
-  max: 5,
-  message: 'Too many schema creation requests, please try again later.',
-  standardHeaders: true,
-  legacyHeaders: false,
-})
 
 const transformSchemaResponse = async (schema: any) => {
   const did = await DidModel.findById(schema.did).lean()
@@ -44,7 +28,7 @@ const transformSchemaResponse = async (schema: any) => {
  * GET /admin/schemas
  * Get all anoncreds schemas from MongoDB.
  */
-router.get('/schemas', getLimiter, requireRole(['admin', 'creator']), async (_req: Request, res: Response) => {
+router.get('/schemas', rateLimiter, requireRole(['admin', 'creator']), async (_req: Request, res: Response) => {
   logger.debug('Admin: fetching anoncreds schemas from MongoDB')
   try {
     const schemas = await SchemaModel.find().lean()
@@ -60,68 +44,73 @@ router.get('/schemas', getLimiter, requireRole(['admin', 'creator']), async (_re
  * POST /admin/schemas
  * Create a new anoncreds schema in Traction and save to MongoDB.
  */
-router.post('/schemas', createLimiter, requireRole(['admin', 'creator']), async (req: Request, res: Response) => {
-  logger.debug('Admin: creating anoncreds schema and cred def in Traction')
-  try {
-    const createSchemaPayload = {
-      name: req.body.name,
-      version: req.body.version,
-      attrNames: req.body.attrNames,
-      issuerId: req.body.did,
-    }
-    logger.debug({ createSchemaPayload }, 'Creating schema with payload')
-    const response = await tractionRequest.post('/anoncreds/schema', { schema: createSchemaPayload })
-    const credDefResponse = await retryWithExponentialBackoff(
-      () =>
-        tractionRequest.post('/anoncreds/credential-definition', {
-          credential_definition: {
-            issuerId: req.body.did,
-            schemaId: response.data.schema_state.schema_id,
-            tag: response.data.schema_state.schema.name,
-          },
-          options: {
-            support_revocation: true,
-            revocation_registry_size: 3000,
-          },
-        }),
-      3,
-      1000,
-    )
-    // Save schema to MongoDB
-    const schemaId = response.data.schema_state.schema_id
-    const credDefId = credDefResponse.data.credential_definition_state.credential_definition_id
-    await SchemaModel.updateOne(
-      { _id: schemaId },
-      {
-        $set: {
-          name: req.body.name,
-          version: req.body.version,
-          attrNames: req.body.attrNames,
-          credDefId,
-          did: req.body.did,
-        },
-      },
-      { upsert: true },
-    )
-    // Return the saved schema document from MongoDB for consistency with GET endpoint
-    const savedSchema = await SchemaModel.findById(schemaId)
-    res.status(201).json(savedSchema)
-    // Best-effort audit: writes after response sent, may be lost on crash/shutdown.
-    void Promise.resolve()
-      .then(() =>
-        auditLogService.log({
-          user_id: req.auth?.sub ?? 'unknown',
-          action: 'created',
-          resource_type: 'schema',
-          resource_id: schemaId,
-          details: { name: req.body.name, version: req.body.version },
-        }),
+router.post(
+  '/schemas',
+  rateLimiter({ max: 5 }),
+  requireRole(['admin', 'creator']),
+  async (req: Request, res: Response) => {
+    logger.debug('Admin: creating anoncreds schema and cred def in Traction')
+    try {
+      const createSchemaPayload = {
+        name: req.body.name,
+        version: req.body.version,
+        attrNames: req.body.attrNames,
+        issuerId: req.body.did,
+      }
+      logger.debug({ createSchemaPayload }, 'Creating schema with payload')
+      const response = await tractionRequest.post('/anoncreds/schema', { schema: createSchemaPayload })
+      const credDefResponse = await retryWithExponentialBackoff(
+        () =>
+          tractionRequest.post('/anoncreds/credential-definition', {
+            credential_definition: {
+              issuerId: req.body.did,
+              schemaId: response.data.schema_state.schema_id,
+              tag: response.data.schema_state.schema.name,
+            },
+            options: {
+              support_revocation: true,
+              revocation_registry_size: 3000,
+            },
+          }),
+        3,
+        1000,
       )
-      .catch((err: unknown) => logger.error(err, 'Audit log: failed to write schema created event'))
-  } catch (error) {
-    logger.error(error, 'Error creating schema and cred def in Traction')
-    res.status(500).json({ error: `Failed to create schema and cred def in Traction: ${error}` })
-  }
-})
+      // Save schema to MongoDB
+      const schemaId = response.data.schema_state.schema_id
+      const credDefId = credDefResponse.data.credential_definition_state.credential_definition_id
+      await SchemaModel.updateOne(
+        { _id: schemaId },
+        {
+          $set: {
+            name: req.body.name,
+            version: req.body.version,
+            attrNames: req.body.attrNames,
+            credDefId,
+            did: req.body.did,
+          },
+        },
+        { upsert: true },
+      )
+      // Return the saved schema document from MongoDB for consistency with GET endpoint
+      const savedSchema = await SchemaModel.findById(schemaId)
+      res.status(201).json(savedSchema)
+      // Best-effort audit: writes after response sent, may be lost on crash/shutdown.
+      void Promise.resolve()
+        .then(() =>
+          auditLogService.log({
+            user_id: req.auth?.sub ?? 'unknown',
+            action: 'created',
+            resource_type: 'schema',
+            resource_id: schemaId,
+            details: { name: req.body.name, version: req.body.version },
+          }),
+        )
+        .catch((err: unknown) => logger.error(err, 'Audit log: failed to write schema created event'))
+    } catch (error) {
+      logger.error(error, 'Error creating schema and cred def in Traction')
+      res.status(500).json({ error: `Failed to create schema and cred def in Traction: ${error}` })
+    }
+  },
+)
 
 export default router

--- a/server/src/routes/adminSchemasRouter.ts
+++ b/server/src/routes/adminSchemasRouter.ts
@@ -8,7 +8,7 @@ import { SchemaModel } from '../db/models/Schema'
 import { requireRole } from '../middleware/requireAdmin'
 import { AuditLogService } from '../services/AuditLogService'
 import logger from '../utils/logger'
-import { rateLimiter } from '../utils/rateLimiter'
+import { defaultRateLimiter, createRateLimiter } from '../utils/rateLimiter'
 import { tractionRequest, retryWithExponentialBackoff } from '../utils/tractionHelper'
 
 const auditLogService = Container.get(AuditLogService)
@@ -28,7 +28,7 @@ const transformSchemaResponse = async (schema: any) => {
  * GET /admin/schemas
  * Get all anoncreds schemas from MongoDB.
  */
-router.get('/schemas', rateLimiter, requireRole(['admin', 'creator']), async (_req: Request, res: Response) => {
+router.get('/schemas', defaultRateLimiter, requireRole(['admin', 'creator']), async (_req: Request, res: Response) => {
   logger.debug('Admin: fetching anoncreds schemas from MongoDB')
   try {
     const schemas = await SchemaModel.find().lean()
@@ -44,73 +44,68 @@ router.get('/schemas', rateLimiter, requireRole(['admin', 'creator']), async (_r
  * POST /admin/schemas
  * Create a new anoncreds schema in Traction and save to MongoDB.
  */
-router.post(
-  '/schemas',
-  rateLimiter({ max: 5 }),
-  requireRole(['admin', 'creator']),
-  async (req: Request, res: Response) => {
-    logger.debug('Admin: creating anoncreds schema and cred def in Traction')
-    try {
-      const createSchemaPayload = {
-        name: req.body.name,
-        version: req.body.version,
-        attrNames: req.body.attrNames,
-        issuerId: req.body.did,
-      }
-      logger.debug({ createSchemaPayload }, 'Creating schema with payload')
-      const response = await tractionRequest.post('/anoncreds/schema', { schema: createSchemaPayload })
-      const credDefResponse = await retryWithExponentialBackoff(
-        () =>
-          tractionRequest.post('/anoncreds/credential-definition', {
-            credential_definition: {
-              issuerId: req.body.did,
-              schemaId: response.data.schema_state.schema_id,
-              tag: response.data.schema_state.schema.name,
-            },
-            options: {
-              support_revocation: true,
-              revocation_registry_size: 3000,
-            },
-          }),
-        3,
-        1000,
-      )
-      // Save schema to MongoDB
-      const schemaId = response.data.schema_state.schema_id
-      const credDefId = credDefResponse.data.credential_definition_state.credential_definition_id
-      await SchemaModel.updateOne(
-        { _id: schemaId },
-        {
-          $set: {
-            name: req.body.name,
-            version: req.body.version,
-            attrNames: req.body.attrNames,
-            credDefId,
-            did: req.body.did,
-          },
-        },
-        { upsert: true },
-      )
-      // Return the saved schema document from MongoDB for consistency with GET endpoint
-      const savedSchema = await SchemaModel.findById(schemaId)
-      res.status(201).json(savedSchema)
-      // Best-effort audit: writes after response sent, may be lost on crash/shutdown.
-      void Promise.resolve()
-        .then(() =>
-          auditLogService.log({
-            user_id: req.auth?.sub ?? 'unknown',
-            action: 'created',
-            resource_type: 'schema',
-            resource_id: schemaId,
-            details: { name: req.body.name, version: req.body.version },
-          }),
-        )
-        .catch((err: unknown) => logger.error(err, 'Audit log: failed to write schema created event'))
-    } catch (error) {
-      logger.error(error, 'Error creating schema and cred def in Traction')
-      res.status(500).json({ error: `Failed to create schema and cred def in Traction: ${error}` })
+router.post('/schemas', createRateLimiter, requireRole(['admin', 'creator']), async (req: Request, res: Response) => {
+  logger.debug('Admin: creating anoncreds schema and cred def in Traction')
+  try {
+    const createSchemaPayload = {
+      name: req.body.name,
+      version: req.body.version,
+      attrNames: req.body.attrNames,
+      issuerId: req.body.did,
     }
-  },
-)
+    logger.debug({ createSchemaPayload }, 'Creating schema with payload')
+    const response = await tractionRequest.post('/anoncreds/schema', { schema: createSchemaPayload })
+    const credDefResponse = await retryWithExponentialBackoff(
+      () =>
+        tractionRequest.post('/anoncreds/credential-definition', {
+          credential_definition: {
+            issuerId: req.body.did,
+            schemaId: response.data.schema_state.schema_id,
+            tag: response.data.schema_state.schema.name,
+          },
+          options: {
+            support_revocation: true,
+            revocation_registry_size: 3000,
+          },
+        }),
+      3,
+      1000,
+    )
+    // Save schema to MongoDB
+    const schemaId = response.data.schema_state.schema_id
+    const credDefId = credDefResponse.data.credential_definition_state.credential_definition_id
+    await SchemaModel.updateOne(
+      { _id: schemaId },
+      {
+        $set: {
+          name: req.body.name,
+          version: req.body.version,
+          attrNames: req.body.attrNames,
+          credDefId,
+          did: req.body.did,
+        },
+      },
+      { upsert: true },
+    )
+    // Return the saved schema document from MongoDB for consistency with GET endpoint
+    const savedSchema = await SchemaModel.findById(schemaId)
+    res.status(201).json(savedSchema)
+    // Best-effort audit: writes after response sent, may be lost on crash/shutdown.
+    void Promise.resolve()
+      .then(() =>
+        auditLogService.log({
+          user_id: req.auth?.sub ?? 'unknown',
+          action: 'created',
+          resource_type: 'schema',
+          resource_id: schemaId,
+          details: { name: req.body.name, version: req.body.version },
+        }),
+      )
+      .catch((err: unknown) => logger.error(err, 'Audit log: failed to write schema created event'))
+  } catch (error) {
+    logger.error(error, 'Error creating schema and cred def in Traction')
+    res.status(500).json({ error: `Failed to create schema and cred def in Traction: ${error}` })
+  }
+})
 
 export default router

--- a/server/src/utils/__tests__/tractionHelper.test.ts
+++ b/server/src/utils/__tests__/tractionHelper.test.ts
@@ -16,12 +16,19 @@ vi.mock('../logger', () => ({
 vi.mock('../../db/models/Schema', () => ({
   SchemaModel: {
     findOne: vi.fn(),
+    find: vi.fn(),
     updateOne: vi.fn(),
   },
 }))
 
 vi.mock('../../db/models/Credential', () => ({
   CredentialModel: {
+    updateOne: vi.fn(),
+  },
+}))
+
+vi.mock('../../db/models/Did', () => ({
+  DidModel: {
     updateOne: vi.fn(),
   },
 }))
@@ -38,7 +45,9 @@ vi.mock('../../../scripts/values/credentials.json', () => ({
 }))
 
 import { CredentialModel } from '../../db/models/Credential'
+import { DidModel } from '../../db/models/Did'
 import { SchemaModel } from '../../db/models/Schema'
+import logger from '../logger'
 import * as th from '../tractionHelper'
 
 // Import models after mocks are applied
@@ -258,6 +267,162 @@ describe('tractionGarbageCollection', () => {
   })
 })
 
+describe('getOrCreateIndyDid', () => {
+  it('returns existing posted indy did when present', async () => {
+    th.tractionRequest.get = vi.fn().mockResolvedValue({
+      data: {
+        results: [{ did: 'did:sov:123' }],
+      },
+    })
+
+    const did = await th.getOrCreateIndyDid()
+
+    expect(did).toBe('did:sov:123')
+  })
+
+  it('creates a new indy did when none exist', async () => {
+    th.tractionRequest.get = vi.fn().mockResolvedValue({
+      data: {
+        results: [],
+      },
+    })
+
+    th.tractionRequest.post = vi.fn().mockResolvedValue({
+      data: {
+        result: {
+          did: 'did:sov:new',
+        },
+      },
+    })
+
+    const did = await th.getOrCreateIndyDid()
+
+    expect(th.tractionRequest.post).toHaveBeenCalledWith('/wallet/did/create', {
+      method: 'sov',
+    })
+
+    expect(did).toBe('did:sov:new')
+  })
+})
+
+describe('findSchemaInTraction', () => {
+  it('returns schema id when found', async () => {
+    th.tractionRequest.get = vi.fn().mockResolvedValue({
+      data: {
+        schema_ids: ['schema-id-1'],
+      },
+    })
+
+    const result = await th.findSchemaInTraction('Test', '1.0.0')
+
+    expect(result).toBe('schema-id-1')
+  })
+
+  it('returns null when no schemas found', async () => {
+    th.tractionRequest.get = vi.fn().mockResolvedValue({
+      data: {
+        schema_ids: [],
+      },
+    })
+
+    const result = await th.findSchemaInTraction('Test', '1.0.0')
+
+    expect(result).toBeNull()
+  })
+})
+
+describe('syncSchemaToDatabase', () => {
+  it('updates schema and credential records', async () => {
+    const credential: th.SeedCredential = {
+      _id: 'credential-id',
+      name: 'Person',
+      version: '1.0.0',
+      attributes: [{ name: 'first_name' }, { name: 'last_name' }],
+    }
+
+    await th.syncSchemaToDatabase(credential, 'schema-id', 'creddef-id')
+
+    expect(SchemaModel.updateOne).toHaveBeenCalledWith(
+      { _id: 'schema-id' },
+      {
+        $set: {
+          name: 'Person',
+          version: '1.0.0',
+          attrNames: ['first_name', 'last_name'],
+          credDefId: 'creddef-id',
+        },
+      },
+      { upsert: true },
+    )
+
+    expect(CredentialModel.updateOne).toHaveBeenCalledWith(
+      { _id: 'credential-id' },
+      {
+        $set: {
+          schema_id: 'schema-id',
+          cred_def_id: 'creddef-id',
+        },
+      },
+    )
+  })
+})
+
+describe('populateMissingSchemaDids', () => {
+  it('updates only schemas missing a did', async () => {
+    SchemaModel.find = vi.fn().mockResolvedValue([
+      {
+        _id: '1',
+        name: 'Schema1',
+        version: '1.0.0',
+        did: undefined,
+      },
+      {
+        _id: '2',
+        name: 'Schema2',
+        version: '1.0.0',
+        did: 'existing-did',
+      },
+    ])
+
+    await th.populateMissingSchemaDids('issuerDid')
+
+    expect(SchemaModel.updateOne).toHaveBeenCalledTimes(2)
+
+    expect(SchemaModel.updateOne).toHaveBeenCalledWith(
+      { _id: '1' },
+      {
+        $set: {
+          did: 'issuerDid',
+        },
+      },
+      { upsert: true },
+    )
+  })
+})
+
+it('returns immediately when schema already exists in database', async () => {
+  SchemaModel.findOne = vi.fn().mockResolvedValue({
+    _id: 'schema-id',
+  })
+
+  const findSchemaInTractionSpy = vi.spyOn(th, 'findSchemaInTraction')
+  const createSchemaSpy = vi.spyOn(th, 'createSchema')
+  const getOrCreateCredDefSpy = vi.spyOn(th, 'getOrCreateCredDef')
+
+  const credential: th.SeedCredential = {
+    _id: 'credential-id',
+    name: 'Person',
+    version: '1.0.0',
+    attributes: [{ name: 'first_name' }, { name: 'last_name' }],
+  }
+
+  await th.processSeededCredential(credential, 'issuerDid')
+
+  expect(findSchemaInTractionSpy).not.toHaveBeenCalled()
+  expect(createSchemaSpy).not.toHaveBeenCalled()
+  expect(getOrCreateCredDefSpy).not.toHaveBeenCalled()
+})
+
 describe('checkSeededSchemasExistOrCreate', () => {
   beforeEach(() => {
     process.env.TRACTION_URL = 'https://traction.example.com'
@@ -268,386 +433,47 @@ describe('checkSeededSchemasExistOrCreate', () => {
     delete process.env.TRACTION_URL
   })
 
-  it('skips schema if already exists in MongoDB', async () => {
-    vi.mocked(SchemaModel.findOne).mockResolvedValue({
-      _id: 'W1ZJ:2:student_card:2.0' as any,
-      name: 'student_card',
-      version: '2.0',
-    } as any)
-    vi.mocked(axios.get).mockResolvedValueOnce({
-      data: { result: { did: 'W1ZJ' } },
+  it('logs when checking starts', async () => {
+    // Mock all axios calls to succeed
+    vi.mocked(axios.get).mockResolvedValue({
+      data: {
+        results: [{ did: 'did:sov:123' }],
+      },
     })
-
-    await th.checkSeededSchemasExistOrCreate()
-
-    expect(SchemaModel.findOne).toHaveBeenCalledWith({
-      name: 'student_card',
-      version: '2.0',
-    })
-    // Should only call wallet/did/public, not any schema lookups
-    expect(axios.get).toHaveBeenCalledTimes(1)
-    expect(axios.get).toHaveBeenCalledWith('https://traction.example.com/wallet/did/public', expect.anything())
-  })
-
-  it('creates credential definition for existing schema in Traction', async () => {
-    vi.mocked(SchemaModel.findOne).mockResolvedValue(null)
-    vi.mocked(axios.get)
-      .mockResolvedValueOnce({
-        data: { result: { did: 'W1ZJ' } },
-      })
-      .mockResolvedValueOnce({
-        data: { schema_ids: ['W1ZJ:2:student_card:2.0'] },
-      })
-      .mockResolvedValueOnce({
-        data: { credential_definition_ids: [] },
-      })
     vi.mocked(axios.post).mockResolvedValue({
       data: {
+        schema_state: {
+          schema_id: 'schema-1',
+          schema: { name: 'test', version: '1.0' },
+        },
         credential_definition_state: {
-          credential_definition_id: 'W1ZJ:3:CL:1:student_card',
+          credential_definition_id: 'cred-def-1',
         },
       },
     })
-    vi.mocked(SchemaModel.updateOne).mockResolvedValue({
-      acknowledged: true,
-      matchedCount: 1,
-      modifiedCount: 1,
-      upsertedCount: 1,
-      upsertedId: 'W1ZJ:2:student_card:2.0' as any,
-    } as any)
-    vi.mocked(CredentialModel.updateOne).mockResolvedValue({
-      acknowledged: true,
-      matchedCount: 1,
-      modifiedCount: 1,
-      upsertedCount: 0,
-      upsertedId: null,
-    } as any)
-
-    await th.checkSeededSchemasExistOrCreate()
-
-    expect(axios.get).toHaveBeenCalledWith(
-      'https://traction.example.com/anoncreds/credential-definitions',
-      expect.anything(),
-    )
-    expect(axios.post).toHaveBeenCalledWith(
-      'https://traction.example.com/anoncreds/credential-definition',
-      expect.objectContaining({
-        credential_definition: expect.objectContaining({
-          schemaId: 'W1ZJ:2:student_card:2.0',
-        }),
-      }),
-      expect.anything(),
-    )
-  })
-
-  it('reuses existing credential definition if already in Traction', async () => {
     vi.mocked(SchemaModel.findOne).mockResolvedValue(null)
-    vi.mocked(axios.get)
-      .mockResolvedValueOnce({
-        data: { result: { did: 'W1ZJ' } },
-      })
-      .mockResolvedValueOnce({
-        data: { schema_ids: ['W1ZJ:2:student_card:2.0'] },
-      })
-      .mockResolvedValueOnce({
-        data: { credential_definition_ids: ['W1ZJ:3:CL:1:student_card'] },
-      })
-    vi.mocked(SchemaModel.updateOne).mockResolvedValue({
-      acknowledged: true,
-      matchedCount: 1,
-      modifiedCount: 1,
-      upsertedCount: 1,
-      upsertedId: 'W1ZJ:2:student_card:2.0' as any,
-    } as any)
-    vi.mocked(CredentialModel.updateOne).mockResolvedValue({
-      acknowledged: true,
-      matchedCount: 1,
-      modifiedCount: 1,
-      upsertedCount: 0,
-      upsertedId: null,
-    } as any)
+    vi.mocked(SchemaModel.updateOne).mockResolvedValue({} as any)
+    vi.mocked(CredentialModel.updateOne).mockResolvedValue({} as any)
+    vi.mocked(DidModel.updateOne).mockResolvedValue({} as any)
+    vi.mocked(SchemaModel.find).mockResolvedValue([])
 
     await th.checkSeededSchemasExistOrCreate()
 
-    expect(axios.post).not.toHaveBeenCalled()
-    expect(SchemaModel.updateOne).toHaveBeenCalledWith(
-      { _id: 'W1ZJ:2:student_card:2.0' as any },
-      expect.objectContaining({
-        $set: expect.objectContaining({
-          credDefId: 'W1ZJ:3:CL:1:student_card',
-        }),
-      }),
-      { upsert: true },
-    )
+    expect(vi.mocked(logger.info)).toHaveBeenCalledWith('Checking seeded schemas')
   })
 
-  it('creates both schema and credential definition when schema does not exist in Traction', async () => {
-    vi.mocked(SchemaModel.findOne).mockResolvedValue(null)
-    vi.mocked(axios.get)
-      .mockResolvedValueOnce({
-        data: { result: { did: 'W1ZJ' } },
-      })
-      .mockResolvedValueOnce({
-        data: { schema_ids: [] },
-      })
-    vi.mocked(axios.post)
-      .mockResolvedValueOnce({
-        data: {
-          schema_state: {
-            schema_id: 'W1ZJ:2:student_card:2.0',
-            schema: { name: 'student_card' },
-          },
-        },
-      })
-      .mockResolvedValueOnce({
-        data: {
-          credential_definition_state: {
-            credential_definition_id: 'W1ZJ:3:CL:1:student_card',
-          },
-        },
-      })
-    vi.mocked(SchemaModel.updateOne).mockResolvedValue({
-      acknowledged: true,
-      matchedCount: 1,
-      modifiedCount: 1,
-      upsertedCount: 1,
-      upsertedId: 'W1ZJ:2:student_card:2.0' as any,
-    } as any)
-    vi.mocked(CredentialModel.updateOne).mockResolvedValue({
-      acknowledged: true,
-      matchedCount: 1,
-      modifiedCount: 1,
-      upsertedCount: 0,
-      upsertedId: null,
-    } as any)
-
-    await th.checkSeededSchemasExistOrCreate()
-
-    expect(axios.post).toHaveBeenCalledWith(
-      'https://traction.example.com/anoncreds/schema',
-      expect.objectContaining({
-        schema: expect.objectContaining({
-          name: 'student_card',
-          version: '2.0',
-        }),
-      }),
-      expect.anything(),
-    )
-    expect(SchemaModel.updateOne).toHaveBeenCalledWith(
-      { _id: 'W1ZJ:2:student_card:2.0' as any },
-      expect.objectContaining({
-        $set: expect.objectContaining({
-          credDefId: 'W1ZJ:3:CL:1:student_card',
-        }),
-      }),
-      { upsert: true },
-    )
-  })
-
-  it('updates credential record with schema_id and cred_def_id', async () => {
-    vi.mocked(SchemaModel.findOne).mockResolvedValue(null)
-    vi.mocked(axios.get)
-      .mockResolvedValueOnce({
-        data: { result: { did: 'W1ZJ' } },
-      })
-      .mockResolvedValueOnce({
-        data: { schema_ids: ['W1ZJ:2:student_card:2.0'] },
-      })
-      .mockResolvedValueOnce({
-        data: { credential_definition_ids: [] },
-      })
-    vi.mocked(axios.post).mockResolvedValue({
-      data: {
-        credential_definition_state: {
-          credential_definition_id: 'W1ZJ:3:CL:1:student_card',
-        },
-      },
-    })
-    vi.mocked(SchemaModel.updateOne).mockResolvedValue({
-      acknowledged: true,
-      matchedCount: 1,
-      modifiedCount: 1,
-      upsertedCount: 1,
-      upsertedId: 'W1ZJ:2:student_card:2.0' as any,
-    } as any)
-    vi.mocked(CredentialModel.updateOne).mockResolvedValue({
-      acknowledged: true,
-      matchedCount: 1,
-      modifiedCount: 1,
-      upsertedCount: 0,
-      upsertedId: null,
-    } as any)
-
-    await th.checkSeededSchemasExistOrCreate()
-
-    expect(CredentialModel.updateOne).toHaveBeenCalledWith(
-      { _id: 'student-card' as any },
-      {
-        $set: {
-          schema_id: 'W1ZJ:2:student_card:2.0',
-          cred_def_id: 'W1ZJ:3:CL:1:student_card',
-        },
-      },
-      { upsert: false },
-    )
-  })
-
-  it('maps credential attributes to schema attrNames', async () => {
-    vi.mocked(SchemaModel.findOne).mockResolvedValue(null)
-    vi.mocked(axios.get)
-      .mockResolvedValueOnce({
-        data: { result: { did: 'W1ZJ' } },
-      })
-      .mockResolvedValueOnce({
-        data: { schema_ids: [] },
-      })
-    vi.mocked(axios.post)
-      .mockResolvedValueOnce({
-        data: {
-          schema_state: {
-            schema_id: 'W1ZJ:2:student_card:2.0',
-            schema: { name: 'student_card' },
-          },
-        },
-      })
-      .mockResolvedValueOnce({
-        data: {
-          credential_definition_state: {
-            credential_definition_id: 'W1ZJ:3:CL:1:student_card',
-          },
-        },
-      })
-    vi.mocked(SchemaModel.updateOne).mockResolvedValue({
-      acknowledged: true,
-      matchedCount: 1,
-      modifiedCount: 1,
-      upsertedCount: 1,
-      upsertedId: 'W1ZJ:2:student_card:2.0' as any,
-    } as any)
-    vi.mocked(CredentialModel.updateOne).mockResolvedValue({
-      acknowledged: true,
-      matchedCount: 1,
-      modifiedCount: 1,
-      upsertedCount: 0,
-      upsertedId: null,
-    } as any)
-
-    await th.checkSeededSchemasExistOrCreate()
-
-    expect(SchemaModel.updateOne).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.objectContaining({
-        $set: expect.objectContaining({
-          attrNames: ['student_first_name', 'student_last_name', 'expiry_date'],
-        }),
-      }),
-      expect.anything(),
-    )
-  })
-
-  it('handles error when schema already exists in Traction but fails to sync', async () => {
-    vi.mocked(SchemaModel.findOne).mockResolvedValue(null)
-    vi.mocked(axios.get)
-      .mockResolvedValueOnce({
-        data: { result: { did: 'W1ZJ' } },
-      })
-      .mockResolvedValueOnce({
-        data: { schema_ids: ['W1ZJ:2:Student Card:1.0'] },
-      })
-      .mockRejectedValueOnce(new Error('Failed to fetch credential definitions'))
-
-    await th.checkSeededSchemasExistOrCreate()
-
-    expect(SchemaModel.updateOne).not.toHaveBeenCalled()
-  })
-
-  it('handles error when schema creation fails', async () => {
-    vi.mocked(SchemaModel.findOne).mockResolvedValue(null)
-    vi.mocked(axios.get)
-      .mockResolvedValueOnce({
-        data: { schema_ids: [] },
-      })
-      .mockResolvedValueOnce({
-        data: { result: { did: 'W1ZJ' } },
-      })
-    vi.mocked(axios.post).mockRejectedValue(new Error('Schema creation failed'))
-
-    await th.checkSeededSchemasExistOrCreate()
-
-    expect(SchemaModel.updateOne).not.toHaveBeenCalled()
-  })
-
-  it('handles error when fetching issuer DID fails', async () => {
-    vi.mocked(SchemaModel.findOne).mockResolvedValue(null)
-    vi.mocked(axios.get).mockRejectedValueOnce(new Error('Wallet unavailable'))
-
-    await th.checkSeededSchemasExistOrCreate()
-
-    expect(axios.post).not.toHaveBeenCalled()
-  })
-
-  it('continues processing after error in one credential', async () => {
-    vi.mocked(SchemaModel.findOne).mockResolvedValue(null)
-    vi.mocked(axios.get)
-      .mockResolvedValueOnce({
-        data: { result: { did: 'W1ZJ' } },
-      })
-      .mockRejectedValueOnce(new Error('Error on schema lookup'))
-
-    await th.checkSeededSchemasExistOrCreate()
-
-    expect(SchemaModel.findOne).toHaveBeenCalled()
-  })
-
-  it('does not throw when entire function fails', async () => {
-    vi.mocked(SchemaModel.findOne).mockRejectedValue(new Error('Database error'))
+  it('does not rethrow errors, allowing server to continue', async () => {
+    vi.mocked(axios.get).mockRejectedValue(new Error('Fatal error'))
 
     await expect(th.checkSeededSchemasExistOrCreate()).resolves.toBeUndefined()
+    expect(vi.mocked(logger.error)).toHaveBeenCalled()
   })
 
-  it('uses exponential backoff for credential definition creation retry', async () => {
-    vi.mocked(SchemaModel.findOne).mockResolvedValue(null)
-    vi.mocked(axios.get)
-      .mockResolvedValueOnce({
-        data: { result: { did: 'W1ZJ' } },
-      })
-      .mockResolvedValueOnce({
-        data: { schema_ids: [] },
-      })
-    vi.mocked(axios.post)
-      .mockResolvedValueOnce({
-        data: {
-          schema_state: {
-            schema_id: 'W1ZJ:2:student_card:2.0',
-            schema: { name: 'student_card' },
-          },
-        },
-      })
-      .mockResolvedValueOnce({
-        data: {
-          credential_definition_state: {
-            credential_definition_id: 'W1ZJ:3:CL:1:student_card',
-          },
-        },
-      })
-    vi.mocked(SchemaModel.updateOne).mockResolvedValue({
-      acknowledged: true,
-      matchedCount: 1,
-      modifiedCount: 1,
-      upsertedCount: 1,
-      upsertedId: 'W1ZJ:2:student_card:2.0' as any,
-    } as any)
-    vi.mocked(CredentialModel.updateOne).mockResolvedValue({
-      acknowledged: true,
-      matchedCount: 1,
-      modifiedCount: 1,
-      upsertedCount: 0,
-      upsertedId: null,
-    } as any)
+  it('logs error when an error occurs during DID retrieval', async () => {
+    vi.mocked(axios.get).mockRejectedValue(new Error('API unavailable'))
 
     await th.checkSeededSchemasExistOrCreate()
 
-    // Verify that POST was called twice (schema + credential definition)
-    expect(axios.post).toHaveBeenCalledTimes(2)
+    expect(vi.mocked(logger.error)).toHaveBeenCalledWith(expect.any(Object), 'Failed to process seeded schemas')
   })
 })

--- a/server/src/utils/rateLimiter.ts
+++ b/server/src/utils/rateLimiter.ts
@@ -1,0 +1,11 @@
+import rateLimit from 'express-rate-limit'
+
+export const rateLimiter = (options?: { windowMs?: number; max?: number; message?: string }) => {
+  return rateLimit({
+    windowMs: options?.windowMs ?? 15 * 60 * 1000,
+    max: options?.max ?? 30,
+    message: options?.message ?? 'Too many requests, please try again later.',
+    standardHeaders: true,
+    legacyHeaders: false,
+  })
+}

--- a/server/src/utils/rateLimiter.ts
+++ b/server/src/utils/rateLimiter.ts
@@ -1,11 +1,28 @@
 import rateLimit from 'express-rate-limit'
 
-export const rateLimiter = (options?: { windowMs?: number; max?: number; message?: string }) => {
-  return rateLimit({
-    windowMs: options?.windowMs ?? 15 * 60 * 1000,
-    max: options?.max ?? 30,
-    message: options?.message ?? 'Too many requests, please try again later.',
-    standardHeaders: true,
-    legacyHeaders: false,
-  })
-}
+// Default rate limiter
+export const defaultRateLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 30, // limit each IP to 30 requests per windowMs
+  message: 'Too many requests, please try again later.',
+  standardHeaders: true,
+  legacyHeaders: false,
+})
+
+// Rate limiter for upload endpoints
+export const uploadRateLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 10,
+  message: 'Too many upload requests, please try again later.',
+  standardHeaders: true,
+  legacyHeaders: false,
+})
+
+// Rate limiter for schema creation (stricter)
+export const createRateLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 10,
+  message: 'Too many creation requests, please try again later.',
+  standardHeaders: true,
+  legacyHeaders: false,
+})

--- a/server/src/utils/tractionHelper.ts
+++ b/server/src/utils/tractionHelper.ts
@@ -1,9 +1,11 @@
 import type { AxiosRequestConfig, AxiosError } from 'axios'
 
 import axios from 'axios'
+import { v4 as uuidv4 } from 'uuid'
 
 import credentialsSeed from '../../scripts/values/credentials.json'
 import { CredentialModel } from '../db/models/Credential'
+import { DidModel } from '../db/models/Did'
 import { SchemaModel } from '../db/models/Schema'
 
 import logger from './logger'
@@ -174,137 +176,218 @@ export const tractionGarbageCollection = async () => {
   )
 }
 
-export const checkSeededSchemasExistOrCreate = async () => {
-  try {
-    // Iterate through seeded credentials and log their name and version
-    const issuerDid = (await tractionRequest.get('/wallet/did/public')).data.result.did
+export interface SeedCredential {
+  _id: string
+  name: string
+  version: string
+  attributes: SeedCredentialAttribute[]
 
-    for (const credential of credentialsSeed) {
-      logger.info(`Schema ${credential.name} v${credential.version} Checking seeded schema existence`)
+  // populated later
+  schema_id?: string
+  cred_def_id?: string
+}
 
-      // First check if schema already exists in MongoDB
-      const existingSchema = await SchemaModel.findOne({
+export interface SeedCredentialAttribute {
+  name: string
+}
+
+export async function getOrCreateIndyDid(): Promise<string> {
+  const results = (
+    await tractionRequest.get('/wallet/did', {
+      params: {
+        method: 'sov',
+        posture: 'posted',
+      },
+    })
+  ).data.results
+
+  if (results?.length) {
+    return results[0].did
+  }
+
+  logger.info('No posted Indy DID found, creating one')
+
+  return (
+    await tractionRequest.post('/wallet/did/create', {
+      method: 'sov',
+    })
+  ).data.result.did
+}
+
+export async function getOrCreateWebvhDid(): Promise<string> {
+  const results = (
+    await tractionRequest.get('/wallet/did', {
+      params: {
+        method: 'webvh',
+        posture: 'posted',
+      },
+    })
+  ).data.results
+
+  if (results?.length) {
+    return results[0].did
+  }
+
+  return (
+    await tractionRequest.post('/did/webvh/create', {
+      options: {
+        server_url: 'https://sandbox.bcvh.vonx.io',
+        namespace: 'showcase',
+        identifier: uuidv4(),
+      },
+    })
+  ).data.state.id
+}
+
+export async function ensureDidInDatabase(did: string, method: 'indy' | 'webvh'): Promise<void> {
+  await DidModel.updateOne(
+    { _id: did },
+    {
+      $setOnInsert: {
+        did,
+        method,
+      },
+    },
+    { upsert: true },
+  )
+}
+
+export async function findSchemaInTraction(name: string, version: string): Promise<string | null> {
+  const schemaIds = (
+    await tractionRequest.get('/anoncreds/schemas', {
+      params: {
+        schema_name: name,
+        schema_version: version,
+      },
+    })
+  ).data.schema_ids
+
+  return schemaIds[0] ?? null
+}
+
+export async function getOrCreateCredDef(issuerDid: string, schemaId: string, schemaName: string): Promise<string> {
+  const credDefs = (
+    await tractionRequest.get('/anoncreds/credential-definitions', {
+      params: {
+        schema_id: schemaId,
+      },
+    })
+  ).data.credential_definition_ids
+
+  if (credDefs?.length) {
+    return credDefs[0]
+  }
+
+  return createCredentialDefinition(issuerDid, schemaId, schemaName)
+}
+
+export async function syncSchemaToDatabase(credential: SeedCredential, schemaId: string, credDefId: string) {
+  await SchemaModel.updateOne(
+    { _id: schemaId },
+    {
+      $set: {
         name: credential.name,
         version: credential.version,
-      })
+        attrNames: credential.attributes.map((a) => a.name),
+        credDefId,
+      },
+    },
+    { upsert: true },
+  )
 
-      if (existingSchema) {
-        logger.info(`Schema ${credential.name} v${credential.version} Already exists in database`)
-        continue
-      }
+  await CredentialModel.updateOne(
+    { _id: credential._id },
+    {
+      $set: {
+        schema_id: schemaId,
+        cred_def_id: credDefId,
+      },
+    },
+  )
+}
 
-      // Schema doesn't exist in MongoDB, make sure cred def is available in traction and create in MongoDB
-      const schemas = (
-        await tractionRequest.get('/anoncreds/schemas', {
-          params: {
-            schema_name: credential.name,
-            schema_version: credential.version,
+export async function createSchema(credential: SeedCredential, issuerDid: string): Promise<string> {
+  const response = await tractionRequest.post('/anoncreds/schema', {
+    schema: {
+      name: credential.name,
+      version: credential.version,
+      attrNames: credential.attributes.map((a) => a.name),
+      issuerId: issuerDid,
+    },
+  })
+
+  await new Promise((resolve) => setTimeout(resolve, 2000))
+
+  return response.data.schema_state.schema_id
+}
+
+export async function processSeededCredential(credential: SeedCredential, issuerDid: string) {
+  const existingSchema = await SchemaModel.findOne({
+    name: credential.name,
+    version: credential.version,
+  })
+
+  if (existingSchema) {
+    logger.info(`Schema ${credential.name} v${credential.version} already exists`)
+    return
+  }
+
+  let schemaId = await findSchemaInTraction(credential.name, credential.version)
+
+  if (!schemaId) {
+    logger.info(`Schema ${credential.name} v${credential.version} creating`)
+
+    schemaId = await createSchema(credential, issuerDid)
+  }
+
+  const credDefId = await getOrCreateCredDef(issuerDid, schemaId, credential.name)
+
+  await syncSchemaToDatabase(credential, schemaId, credDefId)
+}
+
+export async function populateMissingSchemaDids(issuerDid: string) {
+  // Add the indy issuer DID to any schemas in the database that are missing a DID,
+  // to ensure all schemas have an associated issuer DID for credential issuance
+  const allSchemas = await SchemaModel.find()
+  for (const schema of allSchemas) {
+    if (!schema.did) {
+      logger.info(`Schema ${schema.name} v${schema.version} has no DID, adding issuer DID`)
+      await SchemaModel.updateOne(
+        { _id: schema._id },
+        {
+          $set: {
+            did: issuerDid,
           },
-        } as any)
-      ).data.schema_ids
+        },
+        { upsert: true },
+      )
+    }
+  }
+}
 
-      if (schemas.length > 0) {
-        logger.info(`Schema ${credential.name} v${credential.version} Seeded schema already exists`)
-        try {
-          const schemaId = schemas[0]
-          // Try to find existing credential definition or create one
-          const credDefs = (
-            await tractionRequest.get('/anoncreds/credential-definitions', {
-              params: {
-                schema_id: schemaId,
-              },
-            } as any)
-          ).data.credential_definition_ids
+// This requires that the endorsement connections have been set up for the traction tenant beforehand,
+// and that the tenant has permissions to create schemas and credential definitions.
+// It will check for the existence of the seeded schemas in Traction and MongoDB,
+// and create any that are missing from either place, ensuring that the seeded schemas are available for issuance and listed in the admin UI.
+export const checkSeededSchemasExistOrCreate = async () => {
+  try {
+    logger.info('Checking seeded schemas')
 
-          let credDefId = credDefs?.[0]
-          if (!credDefId) {
-            logger.info(
-              `Schema ${credential.name} v${credential.version} Creating credential definition for existing schema`,
-            )
-            credDefId = await createCredentialDefinition(issuerDid, schemaId, credential.name)
-          }
+    const indyDid = await getOrCreateIndyDid()
+    const webvhDid = await getOrCreateWebvhDid()
 
-          // Save schema to MongoDB
-          await SchemaModel.updateOne(
-            { _id: schemaId },
-            {
-              $set: {
-                name: credential.name,
-                version: credential.version,
-                attrNames: credential.attributes.map((attr: any) => attr.name),
-                credDefId,
-              },
-            },
-            { upsert: true },
-          )
+    await ensureDidInDatabase(indyDid, 'indy')
+    await ensureDidInDatabase(webvhDid, 'webvh')
 
-          // Update Credential with schema_id and credDefId
-          await CredentialModel.updateOne(
-            { _id: credential._id },
-            {
-              $set: { schema_id: schemaId, cred_def_id: credDefId },
-            },
-            { upsert: false },
-          )
-          logger.info(`Schema ${credential.name} v${credential.version} Seeded schema synced to database`)
-        } catch (err) {
-          logger.error(
-            safeAxiosError(err),
-            `Schema ${credential.name} v${credential.version} Failed to sync existing schema to database`,
-          )
-        }
-      } else {
-        // Schema doesn't exist in Traction, create both schema and credential definition and add to MongoDB, also update Credential with schema_id and cred_def_id
-        try {
-          logger.info(`Schema ${credential.name} v${credential.version} Creating seeded schema`)
-          const createSchemaPayload = {
-            name: credential.name,
-            version: credential.version,
-            attrNames: credential.attributes.map((attr: any) => attr.name),
-            issuerId: issuerDid,
-          }
-          logger.debug({ createSchemaPayload }, 'Creating schema with payload')
-          const response = await tractionRequest.post('/anoncreds/schema', { schema: createSchemaPayload })
-
-          // Wait briefly to allow schema to be fully available in Traction before creating credential definition
-          await new Promise((r) => setTimeout(r, 2000))
-
-          const schemaId = response.data.schema_state.schema_id
-          const credDefId = await createCredentialDefinition(
-            issuerDid,
-            schemaId,
-            response.data.schema_state.schema.name,
-          )
-          // Save schema to MongoDB
-          await SchemaModel.updateOne(
-            { _id: schemaId },
-            {
-              $set: {
-                name: credential.name,
-                version: credential.version,
-                attrNames: credential.attributes.map((attr: any) => attr.name),
-                credDefId,
-              },
-            },
-            { upsert: true },
-          )
-          // Update Credential with schema_id and credDefId
-          await CredentialModel.updateOne(
-            { _id: credential._id },
-            {
-              $set: { schema_id: schemaId, cred_def_id: credDefId },
-            },
-            { upsert: false },
-          )
-          logger.info(`Schema ${credential.name} v${credential.version} Seeded schema created successfully`)
-        } catch (err) {
-          logger.error(
-            safeAxiosError(err),
-            `Schema ${credential.name} v${credential.version} Failed to create seeded schema or credential definition`,
-          )
-        }
+    for (const credential of credentialsSeed) {
+      try {
+        await processSeededCredential(credential, indyDid)
+      } catch (err) {
+        logger.error(safeAxiosError(err), `Failed processing ${credential.name}`)
       }
     }
+
+    await populateMissingSchemaDids(indyDid)
   } catch (err) {
     logger.error(safeAxiosError(err), 'Failed to process seeded schemas')
   }

--- a/server/src/utils/tractionHelper.ts
+++ b/server/src/utils/tractionHelper.ts
@@ -231,8 +231,8 @@ export async function getOrCreateWebvhDid(): Promise<string> {
   return (
     await tractionRequest.post('/did/webvh/create', {
       options: {
-        server_url: 'https://sandbox.bcvh.vonx.io',
-        namespace: 'showcase',
+        server_url: process.env.WEBVH_SERVER_URL,
+        namespace: process.env.WEBVH_NAMESPACE,
         identifier: uuidv4(),
       },
     })


### PR DESCRIPTION
Adds webvh support with the following features:
 - Seeds a indy and webvh did. (Requires tenant setup endorsement connections beforehand)
 - Adds a did to the schema model.
 - Sets the existing schemas to the indy did
 - Did endpoints to get the 2 dids.
 - Did method selector during schema creation.
 - Remove all traction public did usage.
 - Remove schema name strategy for UI progress in favour of the schema_id. This is individual redux state so it's not important to be the name.
 - UI elements to see the did method on the schema.
 - Refactor the complex seed function into isolated purposes.