### PR TITLE
feat: Preview mode

### DIFF
--- a/frontend/src/admin/components/showcase/PreviewPanel.tsx
+++ b/frontend/src/admin/components/showcase/PreviewPanel.tsx
@@ -2,8 +2,6 @@ import { ArrowsPointingInIcon, ArrowsPointingOutIcon } from '@heroicons/react/24
 import { AnimatePresence, motion } from 'framer-motion'
 import { useEffect, useState } from 'react'
 
-import { publicBaseUrl } from '../../api/adminApi'
-
 interface PreviewPanelProps {
   isExpanded: boolean
   iframeRefreshKey: number
@@ -15,25 +13,44 @@ interface PreviewPanelProps {
 export function PreviewPanel({ isExpanded, iframeRefreshKey, showcaseName, urlPath, type }: PreviewPanelProps) {
   const [isFullscreen, setIsFullscreen] = useState(false)
   const typeParam = type || urlPath
-  const src = `${publicBaseUrl}/preview/${urlPath}?refresh=${iframeRefreshKey}&type=${typeParam}&showcase=${showcaseName}`
 
+  // Build URL with proper query parameter encoding using client app origin
+  const params = new URLSearchParams({
+    refresh: String(iframeRefreshKey),
+    type: typeParam,
+    showcase: showcaseName,
+  })
+  const src = `${window.location.origin}/digital-trust/showcase/preview/${urlPath}?${params.toString()}`
+
+  // Handle fullscreen mode and keyboard escape
   useEffect(() => {
+    if (!isFullscreen) return
+
+    // Store the previous overflow value to restore it later
+    const previousOverflow = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+
     const handleEscapeKey = (event: KeyboardEvent) => {
-      if (event.key === 'Escape' && isFullscreen) {
+      if (event.key === 'Escape') {
         setIsFullscreen(false)
       }
     }
 
-    if (isFullscreen) {
-      document.addEventListener('keydown', handleEscapeKey)
-      document.body.style.overflow = 'hidden'
-    }
+    document.addEventListener('keydown', handleEscapeKey)
 
     return () => {
       document.removeEventListener('keydown', handleEscapeKey)
-      document.body.style.overflow = 'unset'
+      // Restore the previous overflow value instead of always resetting to 'unset'
+      document.body.style.overflow = previousOverflow
     }
   }, [isFullscreen])
+
+  // Exit fullscreen when panel is collapsed
+  useEffect(() => {
+    if (!isExpanded && isFullscreen) {
+      setIsFullscreen(false)
+    }
+  }, [isExpanded])
 
   const previewContent = (
     <div

--- a/frontend/src/admin/components/showcase/PreviewPanel.tsx
+++ b/frontend/src/admin/components/showcase/PreviewPanel.tsx
@@ -2,6 +2,8 @@ import { ArrowsPointingInIcon, ArrowsPointingOutIcon } from '@heroicons/react/24
 import { AnimatePresence, motion } from 'framer-motion'
 import { useEffect, useState } from 'react'
 
+import { publicBaseUrl } from '../../api/adminApi'
+
 interface PreviewPanelProps {
   isExpanded: boolean
   iframeRefreshKey: number
@@ -13,7 +15,7 @@ interface PreviewPanelProps {
 export function PreviewPanel({ isExpanded, iframeRefreshKey, showcaseName, urlPath, type }: PreviewPanelProps) {
   const [isFullscreen, setIsFullscreen] = useState(false)
   const typeParam = type || urlPath
-  const src = `http://localhost:3000/digital-trust/showcase/preview/${urlPath}?refresh=${iframeRefreshKey}&type=${typeParam}&showcase=${showcaseName}`
+  const src = `${publicBaseUrl}/preview/${urlPath}?refresh=${iframeRefreshKey}&type=${typeParam}&showcase=${showcaseName}`
 
   useEffect(() => {
     const handleEscapeKey = (event: KeyboardEvent) => {

--- a/frontend/src/admin/components/showcase/PreviewPanel.tsx
+++ b/frontend/src/admin/components/showcase/PreviewPanel.tsx
@@ -1,0 +1,94 @@
+import { ArrowsPointingInIcon, ArrowsPointingOutIcon } from '@heroicons/react/24/outline'
+import { AnimatePresence, motion } from 'framer-motion'
+import { useEffect, useState } from 'react'
+
+interface PreviewPanelProps {
+  isExpanded: boolean
+  iframeRefreshKey: number
+  showcaseName: string
+  urlPath: string
+  type?: string
+}
+
+export function PreviewPanel({ isExpanded, iframeRefreshKey, showcaseName, urlPath, type }: PreviewPanelProps) {
+  const [isFullscreen, setIsFullscreen] = useState(false)
+  const typeParam = type || urlPath
+  const src = `http://localhost:3000/digital-trust/showcase/preview/${urlPath}?refresh=${iframeRefreshKey}&type=${typeParam}&showcase=${showcaseName}`
+
+  useEffect(() => {
+    const handleEscapeKey = (event: KeyboardEvent) => {
+      if (event.key === 'Escape' && isFullscreen) {
+        setIsFullscreen(false)
+      }
+    }
+
+    if (isFullscreen) {
+      document.addEventListener('keydown', handleEscapeKey)
+      document.body.style.overflow = 'hidden'
+    }
+
+    return () => {
+      document.removeEventListener('keydown', handleEscapeKey)
+      document.body.style.overflow = 'unset'
+    }
+  }, [isFullscreen])
+
+  const previewContent = (
+    <div
+      className={`border border-gray-300 rounded-lg bg-gray-800 overflow-hidden shadow-lg ${isFullscreen ? 'h-full' : ''}`}
+    >
+      <div className="bg-gray-700 px-4 py-2 border-b border-gray-600 flex items-center justify-between">
+        <h3 className="text-sm font-semibold text-white">Preview</h3>
+        <button
+          onClick={() => setIsFullscreen(!isFullscreen)}
+          className="text-white hover:bg-gray-600 rounded p-1 transition-colors"
+          title={isFullscreen ? 'Exit fullscreen (ESC)' : 'Expand to fullscreen'}
+          aria-label={isFullscreen ? 'Exit fullscreen' : 'Expand to fullscreen'}
+        >
+          {isFullscreen ? <ArrowsPointingInIcon className="w-5 h-5" /> : <ArrowsPointingOutIcon className="w-5 h-5" />}
+        </button>
+      </div>
+      <div
+        style={
+          isFullscreen
+            ? { width: '100%', height: 'calc(100% - 40px)' }
+            : { width: '100%', height: '460px', overflow: 'hidden' }
+        }
+      >
+        <iframe
+          key={iframeRefreshKey}
+          src={src}
+          style={
+            isFullscreen
+              ? { transform: 'scale(1)', width: '100%', height: '100%' }
+              : { transform: 'scale(0.50)', transformOrigin: 'top left', width: '200%', height: '200%' }
+          }
+          className="border-none"
+          title="Client Preview"
+          sandbox="allow-same-origin allow-scripts allow-popups allow-forms"
+        />
+      </div>
+    </div>
+  )
+
+  if (isFullscreen) {
+    return <div className="fixed inset-0 bg-black z-50">{previewContent}</div>
+  }
+
+  return (
+    <AnimatePresence mode="wait">
+      {isExpanded && (
+        <motion.div
+          className="flex-shrink-0 bg-gray-50 rounded-lg p-4 sticky top-8"
+          style={{ width: '600px' }}
+          initial={{ opacity: 0, x: 20 }}
+          animate={{ opacity: 1, x: 0 }}
+          exit={{ opacity: 0, x: 20 }}
+          transition={{ duration: 0.3, ease: 'easeInOut' }}
+        >
+          {previewContent}
+        </motion.div>
+      )}
+    </AnimatePresence>
+  )
+}

--- a/frontend/src/admin/components/showcase/buttons/PreviewToggleButton.tsx
+++ b/frontend/src/admin/components/showcase/buttons/PreviewToggleButton.tsx
@@ -1,0 +1,19 @@
+import { EyeIcon, EyeSlashIcon } from '@heroicons/react/24/outline'
+
+interface PreviewToggleButtonProps {
+  isExpanded: boolean
+  onToggle: () => void
+}
+
+export function PreviewToggleButton({ isExpanded, onToggle }: PreviewToggleButtonProps) {
+  return (
+    <button
+      onClick={onToggle}
+      className="px-4 py-2 bg-gray-100 text-bcgov-black font-medium rounded-lg border border-gray-300 hover:bg-gray-200 transition-colors flex items-center gap-2"
+      title={isExpanded ? 'Hide preview' : 'Show preview'}
+    >
+      {isExpanded ? <EyeIcon className="w-4 h-4" /> : <EyeSlashIcon className="w-4 h-4" />}
+      Preview
+    </button>
+  )
+}

--- a/frontend/src/admin/components/showcase/introduction/IntroductionTab.tsx
+++ b/frontend/src/admin/components/showcase/introduction/IntroductionTab.tsx
@@ -6,6 +6,8 @@ import { useAuth } from 'react-oidc-context'
 import { useDragReorder } from '../../../hooks/useDragReorder'
 import { useIntroductionScreens } from '../../../hooks/useIntroductionScreens'
 import { useLineHeightWithProgressIcons } from '../../../hooks/useLineHeightWithProgressIcons'
+import { PreviewPanel } from '../PreviewPanel'
+import { PreviewToggleButton } from '../buttons/PreviewToggleButton'
 import { CreateConnectAndAcceptScreensModal } from '../modals/CreateConnectAndAcceptScreensModal'
 import { CreateOrEditScreenModal } from '../modals/CreateOrEditScreenModal'
 import { DeleteConfirmationModal } from '../modals/DeleteConfirmationModal'
@@ -18,13 +20,23 @@ interface IntroductionTabProps {
   isNewShowcase?: boolean
   onTabChange?: (tab: string) => void
   onRefresh?: () => void | Promise<void>
+  isExpanded: boolean
+  setIsExpanded: (expanded: boolean) => void
 }
 
-export function IntroductionTab({ showcase, isNewShowcase, onTabChange, onRefresh }: IntroductionTabProps) {
+export function IntroductionTab({
+  showcase,
+  isNewShowcase,
+  onTabChange,
+  onRefresh,
+  isExpanded,
+  setIsExpanded,
+}: IntroductionTabProps) {
   const auth = useAuth()
   const [showIntroductionModal, setShowIntroductionModal] = useState<boolean>(isNewShowcase ?? false)
   const [hoverIdx, setHoverIdx] = useState<string | number | null>(null)
   const [isSelectCredentialModalOpen, setIsSelectCredentialModalOpen] = useState(false)
+  const [iframeRefreshKey, setIframeRefreshKey] = useState(0)
   const containerRef = useRef<HTMLDivElement>(null)
 
   const { draggedIdx, dragOverIdx, handleDragStart, handleDragOver, handleDragLeave, setDraggedIdx, setDragOverIdx } =
@@ -50,50 +62,95 @@ export function IntroductionTab({ showcase, isNewShowcase, onTabChange, onRefres
 
   const lineHeight = useLineHeightWithProgressIcons(containerRef, [showcase.introduction, reorderedIntroduction])
 
+  const handleSaveScreenWithRefresh = async (...args: Parameters<typeof handleSaveScreen>) => {
+    await handleSaveScreen(...args)
+    setIframeRefreshKey((prev) => prev + 1)
+  }
+
+  const handleDropWithRefresh = async (dropIdx: number) => {
+    await handleDrop(dropIdx, draggedIdx, setDraggedIdx, setDragOverIdx)
+    setIframeRefreshKey((prev) => prev + 1)
+  }
+
+  const handleDeleteWithRefresh = async (deleteIdx: number) => {
+    await handleDeleteConnectAcceptPair(deleteIdx)
+    setIframeRefreshKey((prev) => prev + 1)
+  }
+
+  const handleAddScreenClickWithRefresh = async (...args: Parameters<typeof handleAddScreenClick>) => {
+    await handleAddScreenClick(...args)
+    setIframeRefreshKey((prev) => prev + 1)
+  }
+
   return (
-    <div className="flex-1 overflow-auto flex flex-col items-center justify-start py-8">
-      {/* Introduction Tab */}
-      <div className="w-4/5 px-6 mb-8">
-        <h2 className="text-2xl font-semibold text-bcgov-black">Introduction Screens</h2>
-        <h5 className="text-gray-500 mt-2">Configure the introduction screens.</h5>
-      </div>
-      <div className="w-4/5 px-6">
-        <IntroductionTimeline
-          introduction={reorderedIntroduction || showcase.introduction || []}
-          showcase={showcase}
-          draggedIdx={draggedIdx}
-          dragOverIdx={dragOverIdx}
-          hoverIdx={hoverIdx}
-          setHoverIdx={setHoverIdx}
-          lineHeight={lineHeight}
-          containerRef={containerRef}
-          onEditClick={handleEditClick}
-          onAddScreenClick={handleAddScreenClick}
-          onShowDeleteConfirm={handleShowDeleteConfirm}
-          onDrop={(dropIdx) => handleDrop(dropIdx, draggedIdx, setDraggedIdx, setDragOverIdx)}
-          onDragStart={handleDragStart}
-          onDragOver={handleDragOver}
-          onDragLeave={handleDragLeave}
-          onSelectCredential={() => setIsSelectCredentialModalOpen(true)}
+    <div className="flex-1 overflow-auto flex gap-8 py-8 px-8">
+      {/* Left Column - Content */}
+      <div className="flex-1 flex flex-col items-center justify-start min-w-0">
+        {/* Introduction Tab */}
+        <div className="w-4/5 px-6 mb-8 flex justify-between items-start w-full">
+          <div className="flex-1">
+            <h2 className="text-2xl font-semibold text-bcgov-black">Introduction Screens</h2>
+            <h5 className="text-gray-500 mt-2">Configure the introduction screens.</h5>
+          </div>
+          <PreviewToggleButton isExpanded={isExpanded} onToggle={() => setIsExpanded(!isExpanded)} />
+        </div>
+        <div className="w-4/5 px-6">
+          <IntroductionTimeline
+            introduction={reorderedIntroduction || showcase.introduction || []}
+            showcase={showcase}
+            draggedIdx={draggedIdx}
+            dragOverIdx={dragOverIdx}
+            hoverIdx={hoverIdx}
+            setHoverIdx={setHoverIdx}
+            lineHeight={lineHeight}
+            containerRef={containerRef}
+            onEditClick={handleEditClick}
+            onAddScreenClick={handleAddScreenClickWithRefresh}
+            onShowDeleteConfirm={handleShowDeleteConfirm}
+            onDrop={handleDropWithRefresh}
+            onDragStart={handleDragStart}
+            onDragOver={handleDragOver}
+            onDragLeave={handleDragLeave}
+            onSelectCredential={() => setIsSelectCredentialModalOpen(true)}
+          />
+        </div>
+
+        <CreateOrEditScreenModal
+          isOpen={editingScreenIdx !== null}
+          onClose={closeEditModal}
+          screen={editingScreen}
+          progressBarStep={editingProgressBar}
+          isCreate={editingScreenIdx === -1}
+          screenType="introduction"
+          showcaseName={showcase.name}
+          auth={auth}
+          disableScreenId={isEditingPredefinedScreen && editingScreenIdx !== -1}
+          disableDelete={isEditingPredefinedScreen && editingScreenIdx !== -1}
+          onSave={handleSaveScreenWithRefresh}
+          onDelete={async () => {
+            await onRefresh?.()
+            closeEditModal()
+            setIframeRefreshKey((prev) => prev + 1)
+          }}
         />
+        {isNewShowcase && (
+          <div className="w-4/5 mt-8 px-6 flex justify-center">
+            <button
+              onClick={() => onTabChange?.('scenarios')}
+              className="px-6 py-2 bg-bcgov-blue text-white font-medium rounded-lg hover:bg-bcgov-blue-dark transition-colors"
+            >
+              Next Step
+            </button>
+          </div>
+        )}
       </div>
 
-      <CreateOrEditScreenModal
-        isOpen={editingScreenIdx !== null}
-        onClose={closeEditModal}
-        screen={editingScreen}
-        progressBarStep={editingProgressBar}
-        isCreate={editingScreenIdx === -1}
-        screenType="introduction"
+      {/* Right Column - Preview */}
+      <PreviewPanel
+        isExpanded={isExpanded}
+        iframeRefreshKey={iframeRefreshKey}
         showcaseName={showcase.name}
-        auth={auth}
-        disableScreenId={isEditingPredefinedScreen && editingScreenIdx !== -1}
-        disableDelete={isEditingPredefinedScreen && editingScreenIdx !== -1}
-        onSave={handleSaveScreen}
-        onDelete={async () => {
-          await onRefresh?.()
-          closeEditModal()
-        }}
+        urlPath="introduction"
       />
       <IntroductionInitializedModal
         isOpen={showIntroductionModal}
@@ -114,22 +171,11 @@ export function IntroductionTab({ showcase, isNewShowcase, onTabChange, onRefres
         onCancel={closeDeleteConfirm}
         onConfirm={() => {
           if (deleteConfirmIdx !== null) {
-            handleDeleteConnectAcceptPair(deleteConfirmIdx)
+            handleDeleteWithRefresh(deleteConfirmIdx)
           }
         }}
         showIcon={false}
       />
-
-      {isNewShowcase && (
-        <div className="w-4/5 mt-8 px-6 flex justify-center">
-          <button
-            onClick={() => onTabChange?.('scenarios')}
-            className="px-6 py-2 bg-bcgov-blue text-white font-medium rounded-lg hover:bg-bcgov-blue-dark transition-colors"
-          >
-            Next Step
-          </button>
-        </div>
-      )}
     </div>
   )
 }

--- a/frontend/src/admin/components/showcase/persona/PersonaTab.tsx
+++ b/frontend/src/admin/components/showcase/persona/PersonaTab.tsx
@@ -9,6 +9,8 @@ import { useErrorDisplay } from '../../../hooks/useErrorDisplay'
 import { useHasRole } from '../../../hooks/useUserRole'
 import log from '../../../utils/logger'
 import { ErrorBanner } from '../../ErrorBanner'
+import { PreviewPanel } from '../PreviewPanel'
+import { PreviewToggleButton } from '../buttons/PreviewToggleButton'
 import { ImageUploadModal } from '../modals/ImageUploadModal'
 
 interface PersonaTabProps {
@@ -17,9 +19,19 @@ interface PersonaTabProps {
   isNewShowcase?: boolean
   onTabChange?: (tab: string) => void
   onRefresh?: () => void | Promise<void>
+  isExpanded: boolean
+  setIsExpanded: (expanded: boolean) => void
 }
 
-export function PersonaTab({ showcase, isLoading, isNewShowcase, onTabChange, onRefresh }: PersonaTabProps) {
+export function PersonaTab({
+  showcase,
+  isLoading,
+  isNewShowcase,
+  onTabChange,
+  onRefresh,
+  isExpanded,
+  setIsExpanded,
+}: PersonaTabProps) {
   const auth = useAuth()
   const canEdit = useHasRole('creator')
   const [isEditingName, setIsEditingName] = useState(false)
@@ -29,6 +41,7 @@ export function PersonaTab({ showcase, isLoading, isNewShowcase, onTabChange, on
   const [isImageUploadModalOpen, setIsImageUploadModalOpen] = useState(false)
   const [isSaving, setIsSaving] = useState(false)
   const [localShowcase, setLocalShowcase] = useState(showcase)
+  const [iframeRefreshKey, setIframeRefreshKey] = useState(0)
   const { error: saveError, displayError, dismissError } = useErrorDisplay()
 
   useEffect(() => {
@@ -72,6 +85,7 @@ export function PersonaTab({ showcase, isLoading, isNewShowcase, onTabChange, on
       setIsEditingName(false)
       setIsEditingType(false)
       dismissError()
+      setIframeRefreshKey((prev) => prev + 1)
     } catch (error) {
       const message = error instanceof Error ? error.message : 'An error occurred while saving'
       displayError(message)
@@ -154,133 +168,152 @@ export function PersonaTab({ showcase, isLoading, isNewShowcase, onTabChange, on
   const handleImageUpdated = () => {
     // Refresh the showcase to get the latest data
     onRefresh?.()
+    setIframeRefreshKey((prev) => prev + 1)
   }
 
   return (
-    <div className="flex-1 overflow-auto flex flex-col items-center justify-start py-8">
-      {/* Persona Tab */}
-      <div className="w-full max-w-4xl mb-8 flex justify-between items-start">
-        <div>
-          <h2 className="text-2xl font-semibold text-bcgov-black">Setup Persona</h2>
-          <h5 className="text-gray-500 mt-2">
-            Configure the details for your persona. This will be the credential holder going through the showcase.
-          </h5>
-        </div>
-        {(name !== showcase.persona?.name || personaType !== showcase.persona?.type) && (
+    <div className="flex-1 overflow-auto flex gap-8 py-8 px-8">
+      {/* Left Column - Form */}
+      <div className="flex-1 flex flex-col items-center justify-start min-w-0">
+        {/* Persona Tab */}
+        <div className="w-full mb-8 flex justify-between items-start">
+          <div>
+            <h2 className="text-2xl font-semibold text-bcgov-black">Setup Persona</h2>
+            <h5 className="text-gray-500 mt-2">
+              Configure the details for your persona. This will be the credential holder going through the showcase.
+            </h5>
+          </div>
           <div className="flex flex-col gap-2 items-end">
-            <button
-              onClick={handleSave}
-              disabled={isSaving || !name.trim() || !personaType.trim()}
-              className="px-4 py-2 bg-bcgov-blue text-white font-medium rounded-lg hover:bg-bcgov-blue-dark transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-            >
-              {isSaving ? 'Saving...' : 'Save'}
-            </button>
-          </div>
-        )}
-      </div>
-      {saveError && (
-        <div className="w-full max-w-4xl mb-6">
-          <ErrorBanner error={saveError} onDismiss={dismissError} title="Error saving persona" variant="left-border" />
-        </div>
-      )}
-      <div className="w-full max-w-4xl px-6 border border-gray-300 rounded-lg bg-white p-8">
-        {/* Title Section */}
-        <div className="mb-8">
-          <label className="block text-sm font-bold text-bcgov-black mb-2">Name</label>
-          <div className="relative group">
-            <input
-              type="text"
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-              disabled={isLoading}
-              readOnly={!isEditingName && !isNewShowcase}
-              className={`w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-bcgov-blue ${
-                isEditingName || isNewShowcase ? 'bg-white text-bcgov-black' : 'bg-gray-100 text-gray-500'
-              }`}
-            />
-            {canEdit && (
-              <PencilIcon
-                onClick={() => setIsEditingName(true)}
-                className="absolute right-3 top-1/2 transform -translate-y-1/2 w-4 h-4 text-gray-400 opacity-0 group-hover:opacity-100 transition-opacity cursor-pointer"
-              />
-            )}
-          </div>
-        </div>
-
-        {/* Type Section */}
-        <div className="mb-8">
-          <label className="block text-sm font-bold text-bcgov-black mb-2">Type</label>
-          <div className="relative group">
-            <input
-              type="text"
-              value={personaType}
-              onChange={(e) => setPersonaType(e.target.value)}
-              disabled={isLoading}
-              readOnly={!isEditingType && !isNewShowcase}
-              className={`w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-bcgov-blue ${
-                isEditingType || isNewShowcase ? 'bg-white text-bcgov-black' : 'bg-gray-100 text-gray-500'
-              }`}
-            />
-            {canEdit && (
-              <PencilIcon
-                onClick={() => setIsEditingType(true)}
-                className="absolute right-3 top-1/2 transform -translate-y-1/2 w-4 h-4 text-gray-400 opacity-0 group-hover:opacity-100 transition-opacity cursor-pointer"
-              />
-            )}
-          </div>
-        </div>
-
-        {/* Image Section */}
-        <div className="mb-8">
-          <label className="block text-sm font-bold text-bcgov-black mb-2">Image</label>
-          <div className="relative group w-fit">
-            {localShowcase.persona?.image ? (
-              <div className="w-24 h-24 border border-gray-300 rounded-lg overflow-hidden bg-gray-100">
-                <img
-                  src={`${publicBaseUrl}${localShowcase.persona?.image}`}
-                  alt={localShowcase.persona?.name}
-                  className="w-full h-full object-contain"
-                />
-                {canEdit && (
-                  <PencilIcon
-                    onClick={() => setIsImageUploadModalOpen(true)}
-                    className="absolute -top-2 -right-2 w-5 h-5 bg-bcgov-blue text-white p-1 rounded-full opacity-0 group-hover:opacity-100 transition-opacity cursor-pointer"
-                  />
-                )}
-              </div>
-            ) : (
+            <PreviewToggleButton isExpanded={isExpanded} onToggle={() => setIsExpanded(!isExpanded)} />
+            {(name !== showcase.persona?.name || personaType !== showcase.persona?.type) && (
               <button
-                onClick={() => setIsImageUploadModalOpen(true)}
-                className="px-3 py-2 bg-white text-bcgov-black font-medium rounded-lg border border-gray-300 hover:bg-gray-50 transition-colors text-sm flex items-center gap-2"
+                onClick={handleSave}
+                disabled={isSaving || !name.trim() || !personaType.trim()}
+                className="px-4 py-2 bg-bcgov-blue text-white font-medium rounded-lg hover:bg-bcgov-blue-dark transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
               >
-                <ArrowUpTrayIcon className="w-4 h-4" />
-                Add Image
+                {isSaving ? 'Saving...' : 'Save'}
               </button>
             )}
           </div>
         </div>
-      </div>
-      {isNewShowcase && (
-        <div className="w-full max-w-4xl mt-8 px-6 flex justify-center">
-          <button
-            onClick={handleNextStep}
-            disabled={isSaving || !name.trim() || !personaType.trim() || !localShowcase.persona?.image}
-            className="px-6 py-2 bg-bcgov-blue text-white font-medium rounded-lg hover:bg-bcgov-blue-dark transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-          >
-            {isSaving ? 'Saving...' : 'Next Step'}
-          </button>
+        {saveError && (
+          <div className="w-full mb-6">
+            <ErrorBanner
+              error={saveError}
+              onDismiss={dismissError}
+              title="Error saving persona"
+              variant="left-border"
+            />
+          </div>
+        )}
+        <div className="w-full max-w-6xl border border-gray-300 rounded-lg bg-white p-8">
+          {/* Title Section */}
+          <div className="mb-8">
+            <label className="block text-sm font-bold text-bcgov-black mb-2">Name</label>
+            <div className="relative group">
+              <input
+                type="text"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                disabled={isLoading}
+                readOnly={!isEditingName && !isNewShowcase}
+                className={`w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-bcgov-blue ${
+                  isEditingName || isNewShowcase ? 'bg-white text-bcgov-black' : 'bg-gray-100 text-gray-500'
+                }`}
+              />
+              {canEdit && (
+                <PencilIcon
+                  onClick={() => setIsEditingName(true)}
+                  className="absolute right-3 top-1/2 transform -translate-y-1/2 w-4 h-4 text-gray-400 opacity-0 group-hover:opacity-100 transition-opacity cursor-pointer"
+                />
+              )}
+            </div>
+          </div>
+
+          {/* Type Section */}
+          <div className="mb-8">
+            <label className="block text-sm font-bold text-bcgov-black mb-2">Type</label>
+            <div className="relative group">
+              <input
+                type="text"
+                value={personaType}
+                onChange={(e) => setPersonaType(e.target.value)}
+                disabled={isLoading}
+                readOnly={!isEditingType && !isNewShowcase}
+                className={`w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-bcgov-blue ${
+                  isEditingType || isNewShowcase ? 'bg-white text-bcgov-black' : 'bg-gray-100 text-gray-500'
+                }`}
+              />
+              {canEdit && (
+                <PencilIcon
+                  onClick={() => setIsEditingType(true)}
+                  className="absolute right-3 top-1/2 transform -translate-y-1/2 w-4 h-4 text-gray-400 opacity-0 group-hover:opacity-100 transition-opacity cursor-pointer"
+                />
+              )}
+            </div>
+          </div>
+
+          {/* Image Section */}
+          <div className="mb-8">
+            <label className="block text-sm font-bold text-bcgov-black mb-2">Image</label>
+            <div className="relative group w-fit">
+              {localShowcase.persona?.image ? (
+                <div className="w-24 h-24 border border-gray-300 rounded-lg overflow-hidden bg-gray-100">
+                  <img
+                    src={`${publicBaseUrl}${localShowcase.persona?.image}`}
+                    alt={localShowcase.persona?.name}
+                    className="w-full h-full object-contain"
+                  />
+                  {canEdit && (
+                    <PencilIcon
+                      onClick={() => setIsImageUploadModalOpen(true)}
+                      className="absolute -top-2 -right-2 w-5 h-5 bg-bcgov-blue text-white p-1 rounded-full opacity-0 group-hover:opacity-100 transition-opacity cursor-pointer"
+                    />
+                  )}
+                </div>
+              ) : (
+                <button
+                  onClick={() => setIsImageUploadModalOpen(true)}
+                  className="px-3 py-2 bg-white text-bcgov-black font-medium rounded-lg border border-gray-300 hover:bg-gray-50 transition-colors text-sm flex items-center gap-2"
+                >
+                  <ArrowUpTrayIcon className="w-4 h-4" />
+                  Add Image
+                </button>
+              )}
+            </div>
+          </div>
         </div>
-      )}
-      <ImageUploadModal
-        isOpen={isImageUploadModalOpen}
-        onClose={() => setIsImageUploadModalOpen(false)}
+        {isNewShowcase && (
+          <div className="w-full mt-8 flex justify-center">
+            <button
+              onClick={handleNextStep}
+              disabled={isSaving || !name.trim() || !personaType.trim() || !localShowcase.persona?.image}
+              className="px-6 py-2 bg-bcgov-blue text-white font-medium rounded-lg hover:bg-bcgov-blue-dark transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {isSaving ? 'Saving...' : 'Next Step'}
+            </button>
+          </div>
+        )}
+        <ImageUploadModal
+          isOpen={isImageUploadModalOpen}
+          onClose={() => setIsImageUploadModalOpen(false)}
+          type="persona"
+          onSelectImage={() => {}}
+          showcase={localShowcase}
+          propertyPath="persona.image"
+          onImageUpdated={() => {
+            handleImageUpdated()
+          }}
+        />
+      </div>
+
+      {/* Right Column - Preview */}
+      <PreviewPanel
+        isExpanded={isExpanded}
+        iframeRefreshKey={iframeRefreshKey}
+        showcaseName={showcase.name}
+        urlPath="introduction"
         type="persona"
-        onSelectImage={() => {}}
-        showcase={localShowcase}
-        propertyPath="persona.image"
-        onImageUpdated={() => {
-          handleImageUpdated()
-        }}
       />
     </div>
   )

--- a/frontend/src/admin/components/showcase/scenarios/ScenarioScreenRow.tsx
+++ b/frontend/src/admin/components/showcase/scenarios/ScenarioScreenRow.tsx
@@ -101,12 +101,26 @@ export function ScenarioScreenRow({
                         {cred.predicates && cred.predicates.length > 0 && (
                           <div className="text-xs space-y-1 ml-2 mt-2">
                             <p className="font-semibold text-gray-700">Predicates:</p>
-                            {cred.predicates.map((pred, predIdx) => (
-                              <div key={predIdx} className="text-gray-600 flex items-center gap-2">
-                                <span className="w-1 h-1 bg-gray-400 rounded-full"></span>
-                                {pred.name} {pred.type} {pred.value}
-                              </div>
-                            ))}
+                            {cred.predicates.map((pred, predIdx) => {
+                              let displayValue = pred.value
+                              if (typeof pred.value === 'string' && pred.value.startsWith('$dateint:')) {
+                                const years = parseInt(pred.value.replace('$dateint:', ''), 10)
+                                if (!isNaN(years)) {
+                                  if (years === 0) {
+                                    displayValue = 'Time of issuance'
+                                  } else {
+                                    const operator = years > 0 ? '+' : '-'
+                                    displayValue = `Time of issuance ${operator} ${Math.abs(years)} years`
+                                  }
+                                }
+                              }
+                              return (
+                                <div key={predIdx} className="text-gray-600 flex items-center gap-2">
+                                  <span className="w-1 h-1 bg-gray-400 rounded-full"></span>
+                                  {pred.name} {pred.type} {displayValue}
+                                </div>
+                              )
+                            })}
                           </div>
                         )}
                         {cred.nonRevoked && (

--- a/frontend/src/admin/components/showcase/scenarios/ScenariosTab.tsx
+++ b/frontend/src/admin/components/showcase/scenarios/ScenariosTab.tsx
@@ -11,6 +11,8 @@ import { useLineHeight } from '../../../hooks/useLineHeight'
 import { useScenarioScreens } from '../../../hooks/useScenarioScreens'
 import { useHasRole } from '../../../hooks/useUserRole'
 import log from '../../../utils/logger'
+import { PreviewPanel } from '../PreviewPanel'
+import { PreviewToggleButton } from '../buttons/PreviewToggleButton'
 import { CreateConnectionAndProofScreensModal } from '../modals/CreateConnectionAndProofScreensModal'
 import { CreateOrEditScreenModal } from '../modals/CreateOrEditScreenModal'
 import { CreateScenarioModal } from '../modals/CreateScenarioModal'
@@ -23,9 +25,11 @@ interface ScenariosTabProps {
   isNewShowcase?: boolean
   onTabChange?: (tab: string) => void
   onRefresh?: () => void | Promise<void>
+  isExpanded: boolean
+  setIsExpanded: (expanded: boolean) => void
 }
 
-export function ScenariosTab({ showcase, isNewShowcase, onRefresh }: ScenariosTabProps) {
+export function ScenariosTab({ showcase, isNewShowcase, onRefresh, isExpanded, setIsExpanded }: ScenariosTabProps) {
   const navigate = useNavigate()
   const auth = useAuth()
   const canEdit = useHasRole('creator')
@@ -33,6 +37,7 @@ export function ScenariosTab({ showcase, isNewShowcase, onRefresh }: ScenariosTa
   const [isCreateScenarioModalOpen, setIsCreateScenarioModalOpen] = useState(false)
   const [isCreateConnectionProofModalOpen, setIsCreateConnectionProofModalOpen] = useState(false)
   const [hoverIdx, setHoverIdx] = useState<string | number | null>(null)
+  const [iframeRefreshKey, setIframeRefreshKey] = useState(0)
   const containerRef = useRef<HTMLDivElement>(null)
   const { draggedIdx, dragOverIdx, handleDragStart, handleDragOver, handleDragLeave, setDraggedIdx, setDragOverIdx } =
     useDragReorder()
@@ -63,6 +68,31 @@ export function ScenariosTab({ showcase, isNewShowcase, onRefresh }: ScenariosTa
 
   const lineHeight = useLineHeight(containerRef, [activeScenario, reorderedScreens])
 
+  const handleAddScreenClickWithRefresh = async (...args: Parameters<typeof handleAddScreenClick>) => {
+    await handleAddScreenClick(...args)
+    setIframeRefreshKey((prev) => prev + 1)
+  }
+
+  const handleSaveScreenWithRefresh = async (updatedScreen: ScenarioScreen) => {
+    await handleSaveScreen(updatedScreen)
+    setIframeRefreshKey((prev) => prev + 1)
+  }
+
+  const handleDropWithRefresh = async (dragIdx: number, dropIdx: number) => {
+    await handleDrop(dragIdx, dropIdx)
+    setIframeRefreshKey((prev) => prev + 1)
+  }
+
+  const handleDeleteScreenWithRefresh = async (screenIdx: number) => {
+    await handleDeleteScreen(screenIdx)
+    setIframeRefreshKey((prev) => prev + 1)
+  }
+
+  const handleDeleteConnectionProofPairWithRefresh = async (deleteIdx: number) => {
+    await handleDeleteConnectionProofPair(deleteIdx)
+    setIframeRefreshKey((prev) => prev + 1)
+  }
+
   const handleFinish = async () => {
     try {
       await updateShowcase(auth, showcase.name, { status: 'active' })
@@ -73,120 +103,135 @@ export function ScenariosTab({ showcase, isNewShowcase, onRefresh }: ScenariosTa
   }
 
   return (
-    <div className="flex-1 overflow-auto flex flex-col items-center justify-start py-8">
-      {/* Scenarios Tab */}
-      <div className="w-4/5 mb-8 px-6 flex items-center justify-between">
-        <div>
-          <h2 className="text-2xl font-semibold text-bcgov-black">Scenarios</h2>
-          <h5 className="text-gray-500 mt-2">Create scenarios to walk users through credential usage.</h5>
+    <div className="flex-1 overflow-auto flex gap-8 py-8 px-8">
+      {/* Left Column - Content */}
+      <div className="flex-1 flex flex-col items-center justify-start min-w-0">
+        {/* Scenarios Tab */}
+        <div className="w-4/5 mb-8 px-6 flex items-center justify-between w-full">
+          <div className="flex-1">
+            <h2 className="text-2xl font-semibold text-bcgov-black">Scenarios</h2>
+            <h5 className="text-gray-500 mt-2">Create scenarios to walk users through credential usage.</h5>
+          </div>
+          <div className="flex items-center gap-2 flex-shrink-0">
+            <PreviewToggleButton isExpanded={isExpanded} onToggle={() => setIsExpanded(!isExpanded)} />
+            {canEdit && (
+              <button
+                onClick={() => setIsCreateScenarioModalOpen(true)}
+                className="flex items-center gap-2 px-4 py-2 bg-bcgov-blue text-white hover:bg-blue-700 rounded-lg font-medium transition-colors"
+              >
+                <PlusIcon className="w-5 h-5" />
+                Create Scenario
+              </button>
+            )}
+          </div>
         </div>
-        {canEdit && (
-          <button
-            onClick={() => setIsCreateScenarioModalOpen(true)}
-            className="flex items-center gap-2 px-4 py-2 bg-bcgov-blue text-white hover:bg-blue-700 rounded-lg font-medium transition-colors"
-          >
-            <PlusIcon className="w-5 h-5" />
-            Create Scenario
-          </button>
+        {/* Inner Tabs for Scenarios */}
+        <div className="w-4/5 px-6 mb-6 w-full">
+          <div className="flex gap-4 border-b border-gray-200">
+            {showcase.scenarios?.map((scenario) => (
+              <button
+                key={scenario.id}
+                onClick={() => setActiveScenario(scenario.id)}
+                className={`py-2 px-3 font-medium transition-colors border-b-2 ${
+                  activeScenario === scenario.id
+                    ? 'border-bcgov-blue-light text-bcgov-blue-light'
+                    : 'border-transparent text-bcgov-darkgrey hover:text-bcgov-black'
+                }`}
+              >
+                {scenario.name}
+              </button>
+            ))}
+          </div>
+        </div>
+        {/* Scenario Content */}
+        <div className="w-4/5 px-6">
+          {showcase?.scenarios?.map((scenario) => {
+            const currentScreens = reorderedScreens[scenario.id] || scenario.screens || []
+            return activeScenario === scenario.id ? (
+              <ScenarioTimeline
+                key={scenario.id}
+                screens={currentScreens}
+                scenarioId={scenario.id}
+                lineHeight={lineHeight}
+                containerRef={containerRef}
+                draggedIdx={draggedIdx}
+                dragOverIdx={dragOverIdx}
+                hoverIdx={hoverIdx}
+                setHoverIdx={setHoverIdx}
+                onEditClick={handleEditClick}
+                onAddScreenClick={handleAddScreenClickWithRefresh}
+                onShowDeleteConfirm={handleShowDeleteConfirm}
+                onDragStart={handleDragStart}
+                onDragOver={handleDragOver}
+                onDragLeave={handleDragLeave}
+                onDrop={(dropIdx) => {
+                  if (draggedIdx !== null) {
+                    handleDropWithRefresh(draggedIdx, dropIdx)
+                  }
+                  setDraggedIdx(null)
+                  setDragOverIdx(null)
+                }}
+                onAddConnectionClick={() => setIsCreateConnectionProofModalOpen(true)}
+              />
+            ) : null
+          })}
+        </div>
+        <CreateOrEditScreenModal
+          isOpen={editingScreenIdx !== null}
+          onClose={closeEditModal}
+          screen={editingScreen as any}
+          progressBarStep={null}
+          isCreate={editingScreenIdx === -1}
+          screenType="scenarios"
+          showcaseName={showcase.name}
+          auth={auth}
+          disableScreenId={isEditingPredefinedScreen && editingScreenIdx !== -1}
+          disableDelete={isEditingPredefinedScreen && editingScreenIdx !== -1}
+          onSave={handleSaveScreenWithRefresh}
+          onDelete={async () => {
+            if (editingScreenIdx !== null && editingScreenIdx !== -1) {
+              await handleDeleteScreenWithRefresh(editingScreenIdx)
+            }
+          }}
+        />
+        <CreateScenarioModal
+          isOpen={isCreateScenarioModalOpen}
+          onClose={() => setIsCreateScenarioModalOpen(false)}
+          showcase={showcase}
+          auth={auth}
+          onRefresh={onRefresh}
+          onScenarioCreated={(scenarioId) => {
+            setIsCreateScenarioModalOpen(false)
+            setActiveScenario(scenarioId)
+          }}
+        />
+        <CreateConnectionAndProofScreensModal
+          isOpen={isCreateConnectionProofModalOpen}
+          onClose={() => setIsCreateConnectionProofModalOpen(false)}
+          showcase={showcase}
+          scenarioId={activeScenario}
+          onComplete={onRefresh}
+        />
+        {isNewShowcase && (
+          <div className="w-4/5 mt-8 px-6 flex justify-center w-full">
+            <button
+              onClick={handleFinish}
+              className="px-6 py-2 bg-bcgov-blue text-white font-medium rounded-lg hover:bg-bcgov-blue-dark transition-colors"
+            >
+              Finish
+            </button>
+          </div>
         )}
       </div>
-      {/* Inner Tabs for Scenarios */}
-      <div className="w-4/5 px-6 mb-6">
-        <div className="flex gap-4 border-b border-gray-200">
-          {showcase.scenarios?.map((scenario) => (
-            <button
-              key={scenario.id}
-              onClick={() => setActiveScenario(scenario.id)}
-              className={`py-2 px-3 font-medium transition-colors border-b-2 ${
-                activeScenario === scenario.id
-                  ? 'border-bcgov-blue-light text-bcgov-blue-light'
-                  : 'border-transparent text-bcgov-darkgrey hover:text-bcgov-black'
-              }`}
-            >
-              {scenario.name}
-            </button>
-          ))}
-        </div>
-      </div>
-      {/* Scenario Content */}
-      <div className="w-4/5 px-6">
-        {showcase?.scenarios?.map((scenario) => {
-          const currentScreens = reorderedScreens[scenario.id] || scenario.screens || []
-          return activeScenario === scenario.id ? (
-            <ScenarioTimeline
-              key={scenario.id}
-              screens={currentScreens}
-              scenarioId={scenario.id}
-              lineHeight={lineHeight}
-              containerRef={containerRef}
-              draggedIdx={draggedIdx}
-              dragOverIdx={dragOverIdx}
-              hoverIdx={hoverIdx}
-              setHoverIdx={setHoverIdx}
-              onEditClick={handleEditClick}
-              onAddScreenClick={handleAddScreenClick}
-              onShowDeleteConfirm={handleShowDeleteConfirm}
-              onDragStart={handleDragStart}
-              onDragOver={handleDragOver}
-              onDragLeave={handleDragLeave}
-              onDrop={(dropIdx) => {
-                if (draggedIdx !== null) {
-                  handleDrop(draggedIdx, dropIdx)
-                }
-                setDraggedIdx(null)
-                setDragOverIdx(null)
-              }}
-              onAddConnectionClick={() => setIsCreateConnectionProofModalOpen(true)}
-            />
-          ) : null
-        })}
-      </div>
-      <CreateOrEditScreenModal
-        isOpen={editingScreenIdx !== null}
-        onClose={closeEditModal}
-        screen={editingScreen as any}
-        progressBarStep={null}
-        isCreate={editingScreenIdx === -1}
-        screenType="scenarios"
+
+      {/* Right Column - Preview */}
+      <PreviewPanel
+        isExpanded={isExpanded}
+        iframeRefreshKey={iframeRefreshKey}
         showcaseName={showcase.name}
-        auth={auth}
-        disableScreenId={isEditingPredefinedScreen && editingScreenIdx !== -1}
-        disableDelete={isEditingPredefinedScreen && editingScreenIdx !== -1}
-        onSave={(updatedScreen) => handleSaveScreen(updatedScreen as ScenarioScreen)}
-        onDelete={async () => {
-          if (editingScreenIdx !== null && editingScreenIdx !== -1) {
-            await handleDeleteScreen(editingScreenIdx)
-          }
-        }}
+        urlPath="scenarios"
+        type="scenarios"
       />
-      <CreateScenarioModal
-        isOpen={isCreateScenarioModalOpen}
-        onClose={() => setIsCreateScenarioModalOpen(false)}
-        showcase={showcase}
-        auth={auth}
-        onRefresh={onRefresh}
-        onScenarioCreated={(scenarioId) => {
-          setIsCreateScenarioModalOpen(false)
-          setActiveScenario(scenarioId)
-        }}
-      />
-      <CreateConnectionAndProofScreensModal
-        isOpen={isCreateConnectionProofModalOpen}
-        onClose={() => setIsCreateConnectionProofModalOpen(false)}
-        showcase={showcase}
-        scenarioId={activeScenario}
-        onComplete={onRefresh}
-      />
-      {isNewShowcase && (
-        <div className="w-4/5 mt-8 px-6 flex justify-center">
-          <button
-            onClick={handleFinish}
-            className="px-6 py-2 bg-bcgov-blue text-white font-medium rounded-lg hover:bg-bcgov-blue-dark transition-colors"
-          >
-            Finish
-          </button>
-        </div>
-      )}
       <DeleteConfirmationModal
         isOpen={showDeleteConfirm}
         title="Delete Connection and Proof Screens?"
@@ -194,7 +239,7 @@ export function ScenariosTab({ showcase, isNewShowcase, onRefresh }: ScenariosTa
         onCancel={closeDeleteConfirm}
         onConfirm={() => {
           if (deleteConfirmIdx !== null) {
-            handleDeleteConnectionProofPair(deleteConfirmIdx)
+            handleDeleteConnectionProofPairWithRefresh(deleteConfirmIdx)
           }
         }}
         showIcon={true}

--- a/frontend/src/admin/pages/ShowcasePage.tsx
+++ b/frontend/src/admin/pages/ShowcasePage.tsx
@@ -23,6 +23,7 @@ export function ShowcasePage() {
   const location = useLocation()
   const [searchParams, setSearchParams] = useSearchParams()
   const { showcase, isLoading, refetch } = useShowcase()
+  const [isExpanded, setIsExpanded] = useState(false)
   const [isNewShowcase, setIsNewShowcase] = useState(location.state?.isNewShowcase || false)
   const tabFromUrl = searchParams.get('tab')
   const [activeTab, setActiveTab] = useState<TabId>(isValidTabId(tabFromUrl) ? tabFromUrl : 'persona')
@@ -97,6 +98,8 @@ export function ShowcasePage() {
               isNewShowcase={isNewShowcase}
               onTabChange={(tab) => setActiveTab(tab as TabId)}
               onRefresh={refetch}
+              isExpanded={isExpanded}
+              setIsExpanded={setIsExpanded}
             />
           )}
           {activeTab === 'introduction' && (
@@ -105,6 +108,8 @@ export function ShowcasePage() {
               isNewShowcase={isNewShowcase}
               onTabChange={(tab) => setActiveTab(tab as TabId)}
               onRefresh={refetch}
+              isExpanded={isExpanded}
+              setIsExpanded={setIsExpanded}
             />
           )}
           {activeTab === 'scenarios' && (
@@ -113,6 +118,8 @@ export function ShowcasePage() {
               isNewShowcase={isNewShowcase}
               onTabChange={(tab) => setActiveTab(tab as TabId)}
               onRefresh={refetch}
+              isExpanded={isExpanded}
+              setIsExpanded={setIsExpanded}
             />
           )}
         </>

--- a/frontend/src/client/App.tsx
+++ b/frontend/src/client/App.tsx
@@ -12,6 +12,8 @@ import { PageNotFound } from './pages/PageNotFound'
 import { DashboardPage } from './pages/dashboard/DashboardPage'
 import { IntroductionPage } from './pages/introduction/IntroductionPage'
 import { LandingPage } from './pages/landing/LandingPage'
+import { IntroductionPreviewPage } from './pages/preview/IntroductionPreviewPage'
+import { ScenarioPreviewPage } from './pages/preview/ScenarioPreviewPage'
 import { ScenarioPage } from './pages/scenario/Scenario'
 import { useConnection } from './slices/connection/connectionSelectors'
 import { usePreferences } from './slices/preferences/preferencesSelectors'
@@ -96,6 +98,8 @@ function App() {
                 </PrivateRoute>
               }
             />
+            <Route path={`${basePath}/preview/introduction`} element={<IntroductionPreviewPage />} />
+            <Route path={`${basePath}/preview/scenarios`} element={<ScenarioPreviewPage />} />
             <Route path="*" element={<PageNotFound />} />
           </Routes>
         </AnimatePresence>

--- a/frontend/src/client/pages/introduction/IntroductionContainer.tsx
+++ b/frontend/src/client/pages/introduction/IntroductionContainer.tsx
@@ -37,6 +37,7 @@ export interface Props {
   invitationUrl?: string
   shortInvitationUrl?: string
   introductionStep: string
+  stopStep?: string
 }
 
 export const IntroductionContainer: React.FC<Props> = ({
@@ -47,6 +48,7 @@ export const IntroductionContainer: React.FC<Props> = ({
   connectionState,
   invitationUrl,
   shortInvitationUrl,
+  stopStep = '',
 }) => {
   const dispatch = useAppDispatch()
   const { issuedCredentials } = useCredentials()
@@ -59,6 +61,7 @@ export const IntroductionContainer: React.FC<Props> = ({
   const introStep = currentShowcase?.introduction.find((step) => step.screenId === introductionStep)
   const credentials = introStep?.credentials
   const credentialsAccepted = credentials?.every((cred) => issuedCredentials.includes(cred.schema_id || 'not-found'))
+  const isAtStopStep = !!(stopStep && introductionStep === stopStep)
 
   const isBackDisabled =
     introductionStep === 'PICK_CHARACTER' ||
@@ -68,7 +71,8 @@ export const IntroductionContainer: React.FC<Props> = ({
     (introductionStep.startsWith('CONNECT') && !connectionCompleted) ||
     (introductionStep.startsWith('ACCEPT_') && !credentialsAccepted) ||
     (introductionStep.startsWith('ACCEPT_') && credentials?.length === 0) ||
-    (introductionStep === 'PICK_CHARACTER' && !currentShowcase)
+    (introductionStep === 'PICK_CHARACTER' && !currentShowcase) ||
+    isAtStopStep
 
   const jumpIntroductionPage = () => {
     trackSelfDescribingEvent({

--- a/frontend/src/client/pages/preview/IntroductionPreviewPage.tsx
+++ b/frontend/src/client/pages/preview/IntroductionPreviewPage.tsx
@@ -1,0 +1,102 @@
+import { trackPageView } from '@snowplow/browser-tracker'
+import { AnimatePresence, motion } from 'framer-motion'
+import React, { useEffect, useMemo, useState } from 'react'
+import { useBeforeUnload, useSearchParams } from 'react-router-dom'
+
+import { page } from '../../FramerAnimations'
+import { CustomUpload } from '../../components/CustomUpload'
+import { useAppDispatch } from '../../hooks/hooks'
+import { useTitle } from '../../hooks/useTitle'
+import { useConnection } from '../../slices/connection/connectionSelectors'
+import { useIntroduction } from '../../slices/introduction/introductionSelectors'
+import { usePreferences } from '../../slices/preferences/preferencesSelectors'
+import { useShowcases } from '../../slices/showcases/showcasesSelectors'
+import { fetchAllShowcases } from '../../slices/showcases/showcasesThunks'
+import { fetchWallets } from '../../slices/wallets/walletsThunks'
+import { IntroductionContainer } from '../introduction/IntroductionContainer'
+import { Stepper } from '../introduction/components/Stepper'
+
+interface PreviewPageProps {
+  contentType?: 'introduction' | 'scenarios' | 'persona'
+}
+
+export const IntroductionPreviewPage: React.FC<PreviewPageProps> = ({ contentType: propContentType } = {}) => {
+  const [searchParams] = useSearchParams()
+  const contentType =
+    (searchParams.get('type') as 'introduction' | 'scenarios' | 'persona' | null) || propContentType || 'introduction'
+  const previewShowcaseName = searchParams.get('showcase') || undefined
+
+  useTitle('Get Started | BC Wallet Self-Sovereign Identity Demo')
+
+  const dispatch = useAppDispatch()
+  const { showcases, currentShowcase, uploadedShowcase } = useShowcases()
+
+  const { introductionStep } = useIntroduction()
+  const { state, invitationUrl, shortInvitationUrl, id } = useConnection()
+  const { showcaseUploadEnabled, showHiddenScenarios } = usePreferences()
+
+  const [mounted, setMounted] = useState(false)
+
+  const allShowcases = useMemo(() => {
+    const all = [...showcases]
+      .filter((showcase) => showcase.status === 'active' || showHiddenScenarios)
+      .filter((showcase) => {
+        return !previewShowcaseName || showcase.name === previewShowcaseName
+      })
+
+    if (uploadedShowcase) {
+      all.push(uploadedShowcase)
+    }
+
+    return all
+  }, [showcases, uploadedShowcase, showHiddenScenarios])
+
+  useEffect(() => {
+    dispatch({ type: 'demo/RESET' })
+    dispatch(fetchWallets())
+    dispatch(fetchAllShowcases())
+    setMounted(true)
+  }, [dispatch, showHiddenScenarios])
+
+  useEffect(() => {
+    trackPageView()
+  }, [])
+
+  useBeforeUnload(() => {
+    dispatch({ type: 'demo/RESET' })
+  })
+
+  const stopStep =
+    contentType === 'persona' ? 'PICK_CHARACTER' : contentType === 'introduction' ? 'SETUP_COMPLETED' : ''
+
+  const previewShowcase = currentShowcase || allShowcases[0]
+
+  return (
+    <>
+      {showcaseUploadEnabled && <CustomUpload />}
+      <motion.div
+        variants={page}
+        initial="hidden"
+        animate="show"
+        exit="exit"
+        className="container flex flex-col items-center p-4"
+      >
+        <Stepper currentShowcase={currentShowcase} introductionStep={introductionStep} />
+        <AnimatePresence mode="wait">
+          {mounted && (
+            <IntroductionContainer
+              showcases={allShowcases}
+              currentShowcase={contentType === 'persona' ? undefined : previewShowcase}
+              introductionStep={introductionStep}
+              connectionId={id}
+              connectionState={state}
+              invitationUrl={invitationUrl}
+              shortInvitationUrl={shortInvitationUrl}
+              stopStep={stopStep}
+            />
+          )}
+        </AnimatePresence>
+      </motion.div>
+    </>
+  )
+}

--- a/frontend/src/client/pages/preview/IntroductionPreviewPage.tsx
+++ b/frontend/src/client/pages/preview/IntroductionPreviewPage.tsx
@@ -48,7 +48,7 @@ export const IntroductionPreviewPage: React.FC<PreviewPageProps> = ({ contentTyp
     }
 
     return all
-  }, [showcases, uploadedShowcase, showHiddenScenarios])
+  }, [showcases, uploadedShowcase, showHiddenScenarios, previewShowcaseName])
 
   useEffect(() => {
     dispatch({ type: 'demo/RESET' })

--- a/frontend/src/client/pages/preview/IntroductionPreviewPage.tsx
+++ b/frontend/src/client/pages/preview/IntroductionPreviewPage.tsx
@@ -4,7 +4,6 @@ import React, { useEffect, useMemo, useState } from 'react'
 import { useBeforeUnload, useSearchParams } from 'react-router-dom'
 
 import { page } from '../../FramerAnimations'
-import { CustomUpload } from '../../components/CustomUpload'
 import { useAppDispatch } from '../../hooks/hooks'
 import { useTitle } from '../../hooks/useTitle'
 import { useConnection } from '../../slices/connection/connectionSelectors'
@@ -33,7 +32,7 @@ export const IntroductionPreviewPage: React.FC<PreviewPageProps> = ({ contentTyp
 
   const { introductionStep } = useIntroduction()
   const { state, invitationUrl, shortInvitationUrl, id } = useConnection()
-  const { showcaseUploadEnabled, showHiddenScenarios } = usePreferences()
+  const { showHiddenScenarios } = usePreferences()
 
   const [mounted, setMounted] = useState(false)
 
@@ -73,7 +72,6 @@ export const IntroductionPreviewPage: React.FC<PreviewPageProps> = ({ contentTyp
 
   return (
     <>
-      {showcaseUploadEnabled && <CustomUpload />}
       <motion.div
         variants={page}
         initial="hidden"
@@ -81,7 +79,7 @@ export const IntroductionPreviewPage: React.FC<PreviewPageProps> = ({ contentTyp
         exit="exit"
         className="container flex flex-col items-center p-4"
       >
-        <Stepper currentShowcase={currentShowcase} introductionStep={introductionStep} />
+        <Stepper currentShowcase={previewShowcase} introductionStep={introductionStep} />
         <AnimatePresence mode="wait">
           {mounted && (
             <IntroductionContainer

--- a/frontend/src/client/pages/preview/ScenarioPreviewPage.tsx
+++ b/frontend/src/client/pages/preview/ScenarioPreviewPage.tsx
@@ -94,7 +94,9 @@ export const ScenarioPreviewPage: React.FC = () => {
         </motion.div>
       )}
 
-      {activeScenario && <ScenarioPage propCurrentShowcase={previewShowcase} propSlug={activeScenario} />}
+      {activeScenario && (
+        <ScenarioPage propCurrentShowcase={previewShowcase} propSlug={activeScenario} explicitAllowForward={true} />
+      )}
     </>
   )
 }

--- a/frontend/src/client/pages/preview/ScenarioPreviewPage.tsx
+++ b/frontend/src/client/pages/preview/ScenarioPreviewPage.tsx
@@ -1,0 +1,100 @@
+import { motion } from 'framer-motion'
+import React, { useEffect, useState } from 'react'
+import { useBeforeUnload, useSearchParams } from 'react-router-dom'
+
+import { dashboardTitle, page, rowContainer } from '../../FramerAnimations'
+import { useAppDispatch } from '../../hooks/hooks'
+import { useShowcases } from '../../slices/showcases/showcasesSelectors'
+import { fetchAllShowcases } from '../../slices/showcases/showcasesThunks'
+import { ProfileCard } from '../dashboard/components/ProfileCard'
+import { ScenarioItem } from '../dashboard/components/ScenarioItem'
+import { NavBar } from '../landing/components/Navbar'
+import { ScenarioPage } from '../scenario/Scenario'
+
+export const ScenarioPreviewPage: React.FC = () => {
+  const [searchParams] = useSearchParams()
+  const previewShowcaseName = searchParams.get('showcase') || undefined
+  const [activeScenario, setActiveScenario] = useState<string | undefined>(undefined)
+  const { showcases } = useShowcases()
+  const dispatch = useAppDispatch()
+
+  useBeforeUnload(() => {
+    dispatch({ type: 'demo/RESET' })
+  })
+
+  useEffect(() => {
+    dispatch(fetchAllShowcases())
+  }, [dispatch, showcases.length])
+
+  const previewShowcase = showcases.find((showcase) => !previewShowcaseName || showcase.name === previewShowcaseName)
+
+  if (!previewShowcase) {
+    return <div>Loading...</div>
+  }
+
+  const startScenario = (slug: string) => {
+    setActiveScenario(slug)
+  }
+
+  const renderScenarios = previewShowcase.scenarios.map((item) => {
+    const requiredCredentials: string[] = []
+    item.screens.forEach((screen) =>
+      screen.requestOptions?.requestedCredentials.forEach((cred) => {
+        if (!requiredCredentials.includes(cred.name)) {
+          requiredCredentials.push(cred.name)
+        }
+      }),
+    )
+
+    return (
+      <ScenarioItem
+        key={item.id}
+        slug={item.id}
+        title={item.name}
+        requiredCredentials={requiredCredentials}
+        currentShowcase={previewShowcase}
+        start={startScenario}
+        isLocked={false}
+        isCompleted={false}
+      />
+    )
+  })
+
+  return (
+    <>
+      {!activeScenario && (
+        <motion.div
+          className="container flex flex-col h-screen justify-between"
+          variants={page}
+          initial="hidden"
+          animate="show"
+          exit="exit"
+        >
+          <div className="mx-8 my-4">
+            <NavBar />
+          </div>
+          <div className="flex flex-col lg:flex-row mb-auto">
+            <div className="w-full lg:w-2/3 order-last lg:order-first">
+              <div className="flex flex-col mx-4 lg:mx-4 my-2 p-4 md:p-6 lg:p-8 bg-white dark:bg-bcgov-darkgrey dark:text-white rounded-lg shadow-sm">
+                <motion.h1 variants={dashboardTitle} className="text-3xl md:text-4xl font-bold mb-2">
+                  Using your credentials
+                </motion.h1>
+                <motion.div
+                  variants={rowContainer}
+                  className="flex flex-col w-auto overflow-x-hidden md:overflow-x-visible"
+                >
+                  {renderScenarios}
+                </motion.div>
+              </div>
+            </div>
+            <div className="flex flex-1 flex-col p-2 mx-2 dark:text-white">
+              <ProfileCard currentShowcase={previewShowcase} />
+            </div>
+          </div>
+        </motion.div>
+      )}
+
+      {activeScenario && <ScenarioPage propCurrentShowcase={previewShowcase} propSlug={activeScenario} />}
+    </>
+  )
+}

--- a/frontend/src/client/pages/preview/ScenarioPreviewPage.tsx
+++ b/frontend/src/client/pages/preview/ScenarioPreviewPage.tsx
@@ -23,7 +23,9 @@ export const ScenarioPreviewPage: React.FC = () => {
   })
 
   useEffect(() => {
-    dispatch(fetchAllShowcases())
+    if (showcases.length === 0) {
+      dispatch(fetchAllShowcases())
+    }
   }, [dispatch, showcases.length])
 
   const previewShowcase = showcases.find((showcase) => !previewShowcaseName || showcase.name === previewShowcaseName)

--- a/frontend/src/client/pages/scenario/Scenario.tsx
+++ b/frontend/src/client/pages/scenario/Scenario.tsx
@@ -33,27 +33,27 @@ interface ScenarioPageProps {
 
 export const ScenarioPage: React.FC<ScenarioPageProps> = ({ propCurrentShowcase, propSlug, explicitAllowForward }) => {
   const dispatch = useAppDispatch()
-  let { slug } = useParams()
+  const { slug: routeSlug } = useParams()
   const { stepCount, sectionCount, isLoading } = useScenarioState()
-  let currentShowcase = useCurrentShowcase()
+  const hookShowcase = useCurrentShowcase()
   const { section } = useSection()
   const connection = useConnection()
   const { issuedCredentials } = useCredentials()
   const { proof, proofUrl } = useProof()
   const [currentScenario, setCurrentScenario] = useState<Scenario>()
-  if (propCurrentShowcase) {
-    currentShowcase = propCurrentShowcase
-    slug = propSlug
-  }
+
+  // Derive the effective showcase and slug from props or hooks, without mutating
+  const effectiveShowcase = propCurrentShowcase || hookShowcase
+  const effectiveSlug = propSlug || routeSlug
 
   const navigate = useNavigate()
   useTitle(`${currentScenario?.name ?? 'Use case'} | BC Wallet Self-Sovereign Identity Demo`)
 
   useEffect(() => {
-    if (currentShowcase && slug) {
-      setCurrentScenario(currentShowcase.scenarios.find((item: { id: string }) => item.id === slug))
+    if (effectiveShowcase && effectiveSlug) {
+      setCurrentScenario(effectiveShowcase.scenarios.find((item: { id: string }) => item.id === effectiveSlug))
     }
-  }, [])
+  }, [effectiveShowcase, effectiveSlug])
 
   useEffect(() => {
     if (currentScenario) {
@@ -100,7 +100,7 @@ export const ScenarioPage: React.FC<ScenarioPageProps> = ({ propCurrentShowcase,
         </div>
       ) : (
         <AnimatePresence mode="wait">
-          {currentShowcase && section && currentScenario ? (
+          {effectiveShowcase && section && currentScenario ? (
             <motion.div
               key={'sectionDiv' + section.screenId}
               initial={{ opacity: 0 }}

--- a/frontend/src/client/pages/scenario/Scenario.tsx
+++ b/frontend/src/client/pages/scenario/Scenario.tsx
@@ -28,9 +28,10 @@ import { Section } from './Section'
 interface ScenarioPageProps {
   propCurrentShowcase?: Showcase
   propSlug?: string
+  explicitAllowForward?: boolean
 }
 
-export const ScenarioPage: React.FC<ScenarioPageProps> = ({ propCurrentShowcase, propSlug }) => {
+export const ScenarioPage: React.FC<ScenarioPageProps> = ({ propCurrentShowcase, propSlug, explicitAllowForward }) => {
   const dispatch = useAppDispatch()
   let { slug } = useParams()
   const { stepCount, sectionCount, isLoading } = useScenarioState()
@@ -117,6 +118,7 @@ export const ScenarioPage: React.FC<ScenarioPageProps> = ({ propCurrentShowcase,
                 credentials={issuedCredentials}
                 proof={proof}
                 proofUrl={proofUrl}
+                explicitAllowForward={explicitAllowForward}
               />
             </motion.div>
           ) : (

--- a/frontend/src/client/pages/scenario/Scenario.tsx
+++ b/frontend/src/client/pages/scenario/Scenario.tsx
@@ -1,4 +1,4 @@
-import type { Scenario } from '../../slices/types'
+import type { Scenario, Showcase } from '../../slices/types'
 
 import { trackPageView } from '@snowplow/browser-tracker'
 import { AnimatePresence, motion } from 'framer-motion'
@@ -25,23 +25,32 @@ import { basePath } from '../../utils/BasePath'
 
 import { Section } from './Section'
 
-export const ScenarioPage: React.FC = () => {
+interface ScenarioPageProps {
+  propCurrentShowcase?: Showcase
+  propSlug?: string
+}
+
+export const ScenarioPage: React.FC<ScenarioPageProps> = ({ propCurrentShowcase, propSlug }) => {
   const dispatch = useAppDispatch()
-  const { slug } = useParams()
+  let { slug } = useParams()
   const { stepCount, sectionCount, isLoading } = useScenarioState()
-  const currentShowcase = useCurrentShowcase()
+  let currentShowcase = useCurrentShowcase()
   const { section } = useSection()
   const connection = useConnection()
   const { issuedCredentials } = useCredentials()
   const { proof, proofUrl } = useProof()
   const [currentScenario, setCurrentScenario] = useState<Scenario>()
+  if (propCurrentShowcase) {
+    currentShowcase = propCurrentShowcase
+    slug = propSlug
+  }
 
   const navigate = useNavigate()
   useTitle(`${currentScenario?.name ?? 'Use case'} | BC Wallet Self-Sovereign Identity Demo`)
 
   useEffect(() => {
     if (currentShowcase && slug) {
-      setCurrentScenario(currentShowcase.scenarios.find((item) => item.id === slug))
+      setCurrentScenario(currentShowcase.scenarios.find((item: { id: string }) => item.id === slug))
     }
   }, [])
 

--- a/frontend/src/client/pages/scenario/Section.tsx
+++ b/frontend/src/client/pages/scenario/Section.tsx
@@ -36,9 +36,18 @@ export interface Props {
   credentials: any[]
   proof?: any
   proofUrl?: string
+  explicitAllowForward?: boolean
 }
 
-export const Section: React.FC<Props> = ({ connection, section, stepCount, sectionCount, credentials, proof }) => {
+export const Section: React.FC<Props> = ({
+  connection,
+  section,
+  stepCount,
+  sectionCount,
+  credentials,
+  proof,
+  explicitAllowForward,
+}) => {
   const dispatch = useAppDispatch()
   const navigate = useNavigate()
 
@@ -267,7 +276,7 @@ export const Section: React.FC<Props> = ({ connection, section, stepCount, secti
                         },
                       })
                     }}
-                    disabled={isForwardDisabled}
+                    disabled={explicitAllowForward ? false : isForwardDisabled}
                     data-cy="use-case-next"
                   />
                 )}


### PR DESCRIPTION
This adds a preview mode to the admin/creator console. It creates preview route handlers in the client app. These aren't auth protected but the client would need to know to use the `/preview` url path to protect them. This was a decision made because I didn't want to add auth to the client app or start pulling client app components/build artifacts into the admin app. They should be separate.

 - Adds a couple preview components that are almost duplicates to the Introduction and Scenario components. This was done because of the state management and stepper architecture of the client app and wanting more control over what the preview window shows. (I will be trying to reduce unnecessary duplication still)
 - Preview mode has a small window and a expand to full screen option.
 - User can hide preview mode.
 - The preview mode toggle state is global so switching between tabs persists the preview mode visible state.
 - The preview only shows content that corresponds to the tab. I did this on purpose because I want the tab screens to be easily viewed and not confuse the use with screens from other tabs. For example, don't show scenario content from the introduction tab a vice versa.
 - Fixed a date predicate rendering in the presentation screen.

Preview Hidden:
<img width="3726" height="2092" alt="image" src="https://github.com/user-attachments/assets/d286fc79-706b-4f98-9eed-13f8240d4b98" />

Preview Open (Small window):
<img width="3720" height="2046" alt="image" src="https://github.com/user-attachments/assets/45102821-bb94-4292-a26c-67829b281a09" />

Preview Open (Big Window):
<img width="3720" height="2046" alt="image" src="https://github.com/user-attachments/assets/ddc7ee6e-c737-4509-8908-af2001ae904f" />

TODO:
 - Maybe try and make the small preview window look more separate from the main admin/creator content.