### PR TITLE
refactor(server): extract Traction registration logic into TractionRegistrationService

### DIFF
--- a/server/src/routes/__tests__/adminSchemasRouter.test.ts
+++ b/server/src/routes/__tests__/adminSchemasRouter.test.ts
@@ -36,6 +36,10 @@ const { mocks } = vi.hoisted(() => {
       mockAuditLogService: {
         log: vi.fn().mockResolvedValue(undefined),
       },
+      mockTractionRegistrationService: {
+        registerSchema: vi.fn(),
+        registerCredentialDefinition: vi.fn(),
+      },
       mockRetryWithExponentialBackoff: vi.fn(),
     },
   }
@@ -58,6 +62,7 @@ vi.mock('typedi', () => ({
   Container: {
     get: (Type: any) => {
       if (Type.name === 'AuditLogService') return mocks.mockAuditLogService
+      if (Type.name === 'TractionRegistrationService') return mocks.mockTractionRegistrationService
       return {}
     },
   },
@@ -174,43 +179,22 @@ describe('adminSchemasRouter', () => {
       ],
     }
 
-    const tractionSchemaResponse = {
-      data: {
-        schema_state: {
-          schema_id: 'W1ZJ:2:Driver License:2.0',
-          schema: {
-            name: 'Driver License',
-            version: '2.0',
-            attrNames: ['name', 'address', 'license_number'],
-          },
-        },
-      },
-    }
-
-    const tractionCredDefResponse = {
-      data: {
-        credential_definition_state: {
-          credential_definition_id: 'W1ZJ:3:CL:123:Driver License',
-        },
-      },
-    }
-
-    it('returns 201 with created schema and cred def', async () => {
-      const savedSchema = {
+    beforeEach(() => {
+      mocks.mockTractionRegistrationService.registerSchema.mockResolvedValue('W1ZJ:2:Driver License:2.0')
+      mocks.mockTractionRegistrationService.registerCredentialDefinition.mockResolvedValue(
+        'W1ZJ:3:CL:123:Driver License',
+      )
+      mocks.mockSchemaModel.updateOne.mockResolvedValue({ upserted: true })
+      mocks.mockSchemaModel.findById.mockResolvedValue({
         _id: 'W1ZJ:2:Driver License:2.0',
         name: 'Driver License',
         version: '2.0',
         attrNames: ['name', 'address', 'license_number'],
         credDefId: 'W1ZJ:3:CL:123:Driver License',
-      }
-      mocks.mockTractionRequest.get.mockResolvedValue({
-        data: { result: { did: mockIssuerDid } },
       })
-      mocks.mockTractionRequest.post.mockResolvedValue(tractionSchemaResponse)
-      mocks.mockRetryWithExponentialBackoff.mockResolvedValue(tractionCredDefResponse)
-      mocks.mockSchemaModel.updateOne.mockResolvedValue({ upserted: true })
-      mocks.mockSchemaModel.findById.mockResolvedValue(savedSchema)
+    })
 
+    it('returns 201 with created schema and cred def', async () => {
       const res = await request(app).post('/admin/schemas').send(schemaPayload)
 
       expect(res.status).toBe(201)
@@ -221,83 +205,28 @@ describe('adminSchemasRouter', () => {
       expect(res.body).toHaveProperty('credDefId', 'W1ZJ:3:CL:123:Driver License')
     })
 
-    it('creates schema in Traction with correct payload', async () => {
-      mocks.mockTractionRequest.get.mockResolvedValue({
-        data: { result: { did: mockIssuerDid } },
-      })
-      mocks.mockTractionRequest.post.mockResolvedValue(tractionSchemaResponse)
-      mocks.mockRetryWithExponentialBackoff.mockResolvedValue(tractionCredDefResponse)
-      mocks.mockSchemaModel.updateOne.mockResolvedValue({ upserted: true })
-      mocks.mockSchemaModel.findById.mockResolvedValue({})
-
+    it('calls registerSchema with correct args', async () => {
       await request(app).post('/admin/schemas').send(schemaPayload)
 
-      expect(mocks.mockTractionRequest.post).toHaveBeenCalledWith(
-        '/anoncreds/schema',
-        expect.objectContaining({
-          schema: expect.objectContaining({
-            name: 'Driver License',
-            version: '2.0',
-            attrNames: ['name', 'address', 'license_number'],
-            issuerId: mockIssuerDid,
-          }),
-        }),
+      expect(mocks.mockTractionRegistrationService.registerSchema).toHaveBeenCalledWith(
+        'Driver License',
+        '2.0',
+        ['name', 'address', 'license_number'],
+        mockIssuerDid,
       )
     })
 
-    it('creates credential definition with exponential backoff retry', async () => {
-      mocks.mockTractionRequest.get.mockResolvedValue({
-        data: { result: { did: mockIssuerDid } },
-      })
-      mocks.mockTractionRequest.post.mockResolvedValue(tractionSchemaResponse)
-      mocks.mockRetryWithExponentialBackoff.mockResolvedValue(tractionCredDefResponse)
-      mocks.mockSchemaModel.updateOne.mockResolvedValue({ upserted: true })
-      mocks.mockSchemaModel.findById.mockResolvedValue({})
-
+    it('calls registerCredentialDefinition with correct args', async () => {
       await request(app).post('/admin/schemas').send(schemaPayload)
 
-      expect(mocks.mockRetryWithExponentialBackoff).toHaveBeenCalledWith(
-        expect.any(Function),
-        3, // maxAttempts
-        1000, // initialDelayMs
+      expect(mocks.mockTractionRegistrationService.registerCredentialDefinition).toHaveBeenCalledWith(
+        mockIssuerDid,
+        'W1ZJ:2:Driver License:2.0',
+        'Driver License',
       )
     })
 
-    it('creates credential definition with revocation support', async () => {
-      mocks.mockTractionRequest.get.mockResolvedValue({
-        data: { result: { did: mockIssuerDid } },
-      })
-      mocks.mockTractionRequest.post.mockResolvedValue(tractionSchemaResponse)
-      mocks.mockRetryWithExponentialBackoff.mockResolvedValue(tractionCredDefResponse)
-      mocks.mockSchemaModel.updateOne.mockResolvedValue({ upserted: true })
-      mocks.mockSchemaModel.findById.mockReturnValue({
-        lean: vi.fn().mockResolvedValue({}),
-      })
-
-      await request(app).post('/admin/schemas').send(schemaPayload)
-
-      const credDefCall = mocks.mockRetryWithExponentialBackoff.mock.calls[0][0]
-      await credDefCall() // Execute the function
-
-      expect(mocks.mockTractionRequest.post).toHaveBeenCalledWith(
-        '/anoncreds/credential-definition',
-        expect.objectContaining({
-          options: {
-            support_revocation: true,
-            revocation_registry_size: 3000,
-          },
-        }),
-      )
-    })
-
-    it('saves schema to MongoDB with upsert', async () => {
-      mocks.mockTractionRequest.post.mockResolvedValue(tractionSchemaResponse)
-      mocks.mockRetryWithExponentialBackoff.mockResolvedValue(tractionCredDefResponse)
-      mocks.mockSchemaModel.updateOne.mockResolvedValue({ upserted: true })
-      mocks.mockSchemaModel.findById.mockReturnValue({
-        lean: vi.fn().mockResolvedValue({}),
-      })
-
+    it('saves schema to MongoDB with correct data', async () => {
       await request(app).post('/admin/schemas').send(schemaPayload)
 
       expect(mocks.mockSchemaModel.updateOne).toHaveBeenCalledWith(
@@ -306,20 +235,7 @@ describe('adminSchemasRouter', () => {
           $set: {
             name: 'Driver License',
             version: '2.0',
-            attributes: [
-              {
-                name: 'name',
-                type: 'string',
-              },
-              {
-                name: 'address',
-                type: 'string',
-              },
-              {
-                name: 'license_number',
-                type: 'string',
-              },
-            ],
+            attributes: expect.any(Array),
             credDefId: 'W1ZJ:3:CL:123:Driver License',
             did: mockIssuerDid,
           },
@@ -329,22 +245,10 @@ describe('adminSchemasRouter', () => {
     })
 
     it('logs audit entry after response is sent', async () => {
-      mocks.mockTractionRequest.get.mockResolvedValue({
-        data: { result: { did: mockIssuerDid } },
-      })
-      mocks.mockTractionRequest.post.mockResolvedValue(tractionSchemaResponse)
-      mocks.mockRetryWithExponentialBackoff.mockResolvedValue(tractionCredDefResponse)
-      mocks.mockSchemaModel.updateOne.mockResolvedValue({ upserted: true })
-      mocks.mockSchemaModel.findById.mockReturnValue({
-        lean: vi.fn().mockResolvedValue({}),
-      })
-
       const res = await request(app).post('/admin/schemas').send(schemaPayload)
 
-      // Response should be sent before audit logging completes
       expect(res.status).toBe(201)
 
-      // Give async logging time to complete
       await new Promise((resolve) => setTimeout(resolve, 10))
 
       expect(mocks.mockAuditLogService.log).toHaveBeenCalledWith(
@@ -361,16 +265,6 @@ describe('adminSchemasRouter', () => {
     })
 
     it('includes user_id from request auth in audit log', async () => {
-      mocks.mockTractionRequest.get.mockResolvedValue({
-        data: { result: { did: mockIssuerDid } },
-      })
-      mocks.mockTractionRequest.post.mockResolvedValue(tractionSchemaResponse)
-      mocks.mockRetryWithExponentialBackoff.mockResolvedValue(tractionCredDefResponse)
-      mocks.mockSchemaModel.updateOne.mockResolvedValue({ upserted: true })
-      mocks.mockSchemaModel.findById.mockReturnValue({
-        lean: vi.fn().mockResolvedValue({}),
-      })
-
       await request(app).post('/admin/schemas').send(schemaPayload)
 
       await new Promise((resolve) => setTimeout(resolve, 10))
@@ -383,16 +277,6 @@ describe('adminSchemasRouter', () => {
     })
 
     it('handles missing user_id with "unknown"', async () => {
-      mocks.mockTractionRequest.get.mockResolvedValue({
-        data: { result: { did: mockIssuerDid } },
-      })
-      mocks.mockTractionRequest.post.mockResolvedValue(tractionSchemaResponse)
-      mocks.mockRetryWithExponentialBackoff.mockResolvedValue(tractionCredDefResponse)
-      mocks.mockSchemaModel.updateOne.mockResolvedValue({ upserted: true })
-      mocks.mockSchemaModel.findById.mockReturnValue({
-        lean: vi.fn().mockResolvedValue({}),
-      })
-
       await request(app).post('/admin/schemas').send(schemaPayload)
 
       await new Promise((resolve) => setTimeout(resolve, 10))
@@ -405,20 +289,13 @@ describe('adminSchemasRouter', () => {
     })
 
     it('returns 500 when fetching issuer DID fails', async () => {
-      // The router now uses req.body.did directly, so verify that a missing did causes an error
       const payloadWithoutDid = {
         name: 'Driver License',
         version: '2.0',
-        attrNames: ['name', 'address', 'license_number'],
+        attributes: [{ name: 'name', type: 'string' }],
       }
 
-      // Mock the post to reject when issuerId is undefined
-      mocks.mockTractionRequest.post.mockImplementation((url: string, data: any) => {
-        if (url === '/anoncreds/schema' && data.schema.issuerId === undefined) {
-          return Promise.reject(new Error('issuerId is required'))
-        }
-        return Promise.resolve(tractionSchemaResponse)
-      })
+      mocks.mockTractionRegistrationService.registerSchema.mockRejectedValue(new Error('issuerId is required'))
 
       const res = await request(app).post('/admin/schemas').send(payloadWithoutDid)
 
@@ -426,7 +303,7 @@ describe('adminSchemasRouter', () => {
     })
 
     it('returns 500 when creating schema in Traction fails', async () => {
-      mocks.mockTractionRequest.post.mockRejectedValue(new Error('Schema creation failed'))
+      mocks.mockTractionRegistrationService.registerSchema.mockRejectedValue(new Error('Schema creation failed'))
 
       const res = await request(app).post('/admin/schemas').send(schemaPayload)
 
@@ -437,8 +314,9 @@ describe('adminSchemasRouter', () => {
     })
 
     it('returns 500 when creating credential definition fails', async () => {
-      mocks.mockTractionRequest.post.mockResolvedValue(tractionSchemaResponse)
-      mocks.mockRetryWithExponentialBackoff.mockRejectedValue(new Error('Credential def creation failed'))
+      mocks.mockTractionRegistrationService.registerCredentialDefinition.mockRejectedValue(
+        new Error('Credential def creation failed'),
+      )
 
       const res = await request(app).post('/admin/schemas').send(schemaPayload)
 
@@ -449,8 +327,6 @@ describe('adminSchemasRouter', () => {
     })
 
     it('returns 500 when saving to MongoDB fails', async () => {
-      mocks.mockTractionRequest.post.mockResolvedValue(tractionSchemaResponse)
-      mocks.mockRetryWithExponentialBackoff.mockResolvedValue(tractionCredDefResponse)
       mocks.mockSchemaModel.updateOne.mockRejectedValue(new Error('MongoDB error'))
 
       const res = await request(app).post('/admin/schemas').send(schemaPayload)
@@ -462,20 +338,10 @@ describe('adminSchemasRouter', () => {
     })
 
     it('continues on audit log error', async () => {
-      mocks.mockTractionRequest.get.mockResolvedValue({
-        data: { result: { did: mockIssuerDid } },
-      })
-      mocks.mockTractionRequest.post.mockResolvedValue(tractionSchemaResponse)
-      mocks.mockRetryWithExponentialBackoff.mockResolvedValue(tractionCredDefResponse)
-      mocks.mockSchemaModel.updateOne.mockResolvedValue({ upserted: true })
-      mocks.mockSchemaModel.findById.mockReturnValue({
-        lean: vi.fn().mockResolvedValue({}),
-      })
       mocks.mockAuditLogService.log.mockRejectedValue(new Error('Audit log error'))
 
       const res = await request(app).post('/admin/schemas').send(schemaPayload)
 
-      // Response should still be 201 even if audit logging fails
       expect(res.status).toBe(201)
     })
   })

--- a/server/src/routes/adminSchemasRouter.ts
+++ b/server/src/routes/adminSchemasRouter.ts
@@ -7,11 +7,12 @@ import { DidModel } from '../db/models/Did'
 import { SchemaModel } from '../db/models/Schema'
 import { requireRole } from '../middleware/requireAdmin'
 import { AuditLogService } from '../services/AuditLogService'
+import { TractionRegistrationService } from '../services/TractionRegistrationService'
 import logger from '../utils/logger'
 import { defaultRateLimiter, createRateLimiter } from '../utils/rateLimiter'
-import { tractionRequest, retryWithExponentialBackoff } from '../utils/tractionHelper'
 
 const auditLogService = Container.get(AuditLogService)
+const tractionRegistrationService = Container.get(TractionRegistrationService)
 
 const router = Router()
 
@@ -47,33 +48,18 @@ router.get('/schemas', defaultRateLimiter, requireRole(['admin', 'creator']), as
 router.post('/schemas', createRateLimiter, requireRole(['admin', 'creator']), async (req: Request, res: Response) => {
   logger.debug('Admin: creating anoncreds schema and cred def in Traction')
   try {
-    const createSchemaPayload = {
-      name: req.body.name,
-      version: req.body.version,
-      attrNames: req.body.attributes.map((a: any) => a.name),
-      issuerId: req.body.did,
-    }
-    logger.debug({ createSchemaPayload }, 'Creating schema with payload')
-    const response = await tractionRequest.post('/anoncreds/schema', { schema: createSchemaPayload })
-    const credDefResponse = await retryWithExponentialBackoff(
-      () =>
-        tractionRequest.post('/anoncreds/credential-definition', {
-          credential_definition: {
-            issuerId: req.body.did,
-            schemaId: response.data.schema_state.schema_id,
-            tag: response.data.schema_state.schema.name,
-          },
-          options: {
-            support_revocation: true,
-            revocation_registry_size: 3000,
-          },
-        }),
-      3,
-      1000,
+    const attrNames = req.body.attributes.map((a: any) => a.name)
+    const schemaId = await tractionRegistrationService.registerSchema(
+      req.body.name,
+      req.body.version,
+      attrNames,
+      req.body.did,
     )
-    // Save schema to MongoDB
-    const schemaId = response.data.schema_state.schema_id
-    const credDefId = credDefResponse.data.credential_definition_state.credential_definition_id
+    const credDefId = await tractionRegistrationService.registerCredentialDefinition(
+      req.body.did,
+      schemaId,
+      req.body.name,
+    )
     await SchemaModel.updateOne(
       { _id: schemaId },
       {
@@ -104,7 +90,8 @@ router.post('/schemas', createRateLimiter, requireRole(['admin', 'creator']), as
       .catch((err: unknown) => logger.error(err, 'Audit log: failed to write schema created event'))
   } catch (error) {
     logger.error(error, 'Error creating schema and cred def in Traction')
-    res.status(500).json({ error: `Failed to create schema and cred def in Traction: ${error}` })
+    const msg = error instanceof Error ? error.message : String(error)
+    res.status(500).json({ error: `Failed to create schema and cred def in Traction: ${msg}` })
   }
 })
 

--- a/server/src/services/TractionRegistrationService.ts
+++ b/server/src/services/TractionRegistrationService.ts
@@ -1,0 +1,102 @@
+import type { AxiosError } from 'axios'
+
+import { isAxiosError } from 'axios'
+import { BadRequestError } from 'routing-controllers'
+import { Service } from 'typedi'
+
+import logger from '../utils/logger'
+import { retryWithExponentialBackoff, tractionRequest } from '../utils/tractionHelper'
+
+// -- Types --
+
+export interface TractionSchemaResponse {
+  readonly data: {
+    readonly schema_state: {
+      readonly schema_id: string
+      readonly schema: { readonly name: string }
+    }
+  }
+}
+
+export interface TractionCredDefResponse {
+  readonly data: {
+    readonly credential_definition_state: {
+      readonly credential_definition_id: string
+    }
+  }
+}
+
+export interface CredDefOptions {
+  readonly support_revocation?: boolean
+  readonly revocation_registry_size?: number
+}
+
+// -- Functional core --
+
+export const buildSchemaPayload = (name: string, version: string, attrNames: readonly string[], issuerId: string) =>
+  ({
+    schema: { name, version, attrNames, issuerId },
+  }) as const
+
+export const buildCredDefPayload = (issuerId: string, schemaId: string, tag: string, options?: CredDefOptions) =>
+  ({
+    credential_definition: { issuerId, schemaId, tag },
+    options: {
+      support_revocation: options?.support_revocation ?? true,
+      revocation_registry_size: options?.revocation_registry_size ?? 3000,
+    },
+  }) as const
+
+export const extractSchemaId = (res: TractionSchemaResponse): string => res.data.schema_state.schema_id
+
+export const extractCredDefId = (res: TractionCredDefResponse): string =>
+  res.data.credential_definition_state.credential_definition_id
+
+export const toRegistrationError = (err: unknown, context: string): Error => {
+  if (isAxiosError(err) && err.response && err.response.status < 500) {
+    const detail = (err as AxiosError<{ detail?: string }>).response?.data?.detail ?? err.message
+    return new BadRequestError(`${context}: ${detail}`)
+  }
+  return err instanceof Error ? err : new Error(String(err))
+}
+
+// -- Imperative shell --
+
+@Service()
+export class TractionRegistrationService {
+  public async registerSchema(
+    name: string,
+    version: string,
+    attrNames: readonly string[],
+    issuerId: string,
+  ): Promise<string> {
+    const payload = buildSchemaPayload(name, version, attrNames, issuerId)
+    logger.debug({ name, version, issuerId }, 'Registering schema in Traction')
+    try {
+      const response = await tractionRequest.post('/anoncreds/schema', payload)
+      return extractSchemaId(response as TractionSchemaResponse)
+    } catch (err) {
+      throw toRegistrationError(err, `Failed to register schema "${name}" v${version}`)
+    }
+  }
+
+  public async registerCredentialDefinition(
+    issuerId: string,
+    schemaId: string,
+    tag: string,
+    options?: CredDefOptions,
+  ): Promise<string> {
+    const payload = buildCredDefPayload(issuerId, schemaId, tag, options)
+    logger.debug({ schemaId, tag }, 'Registering credential definition in Traction')
+    try {
+      const response = await retryWithExponentialBackoff(
+        () => tractionRequest.post('/anoncreds/credential-definition', payload),
+        3,
+        1000,
+      )
+      return extractCredDefId(response as TractionCredDefResponse)
+    } catch (err) {
+      throw toRegistrationError(err, `Failed to register credential definition for schema "${schemaId}"`)
+    }
+  }
+}

--- a/server/src/services/__tests__/TractionRegistrationService.test.ts
+++ b/server/src/services/__tests__/TractionRegistrationService.test.ts
@@ -1,0 +1,226 @@
+import { BadRequestError } from 'routing-controllers'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Mock must be declared before imports that use the mocked module.
+vi.mock('../../utils/tractionHelper', () => ({
+  tractionRequest: { post: vi.fn() },
+  retryWithExponentialBackoff: vi.fn((fn: () => Promise<unknown>) => fn()),
+}))
+
+vi.mock('../../utils/logger', () => ({
+  default: { debug: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}))
+
+import { tractionRequest, retryWithExponentialBackoff } from '../../utils/tractionHelper'
+import {
+  TractionRegistrationService,
+  buildCredDefPayload,
+  buildSchemaPayload,
+  extractCredDefId,
+  extractSchemaId,
+  toRegistrationError,
+} from '../TractionRegistrationService'
+
+// ============================================================================
+// Pure Functions
+// ============================================================================
+
+describe('TractionRegistrationService - Pure Functions', () => {
+  describe('buildSchemaPayload', () => {
+    it('returns schema object with all fields', () => {
+      const result = buildSchemaPayload('Student Card', '1.0', ['name', 'grade'], 'did:indy:abc')
+      expect(result).toEqual({
+        schema: { name: 'Student Card', version: '1.0', attrNames: ['name', 'grade'], issuerId: 'did:indy:abc' },
+      })
+    })
+  })
+
+  describe('buildCredDefPayload', () => {
+    it('applies revocation defaults when options is undefined', () => {
+      const result = buildCredDefPayload('did:indy:abc', 'schema-id', 'Student Card')
+      expect(result.options).toEqual({ support_revocation: true, revocation_registry_size: 3000 })
+    })
+
+    it('allows overriding support_revocation to false', () => {
+      const result = buildCredDefPayload('did:indy:abc', 'schema-id', 'Card', { support_revocation: false })
+      expect(result.options.support_revocation).toBe(false)
+    })
+
+    it('allows overriding revocation_registry_size', () => {
+      const result = buildCredDefPayload('did:indy:abc', 'schema-id', 'Card', { revocation_registry_size: 1000 })
+      expect(result.options.revocation_registry_size).toBe(1000)
+    })
+
+    it('builds credential_definition object with correct fields', () => {
+      const result = buildCredDefPayload('did:indy:abc', 'schema-id', 'MyTag')
+      expect(result.credential_definition).toEqual({ issuerId: 'did:indy:abc', schemaId: 'schema-id', tag: 'MyTag' })
+    })
+  })
+
+  describe('extractSchemaId', () => {
+    it('returns schema_id from Traction response', () => {
+      const res = { data: { schema_state: { schema_id: 'W1ZJ:2:Card:1.0', schema: { name: 'Card' } } } }
+      expect(extractSchemaId(res)).toBe('W1ZJ:2:Card:1.0')
+    })
+  })
+
+  describe('extractCredDefId', () => {
+    it('returns credential_definition_id from Traction response', () => {
+      const res = { data: { credential_definition_state: { credential_definition_id: 'W1ZJ:3:CL:1:Card' } } }
+      expect(extractCredDefId(res)).toBe('W1ZJ:3:CL:1:Card')
+    })
+  })
+
+  describe('toRegistrationError', () => {
+    it('returns BadRequestError for 4xx with Traction detail', () => {
+      const axiosErr = {
+        isAxiosError: true,
+        message: 'Request failed',
+        response: { status: 400, data: { detail: 'Schema already exists' } },
+      }
+      const result = toRegistrationError(axiosErr, 'register schema "Card" v1.0')
+      expect(result).toBeInstanceOf(BadRequestError)
+      expect(result.message).toContain('Schema already exists')
+    })
+
+    it('includes context in error message', () => {
+      const axiosErr = {
+        isAxiosError: true,
+        message: 'Bad request',
+        response: { status: 422, data: { detail: 'Invalid issuerId' } },
+      }
+      const result = toRegistrationError(axiosErr, 'register schema "Card" v1.0')
+      expect(result.message).toContain('register schema "Card" v1.0')
+    })
+
+    it('falls back to axios message when no Traction detail field', () => {
+      const axiosErr = {
+        isAxiosError: true,
+        message: 'Bad request',
+        response: { status: 400, data: {} },
+      }
+      const result = toRegistrationError(axiosErr, 'ctx')
+      expect(result.message).toContain('Bad request')
+    })
+
+    it('does not wrap 5xx as BadRequestError', () => {
+      const axiosErr = {
+        isAxiosError: true,
+        message: 'Internal server error',
+        response: { status: 500, data: { detail: 'Traction exploded' } },
+      }
+      const result = toRegistrationError(axiosErr, 'ctx')
+      expect(result).not.toBeInstanceOf(BadRequestError)
+    })
+
+    it('returns or wraps non-Axios errors without mapping', () => {
+      const original = new Error('network timeout')
+      expect(toRegistrationError(original, 'ctx')).toBe(original)
+      const result = toRegistrationError('string error', 'ctx')
+      expect(result).toBeInstanceOf(Error)
+      expect(result.message).toContain('string error')
+    })
+  })
+})
+
+// ============================================================================
+// Imperative Shell
+// ============================================================================
+
+describe('TractionRegistrationService - Imperative Shell', () => {
+  let service: TractionRegistrationService
+
+  beforeEach(() => {
+    service = new TractionRegistrationService()
+    vi.clearAllMocks()
+    // Default: retryWithExponentialBackoff just calls the function
+    vi.mocked(retryWithExponentialBackoff).mockImplementation((fn: () => Promise<unknown>) => fn())
+  })
+
+  describe('registerSchema', () => {
+    beforeEach(() => {
+      vi.mocked(tractionRequest.post).mockResolvedValue({
+        data: { schema_state: { schema_id: 'W1ZJ:2:Card:1.0', schema: { name: 'Card' } } },
+      })
+    })
+
+    it('POSTs to /anoncreds/schema with payload from buildSchemaPayload', async () => {
+      await service.registerSchema('Card', '1.0', ['name'], 'did:indy:abc')
+      expect(tractionRequest.post).toHaveBeenCalledWith('/anoncreds/schema', {
+        schema: { name: 'Card', version: '1.0', attrNames: ['name'], issuerId: 'did:indy:abc' },
+      })
+    })
+
+    it('returns schema_id from Traction response', async () => {
+      const result = await service.registerSchema('Card', '1.0', ['name'], 'did:indy:abc')
+      expect(result).toBe('W1ZJ:2:Card:1.0')
+    })
+
+    it('throws BadRequestError when Traction returns 4xx', async () => {
+      vi.mocked(tractionRequest.post).mockRejectedValue(
+        Object.assign(new Error('Unprocessable'), {
+          isAxiosError: true,
+          response: { status: 422, data: { detail: 'Invalid issuerId format' } },
+        }),
+      )
+      await expect(service.registerSchema('Card', '1.0', ['name'], 'bad-did')).rejects.toBeInstanceOf(BadRequestError)
+    })
+
+    it('rethrows non-4xx errors unchanged', async () => {
+      const networkErr = new Error('ECONNREFUSED')
+      vi.mocked(tractionRequest.post).mockRejectedValue(networkErr)
+      await expect(service.registerSchema('Card', '1.0', ['name'], 'did:indy:abc')).rejects.toBe(networkErr)
+    })
+  })
+
+  describe('registerCredentialDefinition', () => {
+    beforeEach(() => {
+      vi.mocked(tractionRequest.post).mockResolvedValue({
+        data: { credential_definition_state: { credential_definition_id: 'W1ZJ:3:CL:1:Card' } },
+      })
+    })
+
+    it('wraps POST in retryWithExponentialBackoff with 3 retries and 1000ms delay', async () => {
+      await service.registerCredentialDefinition('did:indy:abc', 'schema-id', 'Card')
+      expect(retryWithExponentialBackoff).toHaveBeenCalledWith(expect.any(Function), 3, 1000)
+    })
+
+    it('POSTs to /anoncreds/credential-definition with payload from buildCredDefPayload', async () => {
+      await service.registerCredentialDefinition('did:indy:abc', 'schema-id', 'Card')
+      expect(tractionRequest.post).toHaveBeenCalledWith('/anoncreds/credential-definition', {
+        credential_definition: { issuerId: 'did:indy:abc', schemaId: 'schema-id', tag: 'Card' },
+        options: { support_revocation: true, revocation_registry_size: 3000 },
+      })
+    })
+
+    it('returns cred_def_id from Traction response', async () => {
+      const result = await service.registerCredentialDefinition('did:indy:abc', 'schema-id', 'Card')
+      expect(result).toBe('W1ZJ:3:CL:1:Card')
+    })
+
+    it('passes custom options to buildCredDefPayload', async () => {
+      await service.registerCredentialDefinition('did:indy:abc', 'schema-id', 'Card', {
+        support_revocation: false,
+        revocation_registry_size: 1000,
+      })
+      expect(tractionRequest.post).toHaveBeenCalledWith(
+        '/anoncreds/credential-definition',
+        expect.objectContaining({
+          options: { support_revocation: false, revocation_registry_size: 1000 },
+        }),
+      )
+    })
+
+    it('throws BadRequestError when Traction returns 4xx', async () => {
+      vi.mocked(tractionRequest.post).mockRejectedValue(
+        Object.assign(new Error('Bad Request'), {
+          isAxiosError: true,
+          response: { status: 400, data: { detail: 'Schema not found' } },
+        }),
+      )
+      await expect(service.registerCredentialDefinition('did:indy:abc', 'schema-id', 'Card')).rejects.toBeInstanceOf(
+        BadRequestError,
+      )
+    })
+  })
+})


### PR DESCRIPTION
This PR resolves #457 

- Move schema and credential definition registration from adminSchemasRouter into a dedicated TractionRegistrationService
- Service methods wrap HTTP calls with error handling and retry logic
- Update router to use service methods and add comprehensive test coverage.