### PR TITLE
Don't filter hidden showcases in preview mode

### DIFF
--- a/frontend/src/client/pages/preview/IntroductionPreviewPage.tsx
+++ b/frontend/src/client/pages/preview/IntroductionPreviewPage.tsx
@@ -37,18 +37,16 @@ export const IntroductionPreviewPage: React.FC<PreviewPageProps> = ({ contentTyp
   const [mounted, setMounted] = useState(false)
 
   const allShowcases = useMemo(() => {
-    const all = [...showcases]
-      .filter((showcase) => showcase.status === 'active' || showHiddenScenarios)
-      .filter((showcase) => {
-        return !previewShowcaseName || showcase.name === previewShowcaseName
-      })
+    const all = [...showcases].filter((showcase) => {
+      return !previewShowcaseName || showcase.name === previewShowcaseName
+    })
 
     if (uploadedShowcase) {
       all.push(uploadedShowcase)
     }
 
     return all
-  }, [showcases, uploadedShowcase, showHiddenScenarios, previewShowcaseName])
+  }, [showcases, uploadedShowcase, previewShowcaseName])
 
   useEffect(() => {
     dispatch({ type: 'demo/RESET' })


### PR DESCRIPTION
We shouldn't be filtering hidden showcases in preview mode. I returned this filter by accident.