### PR TITLE
Bug/499 fix pick character image

### DIFF
--- a/frontend/src/admin/components/showcase/persona/PersonaTab.tsx
+++ b/frontend/src/admin/components/showcase/persona/PersonaTab.tsx
@@ -108,6 +108,7 @@ export function PersonaTab({
             ...screen,
             name: `Meet ${name}`,
             text: `${name} is a ${personaType}. In this demo, ${name} will use digital credentials from their BC Wallet to complete various tasks.`,
+            image: localShowcase.persona?.image || screen.image,
           }
         }
         return screen
@@ -116,6 +117,10 @@ export function PersonaTab({
       await updateShowcase(auth, showcase.name, {
         introduction: updatedIntroduction,
       })
+
+      // Reload the showcase from the server and refresh preview
+      onRefresh?.()
+      setIframeRefreshKey((prev) => prev + 1)
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Failed to update introduction'
       displayError(message)

--- a/frontend/src/client/pages/introduction/components/CharacterContent.tsx
+++ b/frontend/src/client/pages/introduction/components/CharacterContent.tsx
@@ -28,7 +28,11 @@ export const CharacterContent: React.FC<Props> = ({ showcase }) => {
             </div>
             <img
               className="h-72"
-              src={prependApiUrl(showcase.persona?.image || '')}
+              src={prependApiUrl(
+                showcase.introduction?.find((s) => s.screenId === 'PICK_CHARACTER')?.image ||
+                  showcase.persona?.image ||
+                  '',
+              )}
               alt={showcase.persona?.name || ''}
             />
           </motion.div>

--- a/server/migrations/002-persona-to-pick-character-image.ts
+++ b/server/migrations/002-persona-to-pick-character-image.ts
@@ -1,0 +1,14 @@
+import { ShowcaseModel } from '../src/db/models/Showcase'
+
+export async function up() {
+  const showcases = await ShowcaseModel.find()
+
+  for (const showcase of showcases) {
+    const pickCharacterScreen = showcase.introduction?.find((s) => s.screenId === 'PICK_CHARACTER')
+
+    if (pickCharacterScreen && !pickCharacterScreen.image && showcase.persona?.image) {
+      pickCharacterScreen.image = showcase.persona.image
+      await showcase.save()
+    }
+  }
+}

--- a/server/migrations/runner.ts
+++ b/server/migrations/runner.ts
@@ -8,6 +8,10 @@ const migrations = [
     id: '001-add-schema-attributes',
     up: () => import('./001-add-schema-attributes').then((m) => m.up()),
   },
+  {
+    id: '002-persona-to-pick-character-image',
+    up: () => import('./002-persona-to-pick-character-image').then((m) => m.up()),
+  },
 ]
 
 /**


### PR DESCRIPTION
This adds a simple migration that duplicates the persona image to the pick character screen and then changes the character content component to use this image instead. This allow the admin/creator user to customize this image to a different one if they wish and prevents confusion if they did add an image to the pick character screen which wasn't rendering anywhere. 

Also sets the image when creating a new persona. 