### PR TITLE
Remove webvh env variables in favor of traction api and hardcoded nam…

### DIFF
--- a/DEVELOPER/BC Wallet Showcase.md
+++ b/DEVELOPER/BC Wallet Showcase.md
@@ -48,8 +48,6 @@ UPLOADS_DIR=./uploads
 # SHOWCASE_SHORT_INVITATION_URLS_ENABLED=false
 # Optional: TTL for short invitation links in seconds (default: 86400 = 24h)
 # INVITATION_SHORT_LINK_TTL_SECONDS=86400
-WEBVH_SERVER_URL=https://sandbox.bcvh.vonx.io
-WEBVH_NAMESPACE=showcase
 ```
 
 populate the values with the API key and webhook secret that you made in the previous step. `SHOWCASE_PUBLIC_ORIGIN` is required for short invitation URLs to work; set it to your ngrok URL. `UPLOADS_DIR` controls where uploaded images are stored on disk and defaults to `./uploads` relative to the server working directory.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ cp server/.env.example server/.env
 cp frontend/.env.example frontend/.env
 ```
 
-The placeholder values in `.env.example` are enough to start the app locally. To issue or verify **real** credentials you need a [Traction](https://digital.gov.bc.ca/digital-trust/technical-resources/traction/) tenant — set `TRACTION_TENANT_ID`, `TRACTION_TENANT_API_KEY`, `TRACTION_URL`, `TRACTION_DID`, and `WEBHOOK_SECRET`, `WEBVH_SERVER_URL`, `WEBVH_NAMESPACE` in `server/.env`. To test with a mobile wallet, run `ngrok http 5000` and set `SHOWCASE_PUBLIC_ORIGIN` to the ngrok URL — the same tunnel handles both Traction webhooks and short QR invitation URLs. See [DEVELOPER/BC Wallet Showcase.md](DEVELOPER/BC%20Wallet%20Showcase.md) for the full setup.
+The placeholder values in `.env.example` are enough to start the app locally. To issue or verify **real** credentials you need a [Traction](https://digital.gov.bc.ca/digital-trust/technical-resources/traction/) tenant — set `TRACTION_TENANT_ID`, `TRACTION_TENANT_API_KEY`, `TRACTION_URL`, `TRACTION_DID`, and `WEBHOOK_SECRET` in `server/.env`. To test with a mobile wallet, run `ngrok http 5000` and set `SHOWCASE_PUBLIC_ORIGIN` to the ngrok URL — the same tunnel handles both Traction webhooks and short QR invitation URLs. See [DEVELOPER/BC Wallet Showcase.md](DEVELOPER/BC%20Wallet%20Showcase.md) for the full setup.
 
 ### 2. Start the stack
 

--- a/charts/showcase/README.md
+++ b/charts/showcase/README.md
@@ -96,11 +96,6 @@ On **bcgov** dev and PR deploys, pre-create **`showcase-traction`** in the targe
 
 - **`showcase.server.shortInvitationUrls.enabled`** (default **`true`**) sets **`SHOWCASE_SHORT_INVITATION_URLS_ENABLED`** on the server. When **`true`**, connection and OOB proof invites get **`short_url`** for QR codes; wallets resolve **`GET {baseRoute}/i/{oobId}`** to the stored invitation JSON. Set to **`false`** to encode the full Traction **`invitation_url`** in QR codes instead (legacy behaviour).
 
-### WEBVH (optional)
-
-- **`showcase.server.webvhServerUrl`** sets **`WEBVH_SERVER_URL`** on the server (non-secret; base URL of the Webhook Verifier service, no path).
-- **`showcase.server.webvhNamespace`** sets **`WEBVH_NAMESPACE`** on the server (non-secret; namespace where Webhook Verifier is deployed, used for webhook registration with the Traction proxy).
-
 ### Mongo subchart
 
 All **`mongodb:`** keys pass through to CloudPirates. Inspect the packaged chart or:

--- a/charts/showcase/templates/server/deployment.yaml
+++ b/charts/showcase/templates/server/deployment.yaml
@@ -162,10 +162,6 @@ spec:
             - name: TRACTION_URL
               value: {{ .Values.showcase.server.traction.url | quote }}
             {{- end }}
-            - name: WEBVH_SERVER_URL
-              value: {{ .Values.showcase.server.webvhServerUrl | quote }}
-            - name: WEBVH_NAMESPACE
-              value: {{ .Values.showcase.server.webvhNamespace | quote }}
             {{- if .Values.showcase.server.traction.existingSecret }}
             - name: TRACTION_TENANT_ID
               valueFrom:

--- a/server/.env.example
+++ b/server/.env.example
@@ -29,6 +29,3 @@ WEBHOOK_SECRET=secret
 
 # Directory for uploaded showcase assets. Default: ./uploads (relative to cwd).
 # UPLOADS_DIR=./uploads
-
-WEBVH_SERVER_URL=https://sandbox.bcvh.vonx.io
-WEBVH_NAMESPACE=showcase

--- a/server/src/utils/tractionHelper.ts
+++ b/server/src/utils/tractionHelper.ts
@@ -230,7 +230,7 @@ export async function getOrCreateWebvhDid(): Promise<string> {
   const configResponse = await tractionRequest.get('/did/webvh/config')
 
   if (!configResponse.data?.server_url) {
-    throw new Error('Webhook server URL not found in Traction webvh config')
+    throw new Error('Webvh server URL not found in Traction webvh config')
   }
 
   return (

--- a/server/src/utils/tractionHelper.ts
+++ b/server/src/utils/tractionHelper.ts
@@ -227,12 +227,17 @@ export async function getOrCreateWebvhDid(): Promise<string> {
   if (results?.length) {
     return results[0].did
   }
+  const configResponse = await tractionRequest.get('/did/webvh/config')
+
+  if (!configResponse.data?.server_url) {
+    throw new Error('Webhook server URL not found in Traction webvh config')
+  }
 
   return (
     await tractionRequest.post('/did/webvh/create', {
       options: {
-        server_url: process.env.WEBVH_SERVER_URL,
-        namespace: process.env.WEBVH_NAMESPACE,
+        server_url: configResponse.data.server_url,
+        namespace: 'showcase',
         identifier: uuidv4(),
       },
     })


### PR DESCRIPTION
These env variables aren't actually nessecary because the seed script requires webvh endorsement to be set up. This makes the server_url available via the webvh configuration api. The namespace can be hardcoded as showcase and it uses a random identifier. 

Removing them simplifies the deployment configuration.