### PR TITLE
feat: Add presentation restrictions

### DIFF
--- a/frontend/src/admin/components/showcase/modals/CreateConnectionAndProofScreensModal.tsx
+++ b/frontend/src/admin/components/showcase/modals/CreateConnectionAndProofScreensModal.tsx
@@ -360,19 +360,6 @@ export function CreateConnectionAndProofScreensModal({
                 currentRequest={credentialRequests.get(Array.from(selectedCredentials)[currentCredentialIdx]) || null}
                 currentIndex={currentCredentialIdx}
                 totalCredentials={selectedCredentials.size}
-                onUpdateRequest={(updates) => {
-                  const credentialIds = Array.from(selectedCredentials)
-                  const currentCredentialId = credentialIds[currentCredentialIdx]
-                  const currentRequest = credentialRequests.get(currentCredentialId)
-                  if (currentRequest) {
-                    const newRequests = new Map(credentialRequests)
-                    newRequests.set(currentCredentialId, {
-                      ...currentRequest,
-                      ...updates,
-                    })
-                    setCredentialRequests(newRequests)
-                  }
-                }}
                 onUploadIcon={() => {
                   setImageUploadModalCredentialId(Array.from(selectedCredentials)[currentCredentialIdx])
                   setIsImageUploadModalOpen(true)
@@ -392,7 +379,8 @@ export function CreateConnectionAndProofScreensModal({
                         const credential = showcase?.credentials?.find((c) => c.id === credentialId)
                         return {
                           name: credential?.name || req.name,
-                          schema_id: req.schema_id,
+                          schema_id: credential?.schema_id,
+                          cred_def_id: credential?.cred_def_id,
                           icon: req.icon,
                           properties: req.properties,
                           ...(req.predicates && req.predicates.length > 0 && { predicates: req.predicates }),

--- a/frontend/src/admin/components/showcase/modals/steps/DefiningProofRequestStep.tsx
+++ b/frontend/src/admin/components/showcase/modals/steps/DefiningProofRequestStep.tsx
@@ -9,7 +9,6 @@ interface DefiningProofRequestStepProps {
   currentRequest: PresentationRequest | null
   currentIndex: number
   totalCredentials: number
-  onUpdateRequest: (updates: Partial<PresentationRequest>) => void
   onUploadIcon: () => void
   onPrevious: () => void
   onNext: () => void
@@ -21,7 +20,6 @@ export function DefiningProofRequestStep({
   currentRequest,
   currentIndex,
   totalCredentials,
-  onUpdateRequest,
   onUploadIcon,
   onPrevious,
   onNext,
@@ -76,20 +74,6 @@ export function DefiningProofRequestStep({
               </button>
             )}
           </div>
-        </div>
-
-        <div>
-          <label className="block text-sm font-medium text-bcgov-black mb-2">Schema ID</label>
-          <p className="text-xs text-gray-500 mb-1">
-            Optional - Restrict the presentation request to a specific schema
-          </p>
-          <input
-            type="text"
-            value={currentRequest.schema_id || ''}
-            onChange={(e) => onUpdateRequest({ schema_id: e.target.value || undefined })}
-            placeholder="e.g., QEquAHkM35w4XVT3Ku5yat:2:student_card:1.0"
-            className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-bcgov-blue focus:border-transparent"
-          />
         </div>
 
         <div>

--- a/frontend/src/client/pages/scenario/steps/StepProof.tsx
+++ b/frontend/src/client/pages/scenario/steps/StepProof.tsx
@@ -96,21 +96,16 @@ export const StepProof: React.FC<Props> = ({
     const predicates: Record<string, ProofPredicateRequest> = {}
 
     requestedCredentials?.forEach((item) => {
-      const restrictions: ProofRestriction[] = [
-        {
-          schema_name: item.name,
-        },
-      ]
+      const restriction: ProofRestriction = {
+        schema_name: item.name,
+      }
       if (item.schema_id) {
-        restrictions.push({
-          schema_id: item.schema_id,
-        })
+        restriction.schema_id = item.schema_id
       }
       if (item.cred_def_id) {
-        restrictions.push({
-          cred_def_id: item.cred_def_id,
-        })
+        restriction.cred_def_id = item.cred_def_id
       }
+      const restrictions: ProofRestriction[] = [restriction]
       if (item.properties?.length) {
         proofs[item.name] = {
           restrictions,

--- a/frontend/src/client/pages/scenario/steps/StepProofOOB.tsx
+++ b/frontend/src/client/pages/scenario/steps/StepProofOOB.tsx
@@ -70,9 +70,10 @@ export const StepProofOOB: React.FC<Props> = ({ proof, step, requestedCredential
       const predicates: Record<string, ProofPredicateRequest> = {}
 
       requestedCredentials?.forEach((item) => {
-        const restrictions: ProofRestriction[] = [{ schema_name: item.name }]
-        if (item.schema_id) restrictions.push({ schema_id: item.schema_id })
-        if (item.cred_def_id) restrictions.push({ cred_def_id: item.cred_def_id })
+        const restriction: ProofRestriction = { schema_name: item.name }
+        if (item.schema_id) restriction.schema_id = item.schema_id
+        if (item.cred_def_id) restriction.cred_def_id = item.cred_def_id
+        const restrictions: ProofRestriction[] = [restriction]
         if (item.properties?.length) {
           proofs[item.name] = {
             restrictions,

--- a/server/migrations/003-add-restrictions-to-presentations.ts
+++ b/server/migrations/003-add-restrictions-to-presentations.ts
@@ -1,0 +1,27 @@
+import { CredentialModel } from '../src/db/models/Credential'
+import { ShowcaseModel } from '../src/db/models/Showcase'
+
+export async function up() {
+  const showcases = await ShowcaseModel.find()
+
+  for (const showcase of showcases) {
+    for (const scenario of showcase.scenarios || []) {
+      for (const screen of scenario.screens || []) {
+        if (screen.requestOptions?.requestedCredentials) {
+          for (const requestedCredential of screen.requestOptions.requestedCredentials) {
+            // Look up the credential by name
+            const credential = await CredentialModel.findOne({ name: requestedCredential.name })
+            if (credential?.schema_id) {
+              requestedCredential.schema_id = credential.schema_id
+            }
+            if (credential?.cred_def_id) {
+              requestedCredential.cred_def_id = credential.cred_def_id
+            }
+          }
+        }
+      }
+    }
+    // Save the showcase after updating all its scenarios
+    await showcase.save()
+  }
+}

--- a/server/migrations/runner.ts
+++ b/server/migrations/runner.ts
@@ -12,6 +12,10 @@ const migrations = [
     id: '002-persona-to-pick-character-image',
     up: () => import('./002-persona-to-pick-character-image').then((m) => m.up()),
   },
+  {
+    id: '003-add-restrictions-to-presentations',
+    up: () => import('./003-add-restrictions-to-presentations').then((m) => m.up()),
+  },
 ]
 
 /**


### PR DESCRIPTION
- Creates a migration which adds the schema_id and cred_def_id to the presentation/credential request object in the showcases.
- Removes the schema_id input from the presentation creation admin ui form
- Set the restrictions in the presentation in a single object. This is the AND not OR setting.

This takes away the admin needing to configure this but puts the restriction in every presentation. This takes away some customization and makes it so the client user must use the credential issued from the showcase. I think this is appropriate for showcase usage.