### PR TITLE
feat: Dynamc credential viewer/editor

### DIFF
--- a/frontend/src/admin/api/__tests__/adminApi.test.ts
+++ b/frontend/src/admin/api/__tests__/adminApi.test.ts
@@ -1,6 +1,14 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { getAllCredentials } from '../adminApi'
+import {
+  getAllCredentials,
+  getAvailableSchemas,
+  getSchemaById,
+  createSchema,
+  getAvailableDids,
+  getAvailableImages,
+  updateCredential,
+} from '../adminApi'
 
 const mockAuth = {
   user: { access_token: 'test-token' },
@@ -47,5 +55,281 @@ describe('getAllCredentials', () => {
     } as any)
 
     await expect(getAllCredentials(mockAuth)).rejects.toThrow('Request failed: 500')
+  })
+})
+
+describe('getAvailableSchemas', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn())
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('fetches all available schemas', async () => {
+    const schemas = [{ id: 'schema-1', name: 'Test Schema', version: '1.0', attributes: [] }]
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: async () => schemas,
+    } as any)
+
+    const result = await getAvailableSchemas(mockAuth)
+
+    expect(result).toEqual(schemas)
+  })
+
+  it('includes authorization header with token', async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: async () => [],
+    } as any)
+
+    await getAvailableSchemas(mockAuth)
+
+    const call = vi.mocked(fetch).mock.calls[0]
+    expect(call[1]).toMatchObject({
+      headers: expect.objectContaining({
+        Authorization: 'Bearer test-token',
+      }),
+    })
+  })
+})
+
+describe('getSchemaById', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn())
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('fetches a single schema by ID', async () => {
+    const schema = { id: 'schema-1', name: 'Test Schema', version: '1.0', attributes: [] }
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: async () => schema,
+    } as any)
+
+    const result = await getSchemaById(mockAuth, 'schema-1')
+
+    expect(result).toEqual(schema)
+  })
+
+  it('URL-encodes the schema ID in the request', async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: async () => ({}),
+    } as any)
+
+    await getSchemaById(mockAuth, 'test/schema')
+
+    const url = vi.mocked(fetch).mock.calls[0][0] as string
+    expect(url).toContain('test%2Fschema')
+  })
+})
+
+describe('createSchema', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn())
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('creates a new schema', async () => {
+    const schemaData = {
+      name: 'New Schema',
+      version: '1.0',
+      attributes: [{ name: 'attr1', type: 'string' as const }],
+      did: 'did:example:123',
+    }
+    const response = { id: 'schema-1', ...schemaData }
+
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: async () => response,
+    } as any)
+
+    const result = await createSchema(mockAuth, schemaData)
+
+    expect(result).toEqual(response)
+  })
+
+  it('sends POST request with schema data in body', async () => {
+    const schemaData = {
+      name: 'New Schema',
+      version: '1.0',
+      attributes: [{ name: 'attr1', type: 'string' as const }],
+      did: 'did:example:123',
+    }
+
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: async () => ({}),
+    } as any)
+
+    await createSchema(mockAuth, schemaData)
+
+    const call = vi.mocked(fetch).mock.calls[0]
+    expect(call[1]).toMatchObject({
+      method: 'POST',
+      body: JSON.stringify(schemaData),
+    })
+  })
+})
+
+describe('getAvailableDids', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn())
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('fetches all available DIDs', async () => {
+    const dids = [{ id: 'did-1', did: 'did:example:123' }]
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: async () => dids,
+    } as any)
+
+    const result = await getAvailableDids(mockAuth)
+
+    expect(result).toEqual(dids)
+  })
+})
+
+describe('getAvailableImages', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn())
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('fetches images of a specific type', async () => {
+    const images = ['/image1.png', '/image2.png']
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: async () => ({ files: images }),
+    } as any)
+
+    const result = await getAvailableImages(mockAuth, 'icon')
+
+    expect(result).toEqual(images)
+  })
+
+  it('defaults to icon type when not specified', async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: async () => ({ files: [] }),
+    } as any)
+
+    await getAvailableImages(mockAuth)
+
+    const url = vi.mocked(fetch).mock.calls[0][0] as string
+    expect(url).toContain('type=icon')
+  })
+
+  it('includes image type in query parameters', async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: async () => ({ files: [] }),
+    } as any)
+
+    await getAvailableImages(mockAuth, 'screen')
+
+    const url = vi.mocked(fetch).mock.calls[0][0] as string
+    expect(url).toContain('type=screen')
+  })
+})
+
+describe('updateCredential', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn())
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('updates a credential with the provided changes', async () => {
+    const credentialId = 'cred-123'
+    const updates = {
+      attributes: [{ name: 'attr1', value: 'updated-value' }],
+      icon: '/icons/new-icon.png',
+    }
+    const response = { id: credentialId, name: 'Test Credential', ...updates }
+
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: async () => response,
+    } as any)
+
+    const result = await updateCredential(mockAuth, credentialId, updates as any)
+
+    expect(result).toEqual(response)
+  })
+
+  it('URL-encodes the credential ID in the request', async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: async () => ({}),
+    } as any)
+
+    await updateCredential(mockAuth, 'cred/with/slashes', {})
+
+    const url = vi.mocked(fetch).mock.calls[0][0] as string
+    expect(url).toContain('cred%2Fwith%2Fslashes')
+  })
+
+  it('sends PUT request with authorization header', async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: async () => ({}),
+    } as any)
+
+    await updateCredential(mockAuth, 'cred-123', { icon: '/icons/new.png' } as any)
+
+    const call = vi.mocked(fetch).mock.calls[0]
+    expect(call[1]).toMatchObject({
+      method: 'PUT',
+      headers: expect.objectContaining({
+        Authorization: 'Bearer test-token',
+        'Content-Type': 'application/json',
+      }),
+    })
+  })
+
+  it('sends the updates in the request body', async () => {
+    const updates = {
+      attributes: [{ name: 'field1', value: 'value1' }],
+      icon: '/icons/updated.png',
+    }
+
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: async () => ({}),
+    } as any)
+
+    await updateCredential(mockAuth, 'cred-123', updates as any)
+
+    const call = vi.mocked(fetch).mock.calls[0]
+    expect(call[1]?.body).toBe(JSON.stringify(updates))
+  })
+
+  it('throws when the response is not ok', async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: false,
+      status: 404,
+      json: async () => ({ error: 'Credential not found' }),
+    } as any)
+
+    await expect(updateCredential(mockAuth, 'cred-123', {})).rejects.toThrow('Credential not found')
   })
 })

--- a/frontend/src/admin/api/adminApi.tsx
+++ b/frontend/src/admin/api/adminApi.tsx
@@ -214,6 +214,24 @@ export const createCredential = async (
   return data
 }
 
+export const updateCredential = async (
+  auth: AuthContextProps,
+  credentialId: string,
+  updates: Partial<Credential>,
+): Promise<Credential> => {
+  const res = await fetch(`${adminBaseUrl}/credentials/${encodeURIComponent(credentialId)}`, {
+    method: 'PUT',
+    headers: {
+      Authorization: `Bearer ${auth.user?.access_token ?? ''}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(updates),
+  })
+  if (!res.ok) await handleErrorResponse(res)
+  const data = (await res.json()) as Credential
+  return data
+}
+
 // ============================================================================
 // IMAGE ENDPOINTS
 // ============================================================================
@@ -268,6 +286,19 @@ export const getAvailableSchemas = async (auth: AuthContextProps): Promise<Schem
   })
   if (!res.ok) await handleErrorResponse(res)
   const data = await res.json()
+  return data
+}
+
+export const getSchemaById = async (auth: AuthContextProps, id: string): Promise<Schema> => {
+  const res = await fetch(`${adminBaseUrl}/schemas/${encodeURIComponent(id)}`, {
+    method: 'GET',
+    headers: {
+      Authorization: `Bearer ${auth.user?.access_token ?? ''}`,
+      'Content-Type': 'application/json',
+    },
+  })
+  if (!res.ok) await handleErrorResponse(res)
+  const data = (await res.json()) as Schema
   return data
 }
 

--- a/frontend/src/admin/components/showcase/introduction/IntroductionScreenRow.tsx
+++ b/frontend/src/admin/components/showcase/introduction/IntroductionScreenRow.tsx
@@ -29,7 +29,7 @@ interface IntroductionScreenRowProps {
   onDragOver: (e: React.DragEvent<HTMLDivElement>) => void
   onDragLeave: () => void
   onSelectCredential: () => void
-  onRefresh?: () => Promise<void>
+  onRefresh?: () => void | Promise<void>
 }
 
 export function IntroductionScreenRow({

--- a/frontend/src/admin/components/showcase/introduction/IntroductionScreenRow.tsx
+++ b/frontend/src/admin/components/showcase/introduction/IntroductionScreenRow.tsx
@@ -1,11 +1,18 @@
-import type { IntroductionStep } from '../../../types'
+import type { IntroductionStep, Schema } from '../../../types'
 import type { IntroductionRow } from '../../../utils/buildIntroductionRows'
 
-import { publicBaseUrl } from '../../../api/adminApi'
+import { Cog6ToothIcon } from '@heroicons/react/24/outline'
+import { useEffect, useState } from 'react'
+import { useAuth } from 'react-oidc-context'
+
+import { getSchemaById, publicBaseUrl, updateCredential } from '../../../api/adminApi'
 import { useHasRole } from '../../../hooks/useUserRole'
+import { formatPredicateValue, truncateLongString } from '../../../utils/formatters'
+import logger from '../../../utils/logger'
 import { ProgressIconWithTooltip } from '../ProgressIconWithTooltip'
 import { ScreenRowBase } from '../ScreenRowBase'
 import { AddConnectionButton } from '../buttons/AddConnectionButton'
+import { DefineCredentialValuesStep } from '../modals/steps/DefineCredentialValuesStep'
 
 interface IntroductionScreenRowProps {
   row: IntroductionRow
@@ -22,6 +29,7 @@ interface IntroductionScreenRowProps {
   onDragOver: (e: React.DragEvent<HTMLDivElement>) => void
   onDragLeave: () => void
   onSelectCredential: () => void
+  onRefresh?: () => Promise<void>
 }
 
 export function IntroductionScreenRow({
@@ -39,11 +47,30 @@ export function IntroductionScreenRow({
   onDragOver,
   onDragLeave,
   onSelectCredential,
+  onRefresh,
 }: IntroductionScreenRowProps) {
+  const auth = useAuth()
+  const [editingCredentialIdx, setEditingCredentialIdx] = useState<number | null>(null)
+  const [selectedSchema, setSelectedSchema] = useState<Schema | null>(null)
   const { screen, nextScreen, progressStep, acceptProgressStep, idx } = row
   const isConnectScreen = screen.screenId.startsWith('CONNECT')
   const hasAcceptChild = !!(nextScreen && nextScreen.screenId.startsWith('ACCEPT'))
   const canEdit = useHasRole('creator')
+
+  useEffect(() => {
+    const fetchSchema = async () => {
+      if (editingCredentialIdx !== null && nextScreen?.credentials?.[editingCredentialIdx] && auth.isAuthenticated) {
+        const credential = nextScreen.credentials[editingCredentialIdx]
+        if (!credential.schema_id) {
+          setSelectedSchema(null)
+          return
+        }
+        const schema = await getSchemaById(auth, credential.schema_id)
+        setSelectedSchema(schema)
+      }
+    }
+    fetchSchema()
+  }, [editingCredentialIdx, auth.isAuthenticated, nextScreen])
 
   return (
     <div>
@@ -102,7 +129,28 @@ export function IntroductionScreenRow({
                           )}
                           <div className="flex-1">
                             <p className="text-sm font-semibold text-bcgov-black">{cred.name}</p>
+                            {cred.attributes && cred.attributes.length > 0 && (
+                              <div className="mt-2 text-xs text-gray-600 space-y-1">
+                                {cred.attributes.map((attr: any, attrIdx: number) => (
+                                  <div key={attrIdx} className="grid grid-cols-[auto_1fr] gap-3">
+                                    <span className="font-medium text-gray-700">{attr.name}:</span>
+                                    <span className="text-gray-600">
+                                      {truncateLongString(formatPredicateValue(attr.value), 200)}
+                                    </span>
+                                  </div>
+                                ))}
+                              </div>
+                            )}
                           </div>
+                          {canEdit && (
+                            <button
+                              onClick={() => setEditingCredentialIdx(credIdx)}
+                              className="flex-shrink-0 p-2 text-gray-600 hover:text-bcgov-blue hover:bg-blue-50 rounded transition-colors"
+                              title="Edit credential values"
+                            >
+                              <Cog6ToothIcon className="w-5 h-5" />
+                            </button>
+                          )}
                         </div>
                       ))}
                     </div>
@@ -144,6 +192,59 @@ export function IntroductionScreenRow({
       {/* Show "Add Connection and Issuance Screens" after CONNECT/ACCEPT pair */}
       {canEdit && isConnectScreen && hasAcceptChild && (
         <AddConnectionButton onClick={onSelectCredential} containerClassName="mt-2" />
+      )}
+
+      {/* Edit Credential Modal */}
+      {editingCredentialIdx !== null && nextScreen?.credentials?.[editingCredentialIdx] && (
+        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
+          <div className="bg-white rounded-lg shadow-xl max-w-2xl w-full max-h-[90vh] overflow-y-auto">
+            <div className="p-6">
+              {(() => {
+                const credential = nextScreen.credentials[editingCredentialIdx]
+                return (
+                  <DefineCredentialValuesStep
+                    selectedSchema={selectedSchema || null}
+                    initialValues={credential.attributes?.reduce((acc: Record<string, string>, attr: any) => {
+                      acc[attr.name] = attr.value || ''
+                      return acc
+                    }, {})}
+                    initialIcon={credential.icon}
+                    onBack={() => {
+                      setEditingCredentialIdx(null)
+                      setSelectedSchema(null)
+                    }}
+                    onSelectCredential={async (values, icon) => {
+                      if (nextScreen?.credentials) {
+                        const updatedCredential = {
+                          ...nextScreen.credentials[editingCredentialIdx],
+                          attributes: credential.attributes?.map((attr: any) => ({
+                            ...attr,
+                            value: values[attr.name] || attr.value,
+                          })),
+                          icon,
+                        }
+                        nextScreen.credentials[editingCredentialIdx] = updatedCredential
+                        try {
+                          if (updatedCredential.id) {
+                            await updateCredential(auth, updatedCredential.id, {
+                              attributes: updatedCredential.attributes,
+                              icon: updatedCredential.icon,
+                            })
+                          }
+                          await onRefresh?.()
+                        } catch (error) {
+                          logger.error('Error saving credential update:', error)
+                        }
+                      }
+                      setEditingCredentialIdx(null)
+                      setSelectedSchema(null)
+                    }}
+                  />
+                )
+              })()}
+            </div>
+          </div>
+        </div>
       )}
     </div>
   )

--- a/frontend/src/admin/components/showcase/introduction/IntroductionTab.tsx
+++ b/frontend/src/admin/components/showcase/introduction/IntroductionTab.tsx
@@ -19,7 +19,7 @@ interface IntroductionTabProps {
   showcase: Showcase
   isNewShowcase?: boolean
   onTabChange?: (tab: string) => void
-  onRefresh?: () => void | Promise<void>
+  onRefresh?: () => Promise<void>
   isExpanded: boolean
   setIsExpanded: (expanded: boolean) => void
 }
@@ -112,6 +112,7 @@ export function IntroductionTab({
             onDragOver={handleDragOver}
             onDragLeave={handleDragLeave}
             onSelectCredential={() => setIsSelectCredentialModalOpen(true)}
+            onRefresh={onRefresh}
           />
         </div>
 

--- a/frontend/src/admin/components/showcase/introduction/IntroductionTab.tsx
+++ b/frontend/src/admin/components/showcase/introduction/IntroductionTab.tsx
@@ -19,7 +19,7 @@ interface IntroductionTabProps {
   showcase: Showcase
   isNewShowcase?: boolean
   onTabChange?: (tab: string) => void
-  onRefresh?: () => Promise<void>
+  onRefresh?: () => void | Promise<void>
   isExpanded: boolean
   setIsExpanded: (expanded: boolean) => void
 }

--- a/frontend/src/admin/components/showcase/introduction/IntroductionTimeline.tsx
+++ b/frontend/src/admin/components/showcase/introduction/IntroductionTimeline.tsx
@@ -22,6 +22,7 @@ interface IntroductionTimelineProps {
   onDragOver: (e: React.DragEvent<HTMLDivElement>) => void
   onDragLeave: () => void
   onSelectCredential: () => void
+  onRefresh?: () => Promise<void>
 }
 
 export function IntroductionTimeline({
@@ -41,6 +42,7 @@ export function IntroductionTimeline({
   onDragOver,
   onDragLeave,
   onSelectCredential,
+  onRefresh,
 }: IntroductionTimelineProps) {
   const rows = buildIntroductionRows(introduction, showcase.progressBar)
 
@@ -71,6 +73,7 @@ export function IntroductionTimeline({
             onDragOver={onDragOver}
             onDragLeave={onDragLeave}
             onSelectCredential={onSelectCredential}
+            onRefresh={onRefresh}
           />
         </div>
       ))}

--- a/frontend/src/admin/components/showcase/introduction/IntroductionTimeline.tsx
+++ b/frontend/src/admin/components/showcase/introduction/IntroductionTimeline.tsx
@@ -22,7 +22,7 @@ interface IntroductionTimelineProps {
   onDragOver: (e: React.DragEvent<HTMLDivElement>) => void
   onDragLeave: () => void
   onSelectCredential: () => void
-  onRefresh?: () => Promise<void>
+  onRefresh?: () => void | Promise<void>
 }
 
 export function IntroductionTimeline({

--- a/frontend/src/admin/components/showcase/modals/steps/DefineCredentialValuesStep.tsx
+++ b/frontend/src/admin/components/showcase/modals/steps/DefineCredentialValuesStep.tsx
@@ -1,7 +1,7 @@
 import type { Schema } from '../../../../types'
 
 import { ArrowUpTrayIcon } from '@heroicons/react/24/outline'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 
 import { publicBaseUrl } from '../../../../api/adminApi'
 import { ImageUploadModal } from '../ImageUploadModal'
@@ -11,6 +11,8 @@ interface DefineCredentialValuesStepProps {
   onBack: () => void
   onSelectCredential: (values: Record<string, string>, icon: string) => void
   error?: string | null
+  initialValues?: Record<string, string>
+  initialIcon?: string
 }
 
 export function DefineCredentialValuesStep({
@@ -18,22 +20,72 @@ export function DefineCredentialValuesStep({
   onBack,
   onSelectCredential,
   error,
+  initialValues,
+  initialIcon,
 }: DefineCredentialValuesStepProps) {
   const [values, setValues] = useState<Record<string, string>>(
     selectedSchema
       ? selectedSchema.attributes.reduce(
           (acc, attr) => {
-            acc[attr.name] = ''
+            acc[attr.name] = initialValues?.[attr.name] ?? ''
             return acc
           },
           {} as Record<string, string>,
         )
       : {},
   )
-  const [icon, setIcon] = useState<string>('')
+  const [icon, setIcon] = useState<string>(initialIcon ?? '')
   const [dateOptions, setDateOptions] = useState<Record<string, 'custom' | 'issuance'>>({})
   const [yearOffsets, setYearOffsets] = useState<Record<string, number>>({})
   const [isImageUploadModalOpen, setIsImageUploadModalOpen] = useState(false)
+
+  // Initialize values when selectedSchema or initialValues change
+  useEffect(() => {
+    if (selectedSchema && initialValues) {
+      const newValues = selectedSchema.attributes.reduce(
+        (acc, attr) => {
+          acc[attr.name] = initialValues[attr.name] ?? ''
+          return acc
+        },
+        {} as Record<string, string>,
+      )
+      setValues(newValues)
+    }
+  }, [selectedSchema, initialValues])
+
+  // Initialize date options based on initial values
+  useEffect(() => {
+    if (selectedSchema && initialValues) {
+      const newDateOptions: Record<string, 'custom' | 'issuance'> = {}
+      const newYearOffsets: Record<string, number> = {}
+
+      selectedSchema.attributes.forEach((attr) => {
+        if (attr.type === 'date') {
+          const value = initialValues[attr.name]
+          if (value) {
+            if (value.startsWith('$dateint:')) {
+              // Extract year offset from $dateint: format
+              const yearOffset = parseInt(value.replace('$dateint:', ''), 10)
+              newDateOptions[attr.name] = 'issuance'
+              newYearOffsets[attr.name] = yearOffset
+            } else if (!isNaN(Number(value))) {
+              // It's a timestamp, convert to YYYY-MM-DD
+              const date = new Date(Number(value) * 1000)
+              const dateString = date.toISOString().split('T')[0]
+              setValues((prev) => ({ ...prev, [attr.name]: dateString }))
+              newDateOptions[attr.name] = 'custom'
+            } else {
+              // Assume it's already YYYY-MM-DD format
+              newDateOptions[attr.name] = 'custom'
+            }
+          }
+        }
+      })
+
+      setDateOptions(newDateOptions)
+      setYearOffsets(newYearOffsets)
+    }
+  }, [selectedSchema, initialValues])
 
   if (!selectedSchema) return null
 
@@ -229,7 +281,7 @@ export function DefineCredentialValuesStep({
           onClick={onBack}
           className="px-4 py-2 text-gray-700 bg-gray-100 hover:bg-gray-200 rounded-lg font-medium transition-colors"
         >
-          Back
+          {initialValues ? 'Cancel' : 'Back'}
         </button>
         <button
           onClick={handleSubmit}
@@ -238,7 +290,7 @@ export function DefineCredentialValuesStep({
             isFormValid() ? 'bg-bcgov-blue hover:bg-bcgov-blue-dark cursor-pointer' : 'bg-gray-400 cursor-not-allowed'
           }`}
         >
-          Create Credential
+          {initialValues ? 'Update Credential' : 'Create Credential'}
         </button>
       </div>
 

--- a/frontend/src/admin/components/showcase/scenarios/ScenarioScreenRow.tsx
+++ b/frontend/src/admin/components/showcase/scenarios/ScenarioScreenRow.tsx
@@ -2,6 +2,7 @@ import type { ScenarioScreen } from '../../../types'
 
 import { publicBaseUrl } from '../../../api/adminApi'
 import { useHasRole } from '../../../hooks/useUserRole'
+import { formatPredicateValue } from '../../../utils/formatters'
 import { ScreenRowBase } from '../ScreenRowBase'
 
 interface ScenarioScreenRowProps {
@@ -102,18 +103,7 @@ export function ScenarioScreenRow({
                           <div className="text-xs space-y-1 ml-2 mt-2">
                             <p className="font-semibold text-gray-700">Predicates:</p>
                             {cred.predicates.map((pred, predIdx) => {
-                              let displayValue = pred.value
-                              if (typeof pred.value === 'string' && pred.value.startsWith('$dateint:')) {
-                                const years = parseInt(pred.value.replace('$dateint:', ''), 10)
-                                if (!isNaN(years)) {
-                                  if (years === 0) {
-                                    displayValue = 'Time of issuance'
-                                  } else {
-                                    const operator = years > 0 ? '+' : '-'
-                                    displayValue = `Time of issuance ${operator} ${Math.abs(years)} years`
-                                  }
-                                }
-                              }
+                              const displayValue = formatPredicateValue(pred.value)
                               return (
                                 <div key={predIdx} className="text-gray-600 flex items-center gap-2">
                                   <span className="w-1 h-1 bg-gray-400 rounded-full"></span>

--- a/frontend/src/admin/utils/formatters.ts
+++ b/frontend/src/admin/utils/formatters.ts
@@ -1,0 +1,39 @@
+/**
+ * Converts a $dateint marker to a human-readable display string.
+ *
+ * Supported markers:
+ *   `$dateint:0`   → 'Time of issuance'
+ *   `$dateint:1`   → 'Time of issuance + 1 years'
+ *   `$dateint:-19` → 'Time of issuance - 19 years'
+ *
+ * @param value - The predicate value to format
+ * @returns Formatted display string, or the original value if not a $dateint marker
+ */
+export function formatPredicateValue(value: any): string | number {
+  if (typeof value === 'string' && value.startsWith('$dateint:')) {
+    const years = parseInt(value.replace('$dateint:', ''), 10)
+    if (!isNaN(years)) {
+      if (years === 0) {
+        return 'Time of issuance'
+      } else {
+        const operator = years > 0 ? '+' : '-'
+        return `Time of issuance ${operator} ${Math.abs(years)} years`
+      }
+    }
+  }
+  return value
+}
+
+/**
+ * Truncates extremely long strings (like base64-encoded images) to a readable length.
+ *
+ * @param value - The string to truncate
+ * @param maxLength - Maximum length before truncation (default: 100)
+ * @returns Truncated string with ellipsis, or original value if not a string or shorter than maxLength
+ */
+export function truncateLongString(value: any, maxLength: number = 100): string | number {
+  if (typeof value === 'string' && value.length > maxLength) {
+    return `${value.substring(0, maxLength)}...`
+  }
+  return value
+}

--- a/server/src/routes/__tests__/adminSchemasRouter.test.ts
+++ b/server/src/routes/__tests__/adminSchemasRouter.test.ts
@@ -349,4 +349,104 @@ describe('adminSchemasRouter', () => {
       expect(res.status).toBe(201)
     })
   })
+
+  // ============================================================================
+  // GET /admin/schemas/:id
+  // ============================================================================
+
+  describe('GET /admin/schemas/:id', () => {
+    it('returns 200 with single schema by ID', async () => {
+      const mockDid = { _id: mockIssuerDid, did: mockIssuerDid }
+      mocks.mockSchemaModel.findById.mockReturnValue({
+        lean: vi.fn().mockResolvedValue(mockSchema),
+      })
+      mocks.mockDidModel.findById.mockReturnValue({
+        lean: vi.fn().mockResolvedValue(mockDid),
+      })
+
+      const res = await request(app).get(`/admin/schemas/${mockSchema._id}`)
+
+      expect(res.status).toBe(200)
+      expect(res.body).toHaveProperty('_id', mockSchema._id)
+      expect(res.body).toHaveProperty('name', 'Student Card')
+    })
+
+    it('transforms MongoDB _id to id property', async () => {
+      const mockDid = { _id: mockIssuerDid, did: mockIssuerDid }
+      mocks.mockSchemaModel.findById.mockReturnValue({
+        lean: vi.fn().mockResolvedValue(mockSchema),
+      })
+      mocks.mockDidModel.findById.mockReturnValue({
+        lean: vi.fn().mockResolvedValue(mockDid),
+      })
+
+      const res = await request(app).get(`/admin/schemas/${mockSchema._id}`)
+
+      expect(res.body).toHaveProperty('id', mockSchema._id)
+    })
+
+    it('includes DID information in response', async () => {
+      const mockDid = { _id: mockIssuerDid, did: mockIssuerDid, verkey: 'test-verkey' }
+      mocks.mockSchemaModel.findById.mockReturnValue({
+        lean: vi.fn().mockResolvedValue(mockSchema),
+      })
+      mocks.mockDidModel.findById.mockReturnValue({
+        lean: vi.fn().mockResolvedValue(mockDid),
+      })
+
+      const res = await request(app).get(`/admin/schemas/${mockSchema._id}`)
+
+      expect(res.body).toHaveProperty('did')
+      expect(res.body.did).toEqual(mockDid)
+    })
+
+    it('returns 404 when schema does not exist', async () => {
+      mocks.mockSchemaModel.findById.mockReturnValue({
+        lean: vi.fn().mockResolvedValue(null),
+      })
+
+      const res = await request(app).get('/admin/schemas/nonexistent-id')
+
+      expect(res.status).toBe(404)
+      expect(res.body).toHaveProperty('error', 'Schema not found')
+    })
+
+    it('returns 500 when database query fails', async () => {
+      mocks.mockSchemaModel.findById.mockReturnValue({
+        lean: vi.fn().mockRejectedValue(new Error('Database connection error')),
+      })
+
+      const res = await request(app).get(`/admin/schemas/${mockSchema._id}`)
+
+      expect(res.status).toBe(500)
+      expect(res.body).toHaveProperty('error', 'Failed to fetch schema from MongoDB')
+    })
+
+    it('calls SchemaModel.findById with correct ID', async () => {
+      mocks.mockSchemaModel.findById.mockReturnValue({
+        lean: vi.fn().mockResolvedValue(mockSchema),
+      })
+      mocks.mockDidModel.findById.mockReturnValue({
+        lean: vi.fn().mockResolvedValue(null),
+      })
+
+      await request(app).get(`/admin/schemas/${mockSchema._id}`)
+
+      expect(mocks.mockSchemaModel.findById).toHaveBeenCalledWith(mockSchema._id)
+    })
+
+    it('handles missing DID gracefully', async () => {
+      mocks.mockSchemaModel.findById.mockReturnValue({
+        lean: vi.fn().mockResolvedValue(mockSchema),
+      })
+      mocks.mockDidModel.findById.mockReturnValue({
+        lean: vi.fn().mockResolvedValue(null),
+      })
+
+      const res = await request(app).get(`/admin/schemas/${mockSchema._id}`)
+
+      expect(res.status).toBe(200)
+      expect(res.body).toHaveProperty('did', null)
+    })
+  })
 })

--- a/server/src/routes/adminSchemasRouter.ts
+++ b/server/src/routes/adminSchemasRouter.ts
@@ -42,6 +42,31 @@ router.get('/schemas', defaultRateLimiter, requireRole(['admin', 'creator']), as
 })
 
 /**
+ * GET /admin/schemas/:id
+ * Get a single anoncreds schema from MongoDB by ID.
+ */
+router.get(
+  '/schemas/:id',
+  defaultRateLimiter,
+  requireRole(['admin', 'creator']),
+  async (req: Request, res: Response) => {
+    logger.debug({ id: req.params.id }, 'Admin: fetching schema by ID from MongoDB')
+    try {
+      const schema = await SchemaModel.findById(req.params.id).lean()
+      if (!schema) {
+        res.status(404).json({ error: 'Schema not found' })
+        return
+      }
+      const response = await transformSchemaResponse(schema)
+      res.json(response)
+    } catch (error) {
+      logger.error(error, 'Error fetching schema from MongoDB')
+      res.status(500).json({ error: 'Failed to fetch schema from MongoDB' })
+    }
+  },
+)
+
+/**
  * POST /admin/schemas
  * Create a new anoncreds schema in Traction and save to MongoDB.
  */


### PR DESCRIPTION
 - Adds the credential attribute names and values to the credential card.
 - Re-purposes the credential creation modal to support updating credentials.
 - Adds a get schema by id api endpoint.
 - Adds some unit test coverage for the api and missing coverage in general.

Lawyer credential card now:
<img width="2766" height="428" alt="image" src="https://github.com/user-attachments/assets/fc77d0f8-0aa4-4e14-877f-bbeede942e2d" />
Update credential modal with date (student):
<img width="1962" height="1520" alt="image" src="https://github.com/user-attachments/assets/e44bd147-6525-4966-86bf-f49c2b24d069" />

