### PR TITLE
Properly handle failed verification

### DIFF
--- a/frontend/src/client/pages/scenario/Section.tsx
+++ b/frontend/src/client/pages/scenario/Section.tsx
@@ -70,9 +70,7 @@ export const Section: React.FC<Props> = ({
 
   const isConnectionCompleted = isConnected(connection.state as string)
   const isProofCompleted =
-    (proof?.state as string) === 'presentation-received' ||
-    (proof?.state as string) === 'verified' ||
-    proof?.state === 'done'
+    ((proof?.state as string) === 'verified' || proof?.state === 'done') && proof?.verified !== 'false'
   const credentialsReceived = Object.values(credentials).every((x) => isCredIssued(x.state))
 
   const [completed, setCompleted] = useState(false)

--- a/frontend/src/client/pages/scenario/steps/StepProof.tsx
+++ b/frontend/src/client/pages/scenario/steps/StepProof.tsx
@@ -78,10 +78,9 @@ export const StepProof: React.FC<Props> = ({
 }) => {
   const dispatch = useAppDispatch()
   const proofRequestCreatedRef = useRef(false)
-  const proofReceived =
-    (proof?.state as string) === 'presentation-received' ||
-    (proof?.state as string) === 'verified' ||
-    proof?.state === 'done'
+  const proofDone = (proof?.state as string) === 'verified' || proof?.state === 'done'
+  const proofReceived = proofDone && proof?.verified !== 'false'
+  const proofFailed = proofDone && proof?.verified === 'false'
 
   const [isFailedRequestModalOpen, setIsFailedRequestModalOpen] = useState(false)
   const showFailedRequestModal = () => setIsFailedRequestModalOpen(true)
@@ -172,6 +171,13 @@ export const StepProof: React.FC<Props> = ({
       dispatch(deleteProofById(proof?.id))
     }
   }, [proofReceived])
+
+  useEffect(() => {
+    if (proofFailed && proof?.id) {
+      dispatch(deleteProofById(proof.id))
+      showFailedRequestModal()
+    }
+  }, [proofFailed])
 
   const sendNewRequest = () => {
     if (!proofReceived && proof) {

--- a/frontend/src/client/pages/scenario/steps/StepProofOOB.tsx
+++ b/frontend/src/client/pages/scenario/steps/StepProofOOB.tsx
@@ -56,10 +56,9 @@ export const StepProofOOB: React.FC<Props> = ({ proof, step, requestedCredential
   const { shortProofUrl, proofUrl } = useProof()
   const { message } = useSocket()
 
-  const proofReceived =
-    (proof?.state as string) === 'presentation-received' ||
-    (proof?.state as string) === 'verified' ||
-    proof?.state === 'done'
+  const proofDone = (proof?.state as string) === 'verified' || proof?.state === 'done'
+  const proofReceived = proofDone && proof?.verified !== 'false'
+  const proofFailed = proofDone && proof?.verified === 'false'
 
   const deepLink = proofUrl ? `bcwallet://aries_connection_invitation?${proofUrl.split('?')[1]}` : ''
 
@@ -124,13 +123,27 @@ export const StepProofOOB: React.FC<Props> = ({ proof, step, requestedCredential
     }
   }, [proofReceived])
 
+  useEffect(() => {
+    if (proofFailed && proof?.id) {
+      dispatch(deleteProofById(proof.id))
+    }
+  }, [proofFailed])
+
   const qrUrl = shortProofUrl ?? proofUrl
 
   const renderQRCode = (overlay?: boolean) => {
     return qrUrl ? <QRCode invitationUrl={qrUrl} connectionState={proof?.state} overlay={overlay} /> : null
   }
 
-  const renderCTA = !proofReceived ? (
+  const renderCTA = proofFailed ? (
+    <motion.div variants={fade} key="proofFailed">
+      <p className="text-red-600">Verification failed. The credential may have been revoked.</p>
+    </motion.div>
+  ) : proofReceived ? (
+    <motion.div variants={fade} key="proofCompleted">
+      <p>Success! You can continue.</p>
+    </motion.div>
+  ) : (
     <motion.div variants={fade} key="scanProofQr">
       <p>
         Scan the QR code with your digital wallet {isMobile && proofUrl && 'or '}
@@ -142,10 +155,6 @@ export const StepProofOOB: React.FC<Props> = ({ proof, step, requestedCredential
         )}{' '}
         to present the requested credentials.
       </p>
-    </motion.div>
-  ) : (
-    <motion.div variants={fade} key="proofCompleted">
-      <p>Success! You can continue.</p>
     </motion.div>
   )
 

--- a/server/src/controllers/ProofController.ts
+++ b/server/src/controllers/ProofController.ts
@@ -66,8 +66,15 @@ export class ProofController {
   @Delete('/:proofId')
   public async deleteProofById(@Param('proofId') proofId: string) {
     logger.info({ proofId }, 'Deleting proof record')
-    const proofRecord = (await tractionRequest.delete(`/present-proof-2.0/records/${proofId}`)).data
-    return proofRecord
+    try {
+      return (await tractionRequest.delete(`/present-proof-2.0/records/${proofId}`)).data
+    } catch (err: any) {
+      if (err?.response?.status === 404) {
+        logger.debug({ proofId }, 'Proof record already deleted')
+        return {}
+      }
+      throw err
+    }
   }
 
   @Post('/proofs/:proofId/accept-presentation')


### PR DESCRIPTION
The existing code just made sure verification happened but never handled when verified === 'false'. This pr resolves this and is the last step to ensure legacy revocation works.