### PR TITLE
Potential fix for code scanning alert no. 292: DOM text reinterpreted as HTML

### DIFF
--- a/frontend/src/admin/components/ScreenContentCard.tsx
+++ b/frontend/src/admin/components/ScreenContentCard.tsx
@@ -33,7 +33,18 @@ function getSafeImagePath(image?: string): string | null {
   if (trimmed.startsWith('//')) return null
   if (trimmed.includes('://')) return null
   if (trimmed.includes('..')) return null
-  if (/[<>"'`\\\u0000-\u001F\u007F]/.test(trimmed)) return null
+
+  // Check for potentially dangerous characters
+  const dangerousChars = ['<', '>', '"', "'", '`', '\\']
+  if (dangerousChars.some((char) => trimmed.includes(char))) return null
+
+  // Check for control characters (0x00-0x1F and 0x7F)
+  for (let i = 0; i < trimmed.length; i++) {
+    const code = trimmed.charCodeAt(i)
+    if ((code >= 0x00 && code <= 0x1f) || code === 0x7f) {
+      return null
+    }
+  }
 
   return trimmed
 }
@@ -73,6 +84,19 @@ export function ScreenContentCard({
 }: ScreenContentCardProps) {
   const canEdit = useHasRole('creator')
   const safeImageUrl = buildSafeImageUrl(image)
+
+  const containerClasses = [
+    containerClassName,
+    isDragging ? 'opacity-50' : '',
+    isDragOver ? 'bg-blue-50 border-blue-400' : '',
+    draggableId && !disableDrag ? 'cursor-move' : '',
+    disableDrag && draggableId ? 'cursor-not-allowed' : '',
+  ]
+    .filter(Boolean)
+    .join(' ')
+
+  const textClasses = ['text-xs text-gray-600', textMarginClass].filter(Boolean).join(' ')
+
   return (
     <div
       draggable={!!draggableId && !disableDrag}
@@ -80,7 +104,7 @@ export function ScreenContentCard({
       onDragOver={!disableDrag ? onDragOver : undefined}
       onDragLeave={!disableDrag ? onDragLeave : undefined}
       onDrop={!disableDrag ? onDrop : undefined}
-      className={`${containerClassName} ${isDragging ? 'opacity-50' : ''} ${isDragOver ? 'bg-blue-50 border-blue-400' : ''} ${draggableId && !disableDrag ? 'cursor-move' : ''} ${disableDrag && draggableId ? 'cursor-not-allowed' : ''}`}
+      className={containerClasses}
     >
       {canEdit && (
         <button
@@ -95,7 +119,7 @@ export function ScreenContentCard({
       <div className="flex-1">
         <p className="text-sm font-bold text-bcgov-black mb-2">{formatScreenId(screenId)}</p>
         <p className="text-xs font-semibold text-bcgov-black mb-1">{title}</p>
-        <p className={`text-xs text-gray-600 ${textMarginClass}`}>{text}</p>
+        <p className={textClasses}>{text}</p>
       </div>
       {safeImageUrl && (
         <div className="flex-shrink-0 mr-8">

--- a/frontend/src/admin/components/ScreenContentCard.tsx
+++ b/frontend/src/admin/components/ScreenContentCard.tsx
@@ -38,6 +38,22 @@ function getSafeImagePath(image?: string): string | null {
   return trimmed
 }
 
+function buildSafeImageUrl(image?: string): string | null {
+  const safePath = getSafeImagePath(image)
+  if (!safePath) return null
+
+  const encodedPath = safePath
+    .split('/')
+    .map((segment) => encodeURIComponent(segment))
+    .join('/')
+
+  try {
+    return new URL(encodedPath, publicBaseUrl).toString()
+  } catch {
+    return null
+  }
+}
+
 export function ScreenContentCard({
   screenId,
   title,
@@ -56,7 +72,7 @@ export function ScreenContentCard({
   onDrop,
 }: ScreenContentCardProps) {
   const canEdit = useHasRole('creator')
-  const safeImagePath = getSafeImagePath(image)
+  const safeImageUrl = buildSafeImageUrl(image)
   return (
     <div
       draggable={!!draggableId && !disableDrag}
@@ -81,9 +97,9 @@ export function ScreenContentCard({
         <p className="text-xs font-semibold text-bcgov-black mb-1">{title}</p>
         <p className={`text-xs text-gray-600 ${textMarginClass}`}>{text}</p>
       </div>
-      {safeImagePath && (
+      {safeImageUrl && (
         <div className="flex-shrink-0 mr-8">
-          <img src={`${publicBaseUrl}${safeImagePath}`} alt={title} className="h-40 w-auto object-contain" />
+          <img src={safeImageUrl} alt={title} className="h-40 w-auto object-contain" />
         </div>
       )}
     </div>

--- a/frontend/src/admin/components/ScreenContentCard.tsx
+++ b/frontend/src/admin/components/ScreenContentCard.tsx
@@ -25,6 +25,19 @@ interface ScreenContentCardProps {
   onDrop?: (e: React.DragEvent<HTMLDivElement>) => void
 }
 
+function getSafeImagePath(image?: string): string | null {
+  if (!image) return null
+
+  const trimmed = image.trim()
+  if (!trimmed.startsWith('/')) return null
+  if (trimmed.startsWith('//')) return null
+  if (trimmed.includes('://')) return null
+  if (trimmed.includes('..')) return null
+  if (/[<>"'`\\\u0000-\u001F\u007F]/.test(trimmed)) return null
+
+  return trimmed
+}
+
 export function ScreenContentCard({
   screenId,
   title,
@@ -43,6 +56,7 @@ export function ScreenContentCard({
   onDrop,
 }: ScreenContentCardProps) {
   const canEdit = useHasRole('creator')
+  const safeImagePath = getSafeImagePath(image)
   return (
     <div
       draggable={!!draggableId && !disableDrag}
@@ -67,9 +81,9 @@ export function ScreenContentCard({
         <p className="text-xs font-semibold text-bcgov-black mb-1">{title}</p>
         <p className={`text-xs text-gray-600 ${textMarginClass}`}>{text}</p>
       </div>
-      {image && (
+      {safeImagePath && (
         <div className="flex-shrink-0 mr-8">
-          <img src={`${publicBaseUrl}${image}`} alt={title} className="h-40 w-auto object-contain" />
+          <img src={`${publicBaseUrl}${safeImagePath}`} alt={title} className="h-40 w-auto object-contain" />
         </div>
       )}
     </div>


### PR DESCRIPTION
Potential fix for [https://github.com/bcgov/BC-Wallet-Demo/security/code-scanning/292](https://github.com/bcgov/BC-Wallet-Demo/security/code-scanning/292)

The best fix is to **validate and constrain `image` to safe, expected path formats before using it in `src`**. Since current functionality expects local asset-style paths (for example `/public/common/...`), we should enforce an allowlist of relative/static paths and reject anything with unsafe patterns (`://`, `//`, control chars, path traversal, non-leading slash, etc.). If invalid, render no image.

In `frontend/src/admin/components/ScreenContentCard.tsx`:
- Add a small helper function (inside the file) to sanitize/validate image paths.
- Compute `safeImagePath` from `image`.
- Render the `<img>` only when `safeImagePath` exists.
- Build `src` with `publicBaseUrl + safeImagePath` instead of raw `image`.

This preserves existing behavior for valid internal paths and blocks untrusted/unexpected URL payloads without changing component APIs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
