### PR TITLE
feat(admin): add per-scenario hide/show toggle

### DIFF
--- a/frontend/src/admin/components/showcase/scenarios/ScenariosTab.tsx
+++ b/frontend/src/admin/components/showcase/scenarios/ScenariosTab.tsx
@@ -1,6 +1,6 @@
 import type { ScenarioScreen, Showcase } from '../../../types'
 
-import { PlusIcon } from '@heroicons/react/24/outline'
+import { EyeIcon, EyeSlashIcon, PlusIcon } from '@heroicons/react/24/outline'
 import { useEffect, useState, useRef } from 'react'
 import { useAuth } from 'react-oidc-context'
 import { useNavigate } from 'react-router-dom'
@@ -58,6 +58,8 @@ export function ScenariosTab({ showcase, isNewShowcase, onRefresh, isExpanded, s
     handleShowDeleteConfirm,
     handleDeleteConnectionProofPair,
     handleDeleteScreen,
+    handleToggleHidden,
+    togglingHiddenId,
   } = useScenarioScreens({ showcase, activeScenario, onRefresh })
 
   useEffect(() => {
@@ -129,17 +131,29 @@ export function ScenariosTab({ showcase, isNewShowcase, onRefresh, isExpanded, s
         <div className="w-4/5 px-6 mb-6 w-full">
           <div className="flex gap-4 border-b border-gray-200">
             {showcase.scenarios?.map((scenario) => (
-              <button
-                key={scenario.id}
-                onClick={() => setActiveScenario(scenario.id)}
-                className={`py-2 px-3 font-medium transition-colors border-b-2 ${
-                  activeScenario === scenario.id
-                    ? 'border-bcgov-blue-light text-bcgov-blue-light'
-                    : 'border-transparent text-bcgov-darkgrey hover:text-bcgov-black'
-                }`}
-              >
-                {scenario.name}
-              </button>
+              <div key={scenario.id} className="flex items-center">
+                <button
+                  onClick={() => setActiveScenario(scenario.id)}
+                  className={`py-2 px-3 font-medium transition-colors border-b-2 ${
+                    activeScenario === scenario.id
+                      ? 'border-bcgov-blue-light text-bcgov-blue-light'
+                      : 'border-transparent text-bcgov-darkgrey hover:text-bcgov-black'
+                  } ${scenario.hidden ? 'italic text-gray-400' : ''}`}
+                >
+                  {scenario.name}
+                </button>
+                {canEdit && (
+                  <button
+                    onClick={() => handleToggleHidden(scenario.id)}
+                    disabled={togglingHiddenId !== null}
+                    title={scenario.hidden ? 'Show scenario' : 'Hide scenario'}
+                    aria-label={scenario.hidden ? 'Show scenario' : 'Hide scenario'}
+                    className="px-1 text-bcgov-darkgrey hover:text-bcgov-black transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+                  >
+                    {scenario.hidden ? <EyeSlashIcon className="w-4 h-4" /> : <EyeIcon className="w-4 h-4" />}
+                  </button>
+                )}
+              </div>
             ))}
           </div>
         </div>

--- a/frontend/src/admin/hooks/useScenarioScreens.ts
+++ b/frontend/src/admin/hooks/useScenarioScreens.ts
@@ -21,6 +21,7 @@ export function useScenarioScreens({ showcase, activeScenario, onRefresh }: UseS
   const [reorderedScreens, setReorderedScreens] = useState<Record<string, ScenarioScreen[]>>({})
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
   const [deleteConfirmIdx, setDeleteConfirmIdx] = useState<number | null>(null)
+  const [togglingHiddenId, setTogglingHiddenId] = useState<string | null>(null)
 
   const isEditingPredefinedScreen =
     editingScreen?.screenId === 'START' ||
@@ -159,6 +160,20 @@ export function useScenarioScreens({ showcase, activeScenario, onRefresh }: UseS
     closeEditModal()
   }
 
+  const handleToggleHidden = async (scenarioId: string) => {
+    if (!showcase.scenarios || togglingHiddenId) return
+    const updatedScenarios = showcase.scenarios.map((sc) => (sc.id === scenarioId ? { ...sc, hidden: !sc.hidden } : sc))
+    setTogglingHiddenId(scenarioId)
+    try {
+      await updateShowcase(auth, showcase.name, { scenarios: updatedScenarios })
+      await onRefresh?.()
+    } catch (error) {
+      log.error('Error toggling scenario visibility:', error)
+    } finally {
+      setTogglingHiddenId(null)
+    }
+  }
+
   return {
     editingScreenIdx,
     editingScreen,
@@ -176,5 +191,7 @@ export function useScenarioScreens({ showcase, activeScenario, onRefresh }: UseS
     handleShowDeleteConfirm,
     handleDeleteConnectionProofPair,
     handleDeleteScreen,
+    handleToggleHidden,
+    togglingHiddenId,
   }
 }


### PR DESCRIPTION
This pr resolves #493 

Add an eye-icon toggle beside each scenario tab in the admin editor that flips `hidden` and persists via the existing showcase update endpoint.

- handleToggleHidden in useScenarioScreens maps the scenarios array, flips the target's hidden flag, and PUTs the full showcase
- track togglingHiddenId to disable the control while a write is in flight, guarding against concurrent toggles
- gate the toggle behind the creator role; hidden scenarios render greyed/italic with an aria-label
- unit tests cover flip, un-hide, and the in-flight no-op