### PR TITLE
fix: Image path encoding with slashes

### DIFF
--- a/frontend/src/admin/components/ScreenContentCard.tsx
+++ b/frontend/src/admin/components/ScreenContentCard.tsx
@@ -59,7 +59,8 @@ function buildSafeImageUrl(image?: string): string | null {
     .join('/')
 
   try {
-    return new URL(encodedPath, publicBaseUrl).toString()
+    const baseUrl = publicBaseUrl.endsWith('/') ? publicBaseUrl : `${publicBaseUrl}/`
+    return new URL(encodedPath.startsWith('/') ? encodedPath.slice(1) : encodedPath, baseUrl).toString()
   } catch {
     return null
   }


### PR DESCRIPTION
I made a mistake with https://github.com/bcgov/BC-Wallet-Demo/pull/520 where if the url had a `/` as the first argument it replaced the path or the url. 

The fix ensures that:

 - The baseUrl always ends with /
 - The leading / is stripped from the encoded path before passing to the URL constructor