### PR TITLE
Fix the editing attribute useEffect dependencies

### DIFF
--- a/frontend/src/admin/components/showcase/modals/steps/SelectingAttributesStep.tsx
+++ b/frontend/src/admin/components/showcase/modals/steps/SelectingAttributesStep.tsx
@@ -77,7 +77,7 @@ export function SelectingAttributesStep({
       }
     }
     fetchSchema()
-  }, [currentCredential?.schema_id, auth.user?.access_token])
+  }, [currentCredential, selectedAttributes, auth.user?.access_token])
 
   if (!currentCredential) return null
   const isAttributeSelected = (attrName: string) => {


### PR DESCRIPTION
The editing attributes modal wasn't rendering consistently because of the useEffect hook that gets the schema for it's types from the server. I'm hoping removing the optional changing and adding the selectedAttributes to the dependencies will make this consistent. 