### PR TITLE
Truncate long strings to 80 characters

### DIFF
--- a/frontend/src/admin/components/showcase/introduction/IntroductionScreenRow.tsx
+++ b/frontend/src/admin/components/showcase/introduction/IntroductionScreenRow.tsx
@@ -135,7 +135,7 @@ export function IntroductionScreenRow({
                                   <div key={attrIdx} className="grid grid-cols-[auto_1fr] gap-3">
                                     <span className="font-medium text-gray-700">{attr.name}:</span>
                                     <span className="text-gray-600">
-                                      {truncateLongString(formatPredicateValue(attr.value), 200)}
+                                      {truncateLongString(formatPredicateValue(attr.value))}
                                     </span>
                                   </div>
                                 ))}

--- a/frontend/src/admin/utils/formatters.ts
+++ b/frontend/src/admin/utils/formatters.ts
@@ -31,7 +31,7 @@ export function formatPredicateValue(value: any): string | number {
  * @param maxLength - Maximum length before truncation (default: 100)
  * @returns Truncated string with ellipsis, or original value if not a string or shorter than maxLength
  */
-export function truncateLongString(value: any, maxLength: number = 100): string | number {
+export function truncateLongString(value: any, maxLength: number = 80): string | number {
   if (typeof value === 'string' && value.length > maxLength) {
     return `${value.substring(0, maxLength)}...`
   }


### PR DESCRIPTION
The 200 characters forces the screen content card out wider and messes with the layout. I'm going to reduce it to 80 characters and see if this fully resolves it for a reasonable amount of zoom.