### PR TITLE
Use auth.isAuthenticated in dependency chain

### DIFF
--- a/frontend/src/admin/components/showcase/modals/steps/SelectingAttributesStep.tsx
+++ b/frontend/src/admin/components/showcase/modals/steps/SelectingAttributesStep.tsx
@@ -41,7 +41,7 @@ export function SelectingAttributesStep({
 
   useEffect(() => {
     const fetchSchema = async () => {
-      if (currentCredential?.schema_id && auth.user?.access_token) {
+      if (currentCredential?.schema_id && auth.isAuthenticated) {
         try {
           const schemaData = await getSchemaById(auth, currentCredential.schema_id)
           setSchema(schemaData)
@@ -77,7 +77,7 @@ export function SelectingAttributesStep({
       }
     }
     fetchSchema()
-  }, [currentCredential, selectedAttributes, auth.user?.access_token])
+  }, [currentCredential, selectedAttributes, auth.isAuthenticated])
 
   if (!currentCredential) return null
   const isAttributeSelected = (attrName: string) => {


### PR DESCRIPTION
This was still not working only for dev instance. The better thing would have been to use api caching library like tan stack. Maybe we still can.

This is the only place I've been having this issue. I don't think I should have been using the token here and instance the better isAuthenticated boolean.