### PR TITLE
Fix seed script with existing values / Migration Improvements

### DIFF
--- a/server/migrations/002-persona-to-pick-character-image.ts
+++ b/server/migrations/002-persona-to-pick-character-image.ts
@@ -12,8 +12,17 @@ export async function up() {
         const pickCharacterScreen = showcase.introduction?.find((s) => s.screenId === 'PICK_CHARACTER')
 
         if (pickCharacterScreen && !pickCharacterScreen.image && showcase.persona?.image) {
-          pickCharacterScreen.image = showcase.persona.image
-          await showcase.save()
+          await ShowcaseModel.updateOne(
+            {
+              _id: showcase._id,
+              'introduction.screenId': 'PICK_CHARACTER',
+            },
+            {
+              $set: {
+                'introduction.$.image': showcase.persona.image,
+              },
+            },
+          )
           updatedCount++
         }
       } catch (error) {

--- a/server/migrations/003-add-restrictions-to-presentations.ts
+++ b/server/migrations/003-add-restrictions-to-presentations.ts
@@ -31,6 +31,7 @@ export async function up() {
         }
       }
       // Save the showcase after updating all its scenarios
+      showcase.markModified('scenarios')
       await showcase.save()
     } catch (error) {
       logger.error({ showcase: showcase.name, error }, 'Error processing showcase in migration 003')

--- a/server/migrations/__tests__/seed.test.ts
+++ b/server/migrations/__tests__/seed.test.ts
@@ -75,10 +75,9 @@ describe('runSeed', () => {
   it('upserts updated fields when config changes', async () => {
     const { runSeed } = await import('../seed')
     await runSeed()
-
     await ShowcaseModel.findOneAndUpdate(
       { 'persona.type': showcases[0].persona?.type },
-      { $set: { name: 'Modified Name' } },
+      { $setOnInsert: { name: 'Modified Name' } },
     )
 
     await runSeed()

--- a/server/migrations/runner.ts
+++ b/server/migrations/runner.ts
@@ -64,8 +64,11 @@ export async function runMigrations() {
 
       // Atomically attempt to claim the migration lock
       // This will only succeed if the document doesn't exist or status is not set
-      const claimed = await MigrationModel.findByIdAndUpdate(
-        migration.id,
+      const claimed = await MigrationModel.findOneAndUpdate(
+        {
+          _id: migration.id,
+          status: { $exists: false },
+        },
         {
           $set: {
             status: 'applying',
@@ -73,7 +76,10 @@ export async function runMigrations() {
             claimedAt: new Date(),
           },
         },
-        { upsert: true, new: true },
+        {
+          upsert: true,
+          new: true,
+        },
       )
 
       // Double-check we actually claimed it (verify our instanceId is set)
@@ -86,36 +92,42 @@ export async function runMigrations() {
       }
 
       // We successfully claimed the migration - proceed with application
+      let migrationError: unknown = null
       try {
         logger.info({ migrationId: migration.id }, 'Applying migration')
         await migration.up()
-
-        // Mark migration as successfully applied
-        await MigrationModel.updateOne(
-          { _id: migration.id },
-          {
-            $set: {
-              status: 'applied',
-              appliedAt: new Date(),
-            },
-          },
-        )
-        logger.info({ migrationId: migration.id }, 'Migration applied successfully')
+        logger.info({ migrationId: migration.id }, 'Migration execution completed, waiting for write acknowledgment')
       } catch (error) {
-        // Mark migration as failed so it can be investigated and retried
+        migrationError = error
         logger.error({ migrationId: migration.id, error }, 'Migration execution failed')
+      }
+
+      if (migrationError) {
+        // Mark migration as failed
         await MigrationModel.updateOne(
           { _id: migration.id },
           {
             $set: {
               status: 'failed',
-              error: error instanceof Error ? error.message : String(error),
+              error: migrationError instanceof Error ? migrationError.message : String(migrationError),
               failedAt: new Date(),
             },
           },
         )
-        throw error
+        throw migrationError
       }
+
+      // Mark migration as successfully applied
+      await MigrationModel.updateOne(
+        { _id: migration.id },
+        {
+          $set: {
+            status: 'applied',
+            appliedAt: new Date(),
+          },
+        },
+      )
+      logger.info({ migrationId: migration.id }, 'Migration applied successfully')
     } catch (error) {
       logger.error({ migrationId: migration.id, error }, 'Unexpected error during migration processing')
       throw error

--- a/server/migrations/seed.ts
+++ b/server/migrations/seed.ts
@@ -23,7 +23,11 @@ export async function runSeed(): Promise<void> {
   await tractionApiKeyUpdaterInit(true)
   const credResults = await Promise.all(
     allCredentials.map((cred) =>
-      CredentialModel.findOneAndUpdate({ _id: cred._id }, { $set: cred }, { upsert: true, returnDocument: 'after' }),
+      CredentialModel.findOneAndUpdate(
+        { _id: cred._id },
+        { $setOnInsert: cred },
+        { upsert: true, returnDocument: 'after' },
+      ),
     ),
   )
 
@@ -33,7 +37,7 @@ export async function runSeed(): Promise<void> {
     showcases.map((s) =>
       ShowcaseModel.findOneAndUpdate(
         { 'persona.type': s.persona?.type },
-        { $set: s },
+        { $setOnInsert: s },
         { upsert: true, returnDocument: 'after' },
       ),
     ),


### PR DESCRIPTION
The problem wasn't actually the migrations it was that the seed script overrode the existing showcases and credentials and gets run before each new deploy. However, once the object got reset the migrations don't run again so they aren't in the correct state. 

I should have figured this out quicker. I did add some additional improvements to the migrations but I don't think there was actually anything wrong with them.