### PR TITLE
fix: update old schema attrName usage

### DIFF
--- a/frontend/src/admin/components/showcase/modals/CreateConnectAndAcceptScreensModal.tsx
+++ b/frontend/src/admin/components/showcase/modals/CreateConnectAndAcceptScreensModal.tsx
@@ -198,9 +198,9 @@ export function CreateConnectAndAcceptScreensModal({
                           name: selectedSchema.name,
                           icon,
                           version: selectedSchema.version,
-                          attributes: selectedSchema.attrNames.map((attrName) => ({
-                            name: attrName,
-                            value: values[attrName],
+                          attributes: selectedSchema.attributes.map((attr) => ({
+                            name: attr.name,
+                            value: values[attr.name],
                           })),
                           schema_id: selectedSchema.id,
                           cred_def_id: selectedSchema.credDefId,

--- a/frontend/src/admin/components/showcase/modals/steps/SelectingSchemaStep.tsx
+++ b/frontend/src/admin/components/showcase/modals/steps/SelectingSchemaStep.tsx
@@ -49,9 +49,9 @@ export function SelectingSchemaStep({
                   <p className="font-medium text-sm text-bcgov-black">{schema.name}</p>
                   <p className="text-xs text-gray-500">v{schema.version}</p>
                   <div className="text-xs text-gray-400 mt-2 flex flex-wrap gap-1">
-                    {schema.attrNames.map((attr) => (
-                      <span key={attr} className="bg-gray-100 px-2 py-1 rounded">
-                        {attr}
+                    {schema.attributes.map((attr) => (
+                      <span key={attr.name} className="bg-gray-100 px-2 py-1 rounded">
+                        {attr.name}
                       </span>
                     ))}
                   </div>


### PR DESCRIPTION
I missed a couple places where the old attrNames was still used. The problem is non-seeded schemas don't maintain this field. Using it cause the credential value definition feature to break and also the attr names in the schema selection step.