### PR TITLE
(WIP) fix: raise credential image upload limit to 500KB for Traction testing

### DIFF
--- a/frontend/src/admin/components/showcase/modals/CredentialImageUploadModal.tsx
+++ b/frontend/src/admin/components/showcase/modals/CredentialImageUploadModal.tsx
@@ -25,9 +25,9 @@ export function CredentialImageUploadModal({ isOpen, onClose, onSelectImage }: C
       return
     }
 
-    // Validate file size (60KB max)
-    if (file.size > 60 * 1024) {
-      setUploadError('File size must be less than 60KB')
+    // Validate file size (500KB max for testing Traction limits)
+    if (file.size > 500 * 1024) {
+      setUploadError('File size must be less than 500KB')
       return
     }
 
@@ -83,7 +83,7 @@ export function CredentialImageUploadModal({ isOpen, onClose, onSelectImage }: C
             <p className="text-gray-600 mb-2">
               {isUploading ? 'Uploading...' : 'Click to select an image from your filesystem.'}
             </p>
-            <p className="text-xs text-gray-500">Supported formats: PNG, JPG/JPEG (up to 60KB)</p>
+            <p className="text-xs text-gray-500">Supported formats: PNG, JPG/JPEG (up to 500KB)</p>
           </div>
           {uploadError && <p className="text-red-500 text-sm mt-2">{uploadError}</p>}
         </div>

--- a/server/src/controllers/CredentialController.ts
+++ b/server/src/controllers/CredentialController.ts
@@ -91,7 +91,7 @@ export class CredentialController {
   }
 
   @Post('/offerCredential')
-  public async offerCredential(@Body() params: CredentialOfferParams) {
+  public async offerCredential(@Body({ options: { limit: '10mb' } }) params: CredentialOfferParams) {
     logger.debug({ incomingParams: params }, 'Incoming credential offer params')
     const resolvedAttributes =
       params.credential_preview?.attributes != null

--- a/server/src/controllers/DeepLinkController.ts
+++ b/server/src/controllers/DeepLinkController.ts
@@ -8,7 +8,7 @@ import { tractionRequest } from '../utils/tractionHelper'
 @Service()
 export class DeeplinkController {
   @Post('/offerCredential')
-  public async offerCredential(@Body() params: any) {
+  public async offerCredential(@Body({ options: { limit: '10mb' } }) params: any) {
     logger.info({ connectionId: params.connection_id }, 'Deep link: waiting for connection before offering credential')
     const state = await this.waitUntilConnected(params.connection_id)
     if (this.isConnected(state)) {
@@ -23,7 +23,7 @@ export class DeeplinkController {
   }
 
   @Post('/requestProof')
-  public async requestProof(@Body() params: any) {
+  public async requestProof(@Body({ options: { limit: '10mb' } }) params: any) {
     logger.info({ connectionId: params.connection_id }, 'Deep link: waiting for connection before requesting proof')
     const state = await this.waitUntilConnected(params.connection_id)
     if (this.isConnected(state)) {

--- a/server/src/controllers/WebhookController.ts
+++ b/server/src/controllers/WebhookController.ts
@@ -12,7 +12,7 @@ export class WebhookController {
   public constructor(@Inject() private revocationService: RevocationService) {}
 
   @Post('/*')
-  public async handlePostWhook(@Body() params: any, @Req() req: any) {
+  public async handlePostWhook(@Body({ options: { limit: '10mb' } }) params: any, @Req() req: any) {
     logger.debug({ path: req.path }, 'Webhook payload received')
     const socketMap: Map<string, Socket> | undefined = req.app.get('sockets')
     const api_key = req.headers['x-api-key']


### PR DESCRIPTION
This PR resolves #535

The upload size is now bumped to 500KB

I have created an example demo to verify that a larger image (~440kb) will upload for the image field in the Person credential and properly issue. My testing verifies that this is working