### PR TITLE
Get presentation to edit by showcase via cred id

### DIFF
--- a/frontend/src/admin/components/showcase/modals/CreateConnectionAndProofScreensModal.tsx
+++ b/frontend/src/admin/components/showcase/modals/CreateConnectionAndProofScreensModal.tsx
@@ -385,6 +385,7 @@ export function CreateConnectionAndProofScreensModal({
                           name: credential?.name || req.name,
                           schema_id: credential?.schema_id,
                           cred_def_id: credential?.cred_def_id,
+                          cred_id: credential?.id,
                           icon: req.icon,
                           properties: req.properties,
                           ...(req.predicates && req.predicates.length > 0 && { predicates: req.predicates }),

--- a/frontend/src/admin/components/showcase/scenarios/ScenarioScreenRow.tsx
+++ b/frontend/src/admin/components/showcase/scenarios/ScenarioScreenRow.tsx
@@ -1,10 +1,10 @@
-import type { ScenarioScreen, Credential, CredentialRequest } from '../../../types'
+import type { ScenarioScreen, Credential, CredentialRequest, Showcase } from '../../../types'
 
 import { Cog6ToothIcon } from '@heroicons/react/24/outline'
 import { useEffect, useState } from 'react'
 import { useAuth } from 'react-oidc-context'
 
-import { publicBaseUrl, updateShowcase, getShowcaseByName } from '../../../api/adminApi'
+import { publicBaseUrl, updateShowcase } from '../../../api/adminApi'
 import { useHasRole } from '../../../hooks/useUserRole'
 import { formatPredicateValue } from '../../../utils/formatters'
 import logger from '../../../utils/logger'
@@ -16,7 +16,7 @@ interface ScenarioScreenRowProps {
   nextScreen?: ScenarioScreen
   idx: number
   scenarioId: string
-  showcaseName: string
+  showcase: Showcase
   screensLength: number
   hasProofChild: boolean
   isPredefinedScreen: boolean
@@ -39,7 +39,7 @@ export function ScenarioScreenRow({
   nextScreen,
   idx,
   scenarioId,
-  showcaseName,
+  showcase,
   screensLength,
   hasProofChild,
   isPredefinedScreen,
@@ -67,7 +67,6 @@ export function ScenarioScreenRow({
       if (editingCredIdx !== null && nextScreen?.requestOptions?.requestedCredentials?.[editingCredIdx]) {
         const proofRequest = nextScreen.requestOptions.requestedCredentials[editingCredIdx]
         try {
-          const showcase = await getShowcaseByName(auth, showcaseName)
           const cred =
             showcase.credentials.find((c) => c.id === proofRequest.cred_id) ||
             showcase.credentials.find((c) => c.schema_id === proofRequest.schema_id) ||
@@ -75,6 +74,7 @@ export function ScenarioScreenRow({
 
           if (!cred) {
             logger.error('Credential not found for proof request', proofRequest)
+            setEditingCredential(null)
             return
           }
 
@@ -118,7 +118,7 @@ export function ScenarioScreenRow({
       }
     }
     fetchCredential()
-  }, [editingCredIdx, auth.isAuthenticated, nextScreen])
+  }, [editingCredIdx, showcase, nextScreen])
 
   return (
     <>
@@ -234,119 +234,118 @@ export function ScenarioScreenRow({
       />
 
       {/* Edit Proof Request Modal */}
-      {editingCredIdx !== null && nextScreen?.requestOptions?.requestedCredentials?.[editingCredIdx] && (
-        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
-          <div className="bg-white rounded-lg shadow-xl max-w-2xl w-full max-h-[90vh] overflow-y-auto">
-            <div className="p-6">
-              <SelectingAttributesStep
-                currentCredential={editingCredential}
-                selectedAttributes={selectedAttributes}
-                currentIndex={0}
-                totalCredentials={1}
-                initialRequest={nextScreen.requestOptions?.requestedCredentials?.[editingCredIdx]}
-                onUpdateAttribute={(attrName, request) => {
-                  const updated = new Map(selectedAttributes)
-                  updated.set(attrName, request)
-                  setSelectedAttributes(updated)
-                }}
-                onRemoveAttribute={(attrName) => {
-                  const updated = new Map(selectedAttributes)
-                  updated.delete(attrName)
-                  setSelectedAttributes(updated)
-                }}
-                onPrevious={() => {}}
-                onNext={() => {}}
-                onContinue={async () => {
-                  try {
-                    // Convert selectedAttributes Map back to proof request format
-                    const properties: string[] = []
-                    const predicates: any[] = []
-                    let nonRevoked = false
+      {editingCredIdx !== null &&
+        editingCredential &&
+        nextScreen?.requestOptions?.requestedCredentials?.[editingCredIdx] && (
+          <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
+            <div className="bg-white rounded-lg shadow-xl max-w-2xl w-full max-h-[90vh] overflow-y-auto">
+              <div className="p-6">
+                <SelectingAttributesStep
+                  currentCredential={editingCredential}
+                  selectedAttributes={selectedAttributes}
+                  currentIndex={0}
+                  totalCredentials={1}
+                  initialRequest={nextScreen.requestOptions?.requestedCredentials?.[editingCredIdx]}
+                  onUpdateAttribute={(attrName, request) => {
+                    const updated = new Map(selectedAttributes)
+                    updated.set(attrName, request)
+                    setSelectedAttributes(updated)
+                  }}
+                  onRemoveAttribute={(attrName) => {
+                    const updated = new Map(selectedAttributes)
+                    updated.delete(attrName)
+                    setSelectedAttributes(updated)
+                  }}
+                  onPrevious={() => {}}
+                  onNext={() => {}}
+                  onContinue={async () => {
+                    try {
+                      // Convert selectedAttributes Map back to proof request format
+                      const properties: string[] = []
+                      const predicates: any[] = []
+                      let nonRevoked = false
 
-                    selectedAttributes.forEach((request, attrName) => {
-                      if (request.property) {
-                        properties.push(attrName)
-                      }
-                      if (request.predicate) {
-                        predicates.push({
-                          name: attrName,
-                          type: request.predicateType,
-                          value: request.predicateValue,
-                        })
-                      }
-                      if (request.nonRevoked) {
-                        nonRevoked = true
-                      }
-                    })
-
-                    // Fetch the current showcase
-                    const currentShowcase = await getShowcaseByName(auth, showcaseName)
-
-                    // Find and update the proof request in the scenarios
-                    const updatedScenarios = currentShowcase.scenarios.map((scenario) => {
-                      if (scenario.id === scenarioId) {
-                        return {
-                          ...scenario,
-                          screens: scenario.screens.map((scenarioScreen) => {
-                            if (scenarioScreen.screenId === nextScreen?.screenId && scenarioScreen.requestOptions) {
-                              const updatedCredentials = scenarioScreen.requestOptions.requestedCredentials.map(
-                                (cred, credIdx) => {
-                                  if (credIdx === editingCredIdx) {
-                                    const updated: CredentialRequest = {
-                                      ...cred,
-                                      properties: properties.length > 0 ? properties : undefined,
-                                      predicates: predicates.length > 0 ? predicates : undefined,
-                                      nonRevoked: nonRevoked ? { to: '$now' as const } : undefined,
-                                    }
-                                    return updated
-                                  }
-                                  return cred
-                                },
-                              )
-                              return {
-                                ...scenarioScreen,
-                                requestOptions: {
-                                  ...scenarioScreen.requestOptions,
-                                  requestedCredentials: updatedCredentials,
-                                },
-                              }
-                            }
-                            return scenarioScreen
-                          }),
+                      selectedAttributes.forEach((request, attrName) => {
+                        if (request.property) {
+                          properties.push(attrName)
                         }
+                        if (request.predicate) {
+                          predicates.push({
+                            name: attrName,
+                            type: request.predicateType,
+                            value: request.predicateValue,
+                          })
+                        }
+                        if (request.nonRevoked) {
+                          nonRevoked = true
+                        }
+                      })
+
+                      // Find and update the proof request in the scenarios
+                      const updatedScenarios = showcase.scenarios.map((scenario) => {
+                        if (scenario.id === scenarioId) {
+                          return {
+                            ...scenario,
+                            screens: scenario.screens.map((scenarioScreen) => {
+                              if (scenarioScreen.screenId === nextScreen?.screenId && scenarioScreen.requestOptions) {
+                                const updatedCredentials = scenarioScreen.requestOptions.requestedCredentials.map(
+                                  (cred, credIdx) => {
+                                    if (credIdx === editingCredIdx) {
+                                      const updated: CredentialRequest = {
+                                        ...cred,
+                                        properties: properties.length > 0 ? properties : undefined,
+                                        predicates: predicates.length > 0 ? predicates : undefined,
+                                        nonRevoked: nonRevoked ? { to: '$now' as const } : undefined,
+                                      }
+                                      return updated
+                                    }
+                                    return cred
+                                  },
+                                )
+                                return {
+                                  ...scenarioScreen,
+                                  requestOptions: {
+                                    ...scenarioScreen.requestOptions,
+                                    requestedCredentials: updatedCredentials,
+                                  },
+                                }
+                              }
+                              return scenarioScreen
+                            }),
+                          }
+                        }
+                        return scenario
+                      })
+
+                      // Update the showcase with the modified scenarios
+                      await updateShowcase(auth, showcase.name, {
+                        scenarios: updatedScenarios,
+                      })
+
+                      logger.info('Proof request updated successfully')
+
+                      // Refresh the showcase state in parent component
+                      if (onRefreshShowcase) {
+                        await onRefreshShowcase()
                       }
-                      return scenario
-                    })
-
-                    // Update the showcase with the modified scenarios
-                    await updateShowcase(auth, showcaseName, {
-                      scenarios: updatedScenarios,
-                    })
-
-                    logger.info('Proof request updated successfully')
-
-                    // Refresh the showcase state in parent component
-                    if (onRefreshShowcase) {
-                      await onRefreshShowcase()
+                    } catch (error) {
+                      logger.error('Error updating showcase:', error)
                     }
-                  } catch (error) {
-                    logger.error('Error updating showcase:', error)
-                  }
 
-                  setEditingCredIdx(null)
-                  setSelectedAttributes(new Map())
-                  setEditingCredential(null)
-                }}
-                onClose={() => {
-                  setEditingCredIdx(null)
-                  setSelectedAttributes(new Map())
-                  setEditingCredential(null)
-                }}
-              />
+                    setEditingCredIdx(null)
+                    setSelectedAttributes(new Map())
+                    setEditingCredential(null)
+                  }}
+                  onClose={() => {
+                    setEditingCredIdx(null)
+                    setSelectedAttributes(new Map())
+                    setEditingCredential(null)
+                  }}
+                />
+              </div>
             </div>
           </div>
-        </div>
-      )}
+        )}
     </>
   )
 }

--- a/frontend/src/admin/components/showcase/scenarios/ScenarioScreenRow.tsx
+++ b/frontend/src/admin/components/showcase/scenarios/ScenarioScreenRow.tsx
@@ -4,7 +4,7 @@ import { Cog6ToothIcon } from '@heroicons/react/24/outline'
 import { useEffect, useState } from 'react'
 import { useAuth } from 'react-oidc-context'
 
-import { publicBaseUrl, getAllCredentials, updateShowcase, getShowcaseByName } from '../../../api/adminApi'
+import { publicBaseUrl, updateShowcase, getShowcaseByName } from '../../../api/adminApi'
 import { useHasRole } from '../../../hooks/useUserRole'
 import { formatPredicateValue } from '../../../utils/formatters'
 import logger from '../../../utils/logger'
@@ -67,9 +67,18 @@ export function ScenarioScreenRow({
       if (editingCredIdx !== null && nextScreen?.requestOptions?.requestedCredentials?.[editingCredIdx]) {
         const proofRequest = nextScreen.requestOptions.requestedCredentials[editingCredIdx]
         try {
-          const credentials = await getAllCredentials(auth)
-          const cred = credentials.find((c) => c.name === proofRequest.name)
-          setEditingCredential(cred || null)
+          const showcase = await getShowcaseByName(auth, showcaseName)
+          const cred =
+            showcase.credentials.find((c) => c.id === proofRequest.cred_id) ||
+            showcase.credentials.find((c) => c.schema_id === proofRequest.schema_id) ||
+            null
+
+          if (!cred) {
+            logger.error('Credential not found for proof request', proofRequest)
+            return
+          }
+
+          setEditingCredential(cred)
 
           // Build and set initial attributes when modal opens
           const initialRequest = proofRequest

--- a/frontend/src/admin/components/showcase/scenarios/ScenarioTimeline.tsx
+++ b/frontend/src/admin/components/showcase/scenarios/ScenarioTimeline.tsx
@@ -1,4 +1,4 @@
-import type { ScenarioScreen } from '../../../types'
+import type { ScenarioScreen, Showcase } from '../../../types'
 
 import { useMemo } from 'react'
 
@@ -10,7 +10,7 @@ import { ScenarioSectionHeader } from './ScenarioSectionHeader'
 interface ScenarioTimelineProps {
   screens: ScenarioScreen[]
   scenarioId: string
-  showcaseName: string
+  showcase: Showcase
   lineHeight: string
   containerRef: React.RefObject<HTMLDivElement>
   draggedIdx: number | null
@@ -31,7 +31,7 @@ interface ScenarioTimelineProps {
 export function ScenarioTimeline({
   screens,
   scenarioId,
-  showcaseName,
+  showcase,
   lineHeight,
   containerRef,
   draggedIdx,
@@ -68,7 +68,7 @@ export function ScenarioTimeline({
             nextScreen={nextScreen}
             idx={idx}
             scenarioId={scenarioId}
-            showcaseName={showcaseName}
+            showcase={showcase}
             screensLength={screens.length}
             hasProofChild={hasProofChild}
             isPredefinedScreen={isPredefinedScreen}

--- a/frontend/src/admin/components/showcase/scenarios/ScenariosTab.tsx
+++ b/frontend/src/admin/components/showcase/scenarios/ScenariosTab.tsx
@@ -166,7 +166,7 @@ export function ScenariosTab({ showcase, isNewShowcase, onRefresh, isExpanded, s
                 key={scenario.id}
                 screens={currentScreens}
                 scenarioId={scenario.id}
-                showcaseName={showcase.name}
+                showcase={showcase}
                 lineHeight={lineHeight}
                 containerRef={containerRef}
                 draggedIdx={draggedIdx}

--- a/frontend/src/admin/types/index.ts
+++ b/frontend/src/admin/types/index.ts
@@ -42,6 +42,7 @@ export interface CredentialRequest {
   icon?: string
   schema_id?: string
   cred_def_id?: string
+  cred_id?: string
   predicates?: Predicate[]
   properties?: string[]
   nonRevoked?: { to: number | '$now'; from?: number | '$now' }

--- a/server/migrations/values/businessShowcase.json
+++ b/server/migrations/values/businessShowcase.json
@@ -116,6 +116,7 @@
               {
                 "icon": "/public/common/icon/icon-university-card.png",
                 "name": "Digital Business Card",
+                "cred_id": "business-digital-card",
                 "properties": ["business_name", "business_type", "company_status", "family_name", "given_names"]
               }
             ]

--- a/server/migrations/values/lawyerShowcase.json
+++ b/server/migrations/values/lawyerShowcase.json
@@ -141,6 +141,7 @@
               {
                 "icon": "/public/common/screen/lsbc-logo.png",
                 "name": "member_card",
+                "cred_id": "lawyer-member-card",
                 "properties": ["Given Name", "Surname", "PPID"]
               },
               {
@@ -188,12 +189,14 @@
               {
                 "icon": "/public/common/screen/lsbc-logo.png",
                 "name": "member_card",
+                "cred_id": "lawyer-member-card",               
                 "properties": ["Given Name", "Surname", "PPID"],
                 "nonRevoked": { "to": "$now" }
               },
               {
                 "icon": "/public/common/screen/bc-logo.png",
                 "name": "Person",
+                "cred_id": "lawyer-person",
                 "properties": ["given_names", "family_name", "picture"],
                 "nonRevoked": { "to": "$now" }
               }
@@ -237,12 +240,14 @@
               {
                 "icon": "/public/common/screen/bc-logo.png",
                 "name": "Certified Application",
+                "cred_id": "certified-application",
                 "properties": ["Issued At", "Assurance Level"],
                 "nonRevoked": { "to": "$now" }
               },
               {
                 "icon": "/public/common/screen/bc-logo.png",
                 "name": "Person",
+                "cred_id": "lawyer-person",
                 "properties": ["given_names", "family_name", "picture"],
                 "nonRevoked": { "to": "$now" }
               }

--- a/server/migrations/values/lawyerShowcase.json
+++ b/server/migrations/values/lawyerShowcase.json
@@ -189,7 +189,7 @@
               {
                 "icon": "/public/common/screen/lsbc-logo.png",
                 "name": "member_card",
-                "cred_id": "lawyer-member-card",               
+                "cred_id": "lawyer-member-card",
                 "properties": ["Given Name", "Surname", "PPID"],
                 "nonRevoked": { "to": "$now" }
               },

--- a/server/migrations/values/studentShowcase.json
+++ b/server/migrations/values/studentShowcase.json
@@ -115,6 +115,7 @@
               {
                 "icon": "/public/common/icon/icon-university-card.png",
                 "name": "student_card",
+                "cred_id": "student-card",
                 "predicates": [{ "name": "expiry_date", "type": ">=", "value": "$dateint:0" }]
               }
             ]
@@ -156,6 +157,7 @@
               {
                 "icon": "/public/common/icon/icon-university-card.png",
                 "name": "student_card",
+                "cred_id": "student-card",
                 "properties": ["student_first_name"]
               }
             ]

--- a/server/src/content/types.ts
+++ b/server/src/content/types.ts
@@ -71,6 +71,7 @@ export interface CredentialRequest {
   icon?: string
   schema_id?: string
   cred_def_id?: string
+  cred_id?: string
   predicates?: Predicate[]
   properties?: string[]
   nonRevoked?: { to: number | '$now'; from?: number | '$now' }

--- a/server/src/db/models/Scenario.ts
+++ b/server/src/db/models/Scenario.ts
@@ -43,6 +43,7 @@ const CredentialRequestSchema = new Schema<PersistedCredentialRequest>(
     icon: String,
     schema_id: String,
     cred_def_id: String,
+    cred_id: String,
     predicates: [PredicateSchema],
     properties: [String],
     nonRevoked: {


### PR DESCRIPTION
I'm still having issues with a couple presentations not rendering the edit modal. This only happens in dev and only specific credentials. Even PR deployments are completely working.

However, I noticed a couple more issues.
 - I was getting all credentials and filtering. It's better to just get the credentials from the showcase.
 - Pass the showcase through as a prop instead of a extra api call that can cause timing issues.
 - I was filtering by the credential name because that was what was historically there. However, now we could get multiple credentials with the same name. I added the cred id to the presentation request. Now it will look up based on this and then fall back to the schema id. Because we are using the showcase object credentials the problem should be resolved even for historic credentials. There is a chance for dev could have multiple credentials with the same schema_id in the same showcase. I checked and this isn't the case right now and won't continue to be a problem.
 - If the credential can't be found for some reason (the hidden attestation scenario has an undefined credential) don't even try to render the edit modal and just log an error in the console. For dev if the problem still persists then at least a broken modal won't be shown. 