### PR TITLE
fix(server): gate WebVH DID setup behind WEBVH_ENABLED

### DIFF
--- a/charts/showcase/templates/server/deployment.yaml
+++ b/charts/showcase/templates/server/deployment.yaml
@@ -111,6 +111,8 @@ spec:
             {{- end }}
             - name: BASE_ROUTE
               value: {{ .Values.showcase.baseRoute | quote }}
+            - name: WEBVH_ENABLED
+              value: {{ .Values.showcase.server.webvh.enabled | quote }}
             {{- if .Values.showcase.server.traction.url }}
             - name: TRACTION_URL
               value: {{ .Values.showcase.server.traction.url | quote }}
@@ -174,6 +176,8 @@ spec:
               value: {{ .Values.showcase.publicOrigin | quote }}
             - name: SHOWCASE_SHORT_INVITATION_URLS_ENABLED
               value: {{ .Values.showcase.server.shortInvitationUrls.enabled | quote }}
+            - name: WEBVH_ENABLED
+              value: {{ .Values.showcase.server.webvh.enabled | quote }}
             {{- if .Values.showcase.server.traction.url }}
             - name: TRACTION_URL
               value: {{ .Values.showcase.server.traction.url | quote }}

--- a/charts/showcase/values.yaml
+++ b/charts/showcase/values.yaml
@@ -109,6 +109,9 @@ showcase:
     shortInvitationUrls:
       enabled: true
     extraEnv: []
+    ## WebVH DID setup during seed/startup. Requires Traction `/did/webvh/config` when enabled.
+    webvh:
+      enabled: false
     ## Traction (ACA-Py tenant proxy): non-secret base URL in values; tenant id + API key from a Secret (see traction.existingSecret).
     traction:
       ## Tenant proxy base URL (no path). Example: https://traction-tenant-proxy-dev.apps.silver.devops.gov.bc.ca

--- a/server/.env.example
+++ b/server/.env.example
@@ -21,6 +21,8 @@ BASE_ROUTE=/digital-trust/showcase
 # Short OOB invitation URLs for QR codes (`GET …/i/{oobId}`). Set to false to use full Traction invitation_url in QR.
 # SHOWCASE_SHORT_INVITATION_URLS_ENABLED=true
 WEBHOOK_SECRET=secret
+# Set to true to create or reuse a WebVH DID during seed/startup (requires Traction webvh plugin).
+# WEBVH_ENABLED=false
 
 # Admin portal -- Keycloak configuration is loaded at runtime from config/keycloak.json.
 

--- a/server/migrations/__tests__/seed.test.ts
+++ b/server/migrations/__tests__/seed.test.ts
@@ -100,9 +100,10 @@ describe('runSeed', () => {
     expect(doc?.credentials.every((c) => typeof c === 'string')).toBe(true)
   })
 
-  it('skips webvh did when traction does not provide webvh', async () => {
+  it('skips webvh did when WEBVH_ENABLED is not set', async () => {
+    delete process.env.WEBVH_ENABLED
     const tractionHelper = await import('../../src/utils/tractionHelper')
-    vi.mocked(tractionHelper.getOrCreateWebvhDid).mockResolvedValue(null)
+    vi.mocked(tractionHelper.getOrCreateWebvhDid).mockRestore()
     vi.mocked(tractionHelper.ensureDidInDatabase).mockClear()
 
     const { runSeed } = await import('../seed')

--- a/server/migrations/__tests__/seed.test.ts
+++ b/server/migrations/__tests__/seed.test.ts
@@ -99,4 +99,18 @@ describe('runSeed', () => {
     const doc = await ShowcaseModel.findOne({ 'persona.type': showcases[0].persona?.type }).lean()
     expect(doc?.credentials.every((c) => typeof c === 'string')).toBe(true)
   })
+
+  it('skips webvh did when traction does not provide webvh', async () => {
+    const tractionHelper = await import('../../src/utils/tractionHelper')
+    vi.mocked(tractionHelper.getOrCreateWebvhDid).mockResolvedValue(null)
+    vi.mocked(tractionHelper.ensureDidInDatabase).mockClear()
+
+    const { runSeed } = await import('../seed')
+    await runSeed()
+
+    expect(tractionHelper.ensureDidInDatabase).toHaveBeenCalledWith('did:sov:test', 'indy')
+    expect(
+      vi.mocked(tractionHelper.ensureDidInDatabase).mock.calls.some(([, method]) => method === 'webvh'),
+    ).toBe(false)
+  })
 })

--- a/server/migrations/__tests__/seed.test.ts
+++ b/server/migrations/__tests__/seed.test.ts
@@ -110,8 +110,8 @@ describe('runSeed', () => {
     await runSeed()
 
     expect(tractionHelper.ensureDidInDatabase).toHaveBeenCalledWith('did:sov:test', 'indy')
-    expect(
-      vi.mocked(tractionHelper.ensureDidInDatabase).mock.calls.some(([, method]) => method === 'webvh'),
-    ).toBe(false)
+    expect(vi.mocked(tractionHelper.ensureDidInDatabase).mock.calls.some(([, method]) => method === 'webvh')).toBe(
+      false,
+    )
   })
 })

--- a/server/migrations/seed.ts
+++ b/server/migrations/seed.ts
@@ -49,7 +49,9 @@ export async function runSeed(): Promise<void> {
   const webvhDid = await getOrCreateWebvhDid()
 
   await ensureDidInDatabase(indyDid, 'indy')
-  await ensureDidInDatabase(webvhDid, 'webvh')
+  if (webvhDid) {
+    await ensureDidInDatabase(webvhDid, 'webvh')
+  }
 
   for (const credential of credentialsSeed as SeedCredential[]) {
     await processSeededCredential(credential, indyDid)

--- a/server/src/utils/__tests__/tractionHelper.test.ts
+++ b/server/src/utils/__tests__/tractionHelper.test.ts
@@ -272,16 +272,35 @@ describe('getOrCreateWebvhDid', () => {
   let postSpy: ReturnType<typeof vi.spyOn>
 
   beforeEach(() => {
+    delete process.env.WEBVH_ENABLED
     getSpy = vi.spyOn(th.tractionRequest, 'get')
     postSpy = vi.spyOn(th.tractionRequest, 'post')
   })
 
   afterEach(() => {
+    delete process.env.WEBVH_ENABLED
     getSpy.mockRestore()
     postSpy.mockRestore()
   })
 
-  it('returns existing posted webvh did when present', async () => {
+  it('returns null without calling Traction when WEBVH_ENABLED is unset', async () => {
+    const did = await th.getOrCreateWebvhDid()
+
+    expect(did).toBeNull()
+    expect(getSpy).not.toHaveBeenCalled()
+  })
+
+  it('returns null without calling Traction when WEBVH_ENABLED is false', async () => {
+    process.env.WEBVH_ENABLED = 'false'
+
+    const did = await th.getOrCreateWebvhDid()
+
+    expect(did).toBeNull()
+    expect(getSpy).not.toHaveBeenCalled()
+  })
+
+  it('returns existing posted webvh did when enabled', async () => {
+    process.env.WEBVH_ENABLED = 'true'
     getSpy.mockResolvedValue({
       data: {
         results: [{ did: 'did:webvh:example:abc' }],
@@ -294,31 +313,8 @@ describe('getOrCreateWebvhDid', () => {
     expect(getSpy).toHaveBeenCalledTimes(1)
   })
 
-  it('returns null when webvh config endpoint is unavailable', async () => {
-    getSpy
-      .mockResolvedValueOnce({ data: { results: [] } })
-      .mockRejectedValueOnce({ response: { status: 404 }, message: 'Not Found' })
-
-    const did = await th.getOrCreateWebvhDid()
-
-    expect(did).toBeNull()
-    expect(vi.mocked(logger.warn)).toHaveBeenCalledWith(
-      'WebVH not available on Traction tenant; skipping WebVH DID setup',
-    )
-  })
-
-  it('returns null when webvh config has no server_url', async () => {
-    getSpy.mockResolvedValueOnce({ data: { results: [] } }).mockResolvedValueOnce({ data: {} })
-
-    const did = await th.getOrCreateWebvhDid()
-
-    expect(did).toBeNull()
-    expect(vi.mocked(logger.warn)).toHaveBeenCalledWith(
-      'WebVH config missing server_url; skipping WebVH DID setup',
-    )
-  })
-
-  it('creates a webvh did when config is available', async () => {
+  it('creates a webvh did when enabled and config is available', async () => {
+    process.env.WEBVH_ENABLED = 'true'
     getSpy
       .mockResolvedValueOnce({ data: { results: [] } })
       .mockResolvedValueOnce({ data: { server_url: 'https://webvh.example.com' } })
@@ -340,6 +336,15 @@ describe('getOrCreateWebvhDid', () => {
       }),
     })
     expect(did).toBe('did:webvh:example:new')
+  })
+
+  it('throws when enabled and webvh config has no server_url', async () => {
+    process.env.WEBVH_ENABLED = 'true'
+    getSpy.mockResolvedValueOnce({ data: { results: [] } }).mockResolvedValueOnce({ data: {} })
+
+    await expect(th.getOrCreateWebvhDid()).rejects.toThrow(
+      'Webvh server URL not found in Traction webvh config',
+    )
   })
 })
 

--- a/server/src/utils/__tests__/tractionHelper.test.ts
+++ b/server/src/utils/__tests__/tractionHelper.test.ts
@@ -45,7 +45,6 @@ vi.mock('../../../scripts/values/credentials.json', () => ({
 }))
 
 import { CredentialModel } from '../../db/models/Credential'
-import { DidModel } from '../../db/models/Did'
 import { SchemaModel } from '../../db/models/Schema'
 import logger from '../logger'
 import * as th from '../tractionHelper'
@@ -342,9 +341,7 @@ describe('getOrCreateWebvhDid', () => {
     process.env.WEBVH_ENABLED = 'true'
     getSpy.mockResolvedValueOnce({ data: { results: [] } }).mockResolvedValueOnce({ data: {} })
 
-    await expect(th.getOrCreateWebvhDid()).rejects.toThrow(
-      'Webvh server URL not found in Traction webvh config',
-    )
+    await expect(th.getOrCreateWebvhDid()).rejects.toThrow('Webvh server URL not found in Traction webvh config')
   })
 })
 

--- a/server/src/utils/__tests__/tractionHelper.test.ts
+++ b/server/src/utils/__tests__/tractionHelper.test.ts
@@ -267,9 +267,98 @@ describe('tractionGarbageCollection', () => {
   })
 })
 
+describe('getOrCreateWebvhDid', () => {
+  let getSpy: ReturnType<typeof vi.spyOn>
+  let postSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    getSpy = vi.spyOn(th.tractionRequest, 'get')
+    postSpy = vi.spyOn(th.tractionRequest, 'post')
+  })
+
+  afterEach(() => {
+    getSpy.mockRestore()
+    postSpy.mockRestore()
+  })
+
+  it('returns existing posted webvh did when present', async () => {
+    getSpy.mockResolvedValue({
+      data: {
+        results: [{ did: 'did:webvh:example:abc' }],
+      },
+    })
+
+    const did = await th.getOrCreateWebvhDid()
+
+    expect(did).toBe('did:webvh:example:abc')
+    expect(getSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns null when webvh config endpoint is unavailable', async () => {
+    getSpy
+      .mockResolvedValueOnce({ data: { results: [] } })
+      .mockRejectedValueOnce({ response: { status: 404 }, message: 'Not Found' })
+
+    const did = await th.getOrCreateWebvhDid()
+
+    expect(did).toBeNull()
+    expect(vi.mocked(logger.warn)).toHaveBeenCalledWith(
+      'WebVH not available on Traction tenant; skipping WebVH DID setup',
+    )
+  })
+
+  it('returns null when webvh config has no server_url', async () => {
+    getSpy.mockResolvedValueOnce({ data: { results: [] } }).mockResolvedValueOnce({ data: {} })
+
+    const did = await th.getOrCreateWebvhDid()
+
+    expect(did).toBeNull()
+    expect(vi.mocked(logger.warn)).toHaveBeenCalledWith(
+      'WebVH config missing server_url; skipping WebVH DID setup',
+    )
+  })
+
+  it('creates a webvh did when config is available', async () => {
+    getSpy
+      .mockResolvedValueOnce({ data: { results: [] } })
+      .mockResolvedValueOnce({ data: { server_url: 'https://webvh.example.com' } })
+
+    postSpy.mockResolvedValue({
+      data: {
+        state: {
+          id: 'did:webvh:example:new',
+        },
+      },
+    })
+
+    const did = await th.getOrCreateWebvhDid()
+
+    expect(postSpy).toHaveBeenCalledWith('/did/webvh/create', {
+      options: expect.objectContaining({
+        server_url: 'https://webvh.example.com',
+        namespace: 'showcase',
+      }),
+    })
+    expect(did).toBe('did:webvh:example:new')
+  })
+})
+
 describe('getOrCreateIndyDid', () => {
+  let getSpy: ReturnType<typeof vi.spyOn>
+  let postSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    getSpy = vi.spyOn(th.tractionRequest, 'get')
+    postSpy = vi.spyOn(th.tractionRequest, 'post')
+  })
+
+  afterEach(() => {
+    getSpy.mockRestore()
+    postSpy.mockRestore()
+  })
+
   it('returns existing posted indy did when present', async () => {
-    th.tractionRequest.get = vi.fn().mockResolvedValue({
+    getSpy.mockResolvedValue({
       data: {
         results: [{ did: 'did:sov:123' }],
       },
@@ -281,13 +370,13 @@ describe('getOrCreateIndyDid', () => {
   })
 
   it('creates a new indy did when none exist', async () => {
-    th.tractionRequest.get = vi.fn().mockResolvedValue({
+    getSpy.mockResolvedValue({
       data: {
         results: [],
       },
     })
 
-    th.tractionRequest.post = vi.fn().mockResolvedValue({
+    postSpy.mockResolvedValue({
       data: {
         result: {
           did: 'did:sov:new',
@@ -297,7 +386,7 @@ describe('getOrCreateIndyDid', () => {
 
     const did = await th.getOrCreateIndyDid()
 
-    expect(th.tractionRequest.post).toHaveBeenCalledWith('/wallet/did/create', {
+    expect(postSpy).toHaveBeenCalledWith('/wallet/did/create', {
       method: 'sov',
     })
 
@@ -306,8 +395,18 @@ describe('getOrCreateIndyDid', () => {
 })
 
 describe('findSchemaInTraction', () => {
+  let getSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    getSpy = vi.spyOn(th.tractionRequest, 'get')
+  })
+
+  afterEach(() => {
+    getSpy.mockRestore()
+  })
+
   it('returns schema id when found', async () => {
-    th.tractionRequest.get = vi.fn().mockResolvedValue({
+    getSpy.mockResolvedValue({
       data: {
         schema_ids: ['schema-id-1'],
       },
@@ -319,7 +418,7 @@ describe('findSchemaInTraction', () => {
   })
 
   it('returns null when no schemas found', async () => {
-    th.tractionRequest.get = vi.fn().mockResolvedValue({
+    getSpy.mockResolvedValue({
       data: {
         schema_ids: [],
       },
@@ -440,50 +539,33 @@ describe('checkSeededSchemasExistOrCreate', () => {
   beforeEach(() => {
     process.env.TRACTION_URL = 'https://traction.example.com'
     vi.clearAllMocks()
+    vi.spyOn(th, 'getOrCreateIndyDid').mockResolvedValue('did:sov:123')
+    vi.spyOn(th, 'getOrCreateWebvhDid').mockResolvedValue('did:webvh:123')
+    vi.spyOn(th, 'ensureDidInDatabase').mockResolvedValue(undefined)
+    vi.spyOn(th, 'processSeededCredential').mockResolvedValue(undefined)
+    vi.spyOn(th, 'populateMissingSchemaDids').mockResolvedValue(undefined)
   })
 
   afterEach(() => {
+    vi.restoreAllMocks()
     delete process.env.TRACTION_URL
   })
 
   it('logs when checking starts', async () => {
-    // Mock all axios calls to succeed
-    vi.mocked(axios.get).mockResolvedValue({
-      data: {
-        results: [{ did: 'did:sov:123' }],
-      },
-    })
-    vi.mocked(axios.post).mockResolvedValue({
-      data: {
-        schema_state: {
-          schema_id: 'schema-1',
-          schema: { name: 'test', version: '1.0' },
-        },
-        credential_definition_state: {
-          credential_definition_id: 'cred-def-1',
-        },
-      },
-    })
-    vi.mocked(SchemaModel.findOne).mockResolvedValue(null)
-    vi.mocked(SchemaModel.updateOne).mockResolvedValue({} as any)
-    vi.mocked(CredentialModel.updateOne).mockResolvedValue({} as any)
-    vi.mocked(DidModel.updateOne).mockResolvedValue({} as any)
-    vi.mocked(SchemaModel.find).mockResolvedValue([])
-
     await th.checkSeededSchemasExistOrCreate()
 
     expect(vi.mocked(logger.info)).toHaveBeenCalledWith('Checking seeded schemas')
   })
 
   it('does not rethrow errors, allowing server to continue', async () => {
-    vi.mocked(axios.get).mockRejectedValue(new Error('Fatal error'))
+    vi.mocked(th.getOrCreateIndyDid).mockRejectedValue(new Error('Fatal error'))
 
     await expect(th.checkSeededSchemasExistOrCreate()).resolves.toBeUndefined()
     expect(vi.mocked(logger.error)).toHaveBeenCalled()
   })
 
   it('logs error when an error occurs during DID retrieval', async () => {
-    vi.mocked(axios.get).mockRejectedValue(new Error('API unavailable'))
+    vi.mocked(th.getOrCreateIndyDid).mockRejectedValue(new Error('API unavailable'))
 
     await th.checkSeededSchemasExistOrCreate()
 

--- a/server/src/utils/tractionHelper.ts
+++ b/server/src/utils/tractionHelper.ts
@@ -219,7 +219,21 @@ export async function getOrCreateIndyDid(): Promise<string> {
   ).data.result.did
 }
 
+/** Opt-in via WEBVH_ENABLED (default false). */
+export function isWebvhEnabled(): boolean {
+  const raw = process.env.WEBVH_ENABLED?.trim().toLowerCase()
+  if (!raw) {
+    return false
+  }
+  return ['true', '1', 'yes', 'on'].includes(raw)
+}
+
 export async function getOrCreateWebvhDid(): Promise<string | null> {
+  if (!isWebvhEnabled()) {
+    logger.debug('WEBVH_ENABLED is not set; skipping WebVH DID setup')
+    return null
+  }
+
   const results = (
     await tractionRequest.get('/wallet/did', {
       params: {
@@ -233,21 +247,10 @@ export async function getOrCreateWebvhDid(): Promise<string | null> {
     return results[0].did
   }
 
-  let configResponse
-  try {
-    configResponse = await tractionRequest.get('/did/webvh/config')
-  } catch (err) {
-    const status = (err as AxiosError).response?.status
-    if (status === 404) {
-      logger.warn('WebVH not available on Traction tenant; skipping WebVH DID setup')
-      return null
-    }
-    throw err
-  }
+  const configResponse = await tractionRequest.get('/did/webvh/config')
 
   if (!configResponse.data?.server_url) {
-    logger.warn('WebVH config missing server_url; skipping WebVH DID setup')
-    return null
+    throw new Error('Webvh server URL not found in Traction webvh config')
   }
 
   return (

--- a/server/src/utils/tractionHelper.ts
+++ b/server/src/utils/tractionHelper.ts
@@ -219,7 +219,7 @@ export async function getOrCreateIndyDid(): Promise<string> {
   ).data.result.did
 }
 
-export async function getOrCreateWebvhDid(): Promise<string> {
+export async function getOrCreateWebvhDid(): Promise<string | null> {
   const results = (
     await tractionRequest.get('/wallet/did', {
       params: {
@@ -232,10 +232,22 @@ export async function getOrCreateWebvhDid(): Promise<string> {
   if (results?.length) {
     return results[0].did
   }
-  const configResponse = await tractionRequest.get('/did/webvh/config')
+
+  let configResponse
+  try {
+    configResponse = await tractionRequest.get('/did/webvh/config')
+  } catch (err) {
+    const status = (err as AxiosError).response?.status
+    if (status === 404) {
+      logger.warn('WebVH not available on Traction tenant; skipping WebVH DID setup')
+      return null
+    }
+    throw err
+  }
 
   if (!configResponse.data?.server_url) {
-    throw new Error('Webvh server URL not found in Traction webvh config')
+    logger.warn('WebVH config missing server_url; skipping WebVH DID setup')
+    return null
   }
 
   return (
@@ -438,7 +450,9 @@ export const checkSeededSchemasExistOrCreate = async (failOnError: boolean = fal
     const webvhDid = await getOrCreateWebvhDid()
 
     await ensureDidInDatabase(indyDid, 'indy')
-    await ensureDidInDatabase(webvhDid, 'webvh')
+    if (webvhDid) {
+      await ensureDidInDatabase(webvhDid, 'webvh')
+    }
 
     for (const credential of credentialsSeed as (Omit<Credential, 'id'> & { _id: string })[]) {
       try {


### PR DESCRIPTION
## Summary
- Add optional `WEBVH_ENABLED` env var (default **false**) so seed and startup skip WebVH DID setup on Indy-only Traction tenants
- Wire `showcase.server.webvh.enabled` in the Helm chart to set `WEBVH_ENABLED` on seed and server containers
- Seed and `checkSeededSchemasExistOrCreate` only persist a WebVH DID when one is obtained

Fixes deploy failure in `a99fd4-test` where seed init crashed calling `/did/webvh/config` (404) on the test Traction tenant proxy.

## Test plan
- [x] `npm test -- --run src/utils/__tests__/tractionHelper.test.ts migrations/__tests__/seed.test.ts`
- [ ] Merge and confirm `ghcr.io/bcgov/bc-wallet-showcase-server:main` rebuilds
- [ ] Redeploy showcase in `a99fd4-test` with chart **0.4.0** (no chart bump required)
- [ ] Verify `showcase-server` seed init completes and server pod becomes Ready
- [ ] Optionally set `showcase.server.webvh.enabled: true` (or `WEBVH_ENABLED=true`) on a tenant with WebVH configured


Made with [Cursor](https://cursor.com)