### PR TITLE
Update the webvh config endpoint in seed script

### DIFF
--- a/server/src/utils/tractionHelper.ts
+++ b/server/src/utils/tractionHelper.ts
@@ -232,7 +232,7 @@ export async function getOrCreateWebvhDid(): Promise<string> {
   if (results?.length) {
     return results[0].did
   }
-  const configResponse = await tractionRequest.get('/did/webvh/config')
+  const configResponse = await tractionRequest.get('/did/webvh/configuration')
 
   if (!configResponse.data?.server_url) {
     throw new Error('Webvh server URL not found in Traction webvh config')


### PR DESCRIPTION
This endpoint has changed that is used to get the webvh server location. I'm not really sure when this changed. This was working for the dev deployment. 