### PR TITLE
Hide create schema modal for non permissioned roles

### DIFF
--- a/frontend/src/admin/pages/SchemasPage.tsx
+++ b/frontend/src/admin/pages/SchemasPage.tsx
@@ -10,11 +10,13 @@ import { AdminNavbar } from '../components/AdminNavbar'
 import { CreateSchemaModal } from '../components/schema/CreateSchemaModal'
 import { SchemaCard } from '../components/schema/SchemaCard'
 import { useCreatorTabs } from '../hooks/useCreatorTabs'
+import { useHasRole } from '../hooks/useUserRole'
 
 export function SchemasPage() {
   const auth = useAuth()
   const location = useLocation()
   const navigate = useNavigate()
+  const canCreateSchemas = useHasRole('creator') || useHasRole('admin')
   const [schemas, setSchemas] = useState<Schema[]>([])
   const [isLoading, setIsLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
@@ -56,13 +58,15 @@ export function SchemasPage() {
                   <h5 className="text-gray-500 mt-2">Select or Create a schema for the showcase</h5>
                 )}
               </div>
-              <button
-                onClick={() => setIsCreateModalOpen(true)}
-                className="flex items-center gap-2 px-4 py-2 bg-bcgov-blue text-white hover:bg-blue-700 rounded-lg font-medium transition-colors"
-              >
-                <PlusIcon className="w-5 h-5" />
-                Create Schema
-              </button>
+              {canCreateSchemas && (
+                <button
+                  onClick={() => setIsCreateModalOpen(true)}
+                  className="flex items-center gap-2 px-4 py-2 bg-bcgov-blue text-white hover:bg-blue-700 rounded-lg font-medium transition-colors"
+                >
+                  <PlusIcon className="w-5 h-5" />
+                  Create Schema
+                </button>
+              )}
             </div>
 
             {isLoading ? (

--- a/server/src/routes/adminSchemasRouter.ts
+++ b/server/src/routes/adminSchemasRouter.ts
@@ -29,17 +29,22 @@ const transformSchemaResponse = async (schema: any) => {
  * GET /admin/schemas
  * Get all anoncreds schemas from MongoDB.
  */
-router.get('/schemas', defaultRateLimiter, requireRole(['admin', 'creator']), async (_req: Request, res: Response) => {
-  logger.debug('Admin: fetching anoncreds schemas from MongoDB')
-  try {
-    const schemas = await SchemaModel.find().lean()
-    const response = await Promise.all(schemas.map(async (schema) => transformSchemaResponse(schema)))
-    res.json(response)
-  } catch (error) {
-    logger.error(error, 'Error fetching schemas from MongoDB')
-    res.status(500).json({ error: 'Failed to fetch schemas from MongoDB' })
-  }
-})
+router.get(
+  '/schemas',
+  defaultRateLimiter,
+  requireRole(['admin', 'creator', 'viewer']),
+  async (_req: Request, res: Response) => {
+    logger.debug('Admin: fetching anoncreds schemas from MongoDB')
+    try {
+      const schemas = await SchemaModel.find().lean()
+      const response = await Promise.all(schemas.map(async (schema) => transformSchemaResponse(schema)))
+      res.json(response)
+    } catch (error) {
+      logger.error(error, 'Error fetching schemas from MongoDB')
+      res.status(500).json({ error: 'Failed to fetch schemas from MongoDB' })
+    }
+  },
+)
 
 /**
  * GET /admin/schemas/:id
@@ -48,7 +53,7 @@ router.get('/schemas', defaultRateLimiter, requireRole(['admin', 'creator']), as
 router.get(
   '/schemas/:id',
   defaultRateLimiter,
-  requireRole(['admin', 'creator']),
+  requireRole(['admin', 'creator', 'viewer']),
   async (req: Request, res: Response) => {
     logger.debug({ id: req.params.id }, 'Admin: fetching schema by ID from MongoDB')
     try {


### PR DESCRIPTION
 - Hide the create schema modal for users who don't have admin or creator roles.
 - Allow viewer role to get the schemas, but not create.