### PR TITLE
chore(release): bump versions to 0.2.1

### DIFF
--- a/.github/workflows/build_packages.yml
+++ b/.github/workflows/build_packages.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Start App
         run: |
           yarn install --frozen-lockfile --network-timeout 600000
-          NODE_ENV=test AGENT_WALLET_KEY=ba8e2462-f9ac-4da0-a9c6-99592a7dbc12 VITE_HOST_BACKEND=http://localhost:5000 AGENT_PUBLIC_DID_SEED=testtesttesttesttesttesttesttest yarn dev &
+          NODE_ENV=test VITE_HOST_BACKEND=http://localhost:5000 yarn dev &
 
       - name: Wait for dev servers (HTTP)
         run: >

--- a/charts/showcase/Chart.yaml
+++ b/charts/showcase/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: showcase
 description: Helm chart for the BC Wallet Demo showcase (frontend + server API + MongoDB by default)
 type: application
-version: 0.4.0
+version: 0.5.0
 appVersion: '1.0.0'
 dependencies:
   - name: mongodb

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bc-wallet-demo",
-  "version": "0.1.0",
+  "version": "0.2.1",
   "private": true,
   "license": "Apache-2.0",
   "description": "BC Wallet - Verifiable Credential Demo",


### PR DESCRIPTION
Update application version in package.json from 0.1.0 to 0.2.1. Update Helm chart version in charts/showcase/Chart.yaml from 0.4.0 to 0.5.0.

Application and chart versions are independent tracks following semver. This bump is ready for release v0.2.1 publication.