### PR TITLE
fix(ci): skip Cypress E2E on release image publish

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -72,9 +72,9 @@ This folder defines automation for the BC Wallet Demo monorepo (`frontend` and `
 
 ### Job graph
 
-1. **`cypress-run`** (conditional) — On every **release** publish, or when manual dispatch sets `run_cypress: true`. Checks out the repo, uses `setup-node` (Node 22), runs `yarn install --frozen-lockfile`, starts `yarn dev` in the background, waits with `wait-on` for `http://localhost:3000` and `http://localhost:5000`, short warm-up sleep, then runs **Cypress** (`cypress-io/github-action@v6`, `install: false`, optional Dashboard recording via `CYPRESS_RECORD_KEY`).
+1. **`cypress-run`** (conditional) — Only when manual **`workflow_dispatch`** sets `run_cypress: true`. Checks out the repo, uses `setup-node` (Node 22), runs `yarn install --frozen-lockfile`, starts `yarn dev` in the background, waits with `wait-on` for `http://localhost:3000` and `http://localhost:5000`, short warm-up sleep, then runs **Cypress** (`cypress-io/github-action@v6`, `install: false`, optional Dashboard recording via `CYPRESS_RECORD_KEY`).
 
-2. **`cypress-skipped`** — Runs when Cypress is not required (manual dispatch with `run_cypress: false`). Satisfies `needs` for the image jobs without doing work.
+2. **`cypress-skipped`** — On **release** publish (E2E skipped) or manual dispatch with `run_cypress: false`. Satisfies `needs` for the image jobs without doing work.
 
 3. **`build-and-push-image-server`** and **`build-and-push-image-frontend`** — Both `need` the Cypress jobs and only proceed if nothing failed and at least one of the Cypress paths succeeded (see `if:` in the workflow). They **do not** run `yarn install` on the runner: the only install/build for the published images happens **inside Docker**, avoiding duplicate work.
 

--- a/.github/workflows/build_packages.yml
+++ b/.github/workflows/build_packages.yml
@@ -25,7 +25,7 @@ jobs:
     name: Cypress E2E (optional)
     runs-on: ubuntu-latest
     timeout-minutes: 180
-    if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.run_cypress)
+    if: github.event_name == 'workflow_dispatch' && inputs.run_cypress
     permissions:
       contents: read
     steps:
@@ -68,7 +68,7 @@ jobs:
   cypress-skipped:
     name: Cypress skipped
     runs-on: ubuntu-latest
-    if: github.event_name == 'workflow_dispatch' && !inputs.run_cypress
+    if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && !inputs.run_cypress)
     permissions:
       contents: read
     steps:


### PR DESCRIPTION
## Summary
- Stop running the optional Cypress job when a GitHub Release triggers **Build and Publish Packages**
- Route release publishes through the existing `cypress-skipped` no-op job so server/frontend image builds start immediately
- Keep Cypress available via manual `workflow_dispatch` with `run_cypress: true`; PR CI still covers E2E on `main`/`release`

## Test plan
- [ ] Merge and publish a release (or re-run the release workflow) and confirm `cypress-skipped` runs while `cypress-run` is skipped
- [ ] Confirm `build-and-push-image-server` and `build-and-push-image-frontend` succeed without waiting on Cypress
- [ ] Optionally run **Build and Publish Packages** manually with `run_cypress: true` to verify the E2E path still works


Made with [Cursor](https://cursor.com)