### PR TITLE
Fix the styling for the character select button

### DIFF
--- a/frontend/src/client/pages/introduction/steps/PickCharacter.tsx
+++ b/frontend/src/client/pages/introduction/steps/PickCharacter.tsx
@@ -50,7 +50,7 @@ export const PickCharacter: React.FC<Props> = ({ currentShowcase, showcases, tit
       >
         <motion.img
           whileHover={{ scale: 1.05 }}
-          className={`m-auto h-36 w-36 sm:h-36 sm:w-36 md:h-36 md:w-36 md:p-4 lg:h-36 lg:w-36 p-8 rounded-full bg-bcgov-white dark:bg-bcgov-black my-6 shadow ${
+          className={`m-auto h-36 w-36 sm:h-36 sm:w-36 md:h-36 md:w-36 md:p-4 lg:h-36 lg:w-36 p-8 rounded-full bg-bcgov-white dark:bg-bcgov-black my-6 shadow object-contain ${
             currentShowcase?.persona?.type === showcase.persona?.type ? cardStyleSelected : cardStyleUnselected
           }`}
           src={prependApiUrl(showcase.persona?.image || '')}

--- a/server/src/utils/validateFileType.ts
+++ b/server/src/utils/validateFileType.ts
@@ -1,7 +1,7 @@
 /**
  * Allowed MIME types for image uploads
  */
-const ALLOWED_MIME_TYPES = new Set(['image/svg+xml', 'image/png', 'image/jpeg', 'image/webp'])
+const ALLOWED_MIME_TYPES = new Set(['image/svg+xml', 'image/png', 'image/jpeg', 'image/webp', 'application/xml'])
 
 /**
  * Validate file by magic bytes (actual file content) rather than just extension


### PR DESCRIPTION
The character select image styling needs object-contain. Otherwise perfectly fine images would get the same height and width and cause images to get squished.

Also, svgs were getting blocked even though they are scanned and validated. This is because the `file-type` library gets a `application/xml` mime type even when the image is actually being sent as `image/svg+xml`.