### PR TITLE
fix: Aspect ratios for custom images in public facing app

### DIFF
--- a/frontend/src/client/pages/dashboard/components/ProfileCard.tsx
+++ b/frontend/src/client/pages/dashboard/components/ProfileCard.tsx
@@ -45,7 +45,7 @@ export const ProfileCard: React.FC<Props> = ({ currentShowcase }) => {
       <motion.div initial="hidden" animate="show" exit="exit" variants={fade}>
         <motion.img
           whileHover={{ scale: 1.05 }}
-          className="m-auto h-32 w-32 md:h-36 md:w-36 p-4 rounded-full bg-bcgov-white dark:bg-bcgov-black ring-2 ring-white mb-4 shadow"
+          className="m-auto h-32 w-32 md:h-36 md:w-36 p-4 rounded-full bg-bcgov-white dark:bg-bcgov-black ring-2 ring-white mb-4 shadow object-contain"
           src={prependApiUrl(currentShowcase.persona?.image || '')}
           alt={currentShowcase.persona?.name}
         />

--- a/frontend/src/client/pages/introduction/components/CharacterContent.tsx
+++ b/frontend/src/client/pages/introduction/components/CharacterContent.tsx
@@ -23,11 +23,11 @@ export const CharacterContent: React.FC<Props> = ({ showcase }) => {
             exit="exit"
             className="flex flex-col h-full justify-around"
           >
-            <div className="p-2 bg-bcgov-blue dark:bg-bcgov-gold text-white rounded-l-lg flex px-4 self-end">
+            <div className="p-2 bg-bcgov-blue dark:bg-bcgov-gold text-white rounded-l-lg flex px-4 self-end object-contain">
               <p>{showcase.persona?.type}</p>
             </div>
             <img
-              className="h-72"
+              className="h-72 max-w-full object-contain"
               src={prependApiUrl(
                 showcase.introduction?.find((s) => s.screenId === 'PICK_CHARACTER')?.image ||
                   showcase.persona?.image ||

--- a/frontend/src/client/pages/preview/ScenarioPreviewPage.tsx
+++ b/frontend/src/client/pages/preview/ScenarioPreviewPage.tsx
@@ -23,10 +23,8 @@ export const ScenarioPreviewPage: React.FC = () => {
   })
 
   useEffect(() => {
-    if (showcases.length === 0) {
-      dispatch(fetchAllShowcases())
-    }
-  }, [dispatch, showcases.length])
+    dispatch(fetchAllShowcases())
+  }, [dispatch])
 
   const previewShowcase = showcases.find((showcase) => !previewShowcaseName || showcase.name === previewShowcaseName)
 

--- a/frontend/src/client/pages/scenario/components/ProofAttributesCard.tsx
+++ b/frontend/src/client/pages/scenario/components/ProofAttributesCard.tsx
@@ -59,7 +59,7 @@ export const ProofAttributesCard: React.FC<Props> = ({ entityName, requestedCred
                 </div>
                 {isDataUrl(value) ? (
                   <div className="text-sm bg-white dark:bg-grey p-1 px-2 rounded-lg m-2 truncate">
-                    <img src={value} style={{ height: 100 }} />
+                    <img src={value} style={{ height: 100, width: 100 }} className="object-contain" />
                   </div>
                 ) : (
                   <p className="flex-1 text-sm bg-white dark:bg-grey p-1 px-2 rounded-lg m-2 truncate">

--- a/frontend/src/client/pages/scenario/components/StartContainer.tsx
+++ b/frontend/src/client/pages/scenario/components/StartContainer.tsx
@@ -83,7 +83,9 @@ export const StartContainer: React.FC<Props> = ({ entity, requestedCredentials, 
         </div>
       </div>
       <div className="bg-bcgov-white dark:bg-bcgov-black hidden lg:flex lg:w-1/3 rounded-r-lg flex content-center p-4 select-none">
-        {step.image && <img className="p-8" src={prependApiUrl(step.image)} alt={step.name} />}
+        {step.image && (
+          <img className="max-h-full max-w-full object-contain" src={prependApiUrl(step.image)} alt={step.name} />
+        )}
       </div>
     </motion.div>
   )

--- a/frontend/src/client/pages/scenario/steps/StepEnd.tsx
+++ b/frontend/src/client/pages/scenario/steps/StepEnd.tsx
@@ -15,7 +15,9 @@ export const StepEnd: React.FC<Props> = ({ step }) => {
   return (
     <motion.div variants={fadeX} initial="hidden" animate="show" exit="exit" className="flex flex-col h-full">
       <StepInfo title={step.name} description={step.text} />
-      {step.image && <img className="h-full w-1/2 m-auto" src={prependApiUrl(step.image)} alt={step.name} />}
+      {step.image && (
+        <img className="h-full w-1/2 m-auto object-contain" src={prependApiUrl(step.image)} alt={step.name} />
+      )}
     </motion.div>
   )
 }


### PR DESCRIPTION
 - I think this should be a lot better for the custom image rendering. Adds object-contain to image elements. This will make images attempt to fill the space vertically and horizontally but adjust the width or height so the aspect rations don't change. This prevents images from getting stretched or squished. 
 - Also changed the scenario preview page useEffect dependency. I had the showcase.length before but it is not actually needed, and it prevents the showcases from getting updated correct when there was a change.
 - Tries to test this as well as I could with dev showcase images that didn't look right and used copilot to try and locate any other problem areas.