### PR TITLE
Allow relative path images on screen cards

### DIFF
--- a/frontend/src/admin/components/ScreenContentCard.tsx
+++ b/frontend/src/admin/components/ScreenContentCard.tsx
@@ -58,12 +58,9 @@ function buildSafeImageUrl(image?: string): string | null {
     .map((segment) => encodeURIComponent(segment))
     .join('/')
 
-  try {
-    const baseUrl = publicBaseUrl.endsWith('/') ? publicBaseUrl : `${publicBaseUrl}/`
-    return new URL(encodedPath.startsWith('/') ? encodedPath.slice(1) : encodedPath, baseUrl).toString()
-  } catch {
-    return null
-  }
+  // Build URL with simple concatenation (works with both absolute URLs and relative paths)
+  const baseUrl = publicBaseUrl.endsWith('/') ? publicBaseUrl : `${publicBaseUrl}/`
+  return `${baseUrl}${encodedPath.startsWith('/') ? encodedPath.slice(1) : encodedPath}`
 }
 
 export function ScreenContentCard({


### PR DESCRIPTION
I noticed the images had disappeared from the screen cards. I don't really understand what happened because they were definitely showing after we deployed but then disappeared. Maybe they were being cached so looked like everything was still working.

What I think happened is we used to have the full URL for the baseUrl injected at runtime but we removed it. This safe function expected a url so it started returning null here when we changed that build argument. Easiest way to fix this is allow relative lookup here which is done for all the other images.