### PR TITLE
Use unique key for Stepper Items

### DIFF
--- a/frontend/src/client/pages/introduction/components/Stepper.tsx
+++ b/frontend/src/client/pages/introduction/components/Stepper.tsx
@@ -14,7 +14,14 @@ export interface Props {
 
 export const Stepper: React.FC<Props> = ({ currentShowcase, introductionStep }) => {
   const renderSteps = currentShowcase?.progressBar?.map((item) => {
-    return <StepperItem key={item.name} item={item} currentStep={introductionStep} currentShowcase={currentShowcase} />
+    return (
+      <StepperItem
+        key={item.introductionStep}
+        item={item}
+        currentStep={introductionStep}
+        currentShowcase={currentShowcase}
+      />
+    )
   })
 
   return (


### PR DESCRIPTION
This was an existing problem where the progress icon name was being used for the stepper item. When another progress bar icon had the same name react would get confused and cause this issue. React warns that all list components like this should have unique names. Simply using the introduction step it is linked with, which is unique per showcase fixed the issue.