### PR TITLE
Disable back button when setup completed

### DIFF
--- a/frontend/src/client/pages/introduction/IntroductionContainer.tsx
+++ b/frontend/src/client/pages/introduction/IntroductionContainer.tsx
@@ -66,7 +66,8 @@ export const IntroductionContainer: React.FC<Props> = ({
   const isBackDisabled =
     introductionStep === 'PICK_CHARACTER' ||
     introductionStep.startsWith('CONNECT') ||
-    introductionStep.startsWith('ACCEPT')
+    introductionStep.startsWith('ACCEPT') ||
+    introductionStep === 'SETUP_COMPLETED'
   const isForwardDisabled =
     (introductionStep.startsWith('CONNECT') && !connectionCompleted) ||
     (introductionStep.startsWith('ACCEPT_') && !credentialsAccepted) ||


### PR DESCRIPTION
This solves https://github.com/bcgov/BC-Wallet-Demo/issues/570 by hiding the back button when issuance setup was completed. Using the back button here would attempt to issuance a credential that had already been issued. It makes more sense to just hide the back option and force the user to continue on this step.

<img width="2056" height="1826" alt="image" src="https://github.com/user-attachments/assets/968686d6-6ffb-45e1-a890-08b5b98b81de" />
