### PR TITLE
Make credential names and scenario icons editable

### DIFF
--- a/frontend/src/admin/components/showcase/introduction/IntroductionScreenRow.tsx
+++ b/frontend/src/admin/components/showcase/introduction/IntroductionScreenRow.tsx
@@ -205,6 +205,9 @@ export function IntroductionScreenRow({
             <div className="p-6">
               {(() => {
                 const credential = nextScreen.credentials[editingCredentialIdx]
+                if (selectedSchema) {
+                  selectedSchema.name = credential.name
+                }
                 return (
                   <DefineCredentialValuesStep
                     selectedSchema={selectedSchema || null}
@@ -217,7 +220,7 @@ export function IntroductionScreenRow({
                       setEditingCredentialIdx(null)
                       setSelectedSchema(null)
                     }}
-                    onSelectCredential={async (values, icon) => {
+                    onSelectCredential={async (values, icon, name) => {
                       if (nextScreen?.credentials) {
                         const updatedCredential = {
                           ...nextScreen.credentials[editingCredentialIdx],
@@ -226,6 +229,7 @@ export function IntroductionScreenRow({
                             value: values[attr.name] || attr.value,
                           })),
                           icon,
+                          name,
                         }
                         nextScreen.credentials[editingCredentialIdx] = updatedCredential
                         try {
@@ -233,6 +237,7 @@ export function IntroductionScreenRow({
                             await updateCredential(auth, updatedCredential.id, {
                               attributes: updatedCredential.attributes,
                               icon: updatedCredential.icon,
+                              name: updatedCredential.name,
                             })
                           }
                           await onRefresh?.()

--- a/frontend/src/admin/components/showcase/introduction/IntroductionScreenRow.tsx
+++ b/frontend/src/admin/components/showcase/introduction/IntroductionScreenRow.tsx
@@ -205,12 +205,10 @@ export function IntroductionScreenRow({
             <div className="p-6">
               {(() => {
                 const credential = nextScreen.credentials[editingCredentialIdx]
-                if (selectedSchema) {
-                  selectedSchema.name = credential.name
-                }
+                const schemaForEditor = selectedSchema ? { ...selectedSchema, name: credential.name } : null
                 return (
                   <DefineCredentialValuesStep
-                    selectedSchema={selectedSchema || null}
+                    selectedSchema={schemaForEditor}
                     initialValues={credential.attributes?.reduce((acc: Record<string, string>, attr: any) => {
                       acc[attr.name] = attr.value || ''
                       return acc

--- a/frontend/src/admin/components/showcase/modals/CreateConnectionAndProofScreensModal.tsx
+++ b/frontend/src/admin/components/showcase/modals/CreateConnectionAndProofScreensModal.tsx
@@ -279,6 +279,7 @@ export function CreateConnectionAndProofScreensModal({
                   const newRequests = new Map<string, CredentialRequest>()
                   for (const credentialId of selectedCredentials) {
                     const attrs = selectedAttributes.get(credentialId)
+                    const credential = showcase?.credentials?.find((c) => c.id === credentialId)
                     const properties = attrs ? Array.from(attrs.keys()).filter((name) => attrs.get(name)?.property) : []
 
                     // Transform predicate configurations into Predicate objects
@@ -319,6 +320,7 @@ export function CreateConnectionAndProofScreensModal({
                     newRequests.set(credentialId, {
                       name: '',
                       schema_id: '',
+                      icon: credential?.icon,
                       properties,
                       predicates: predicates.length > 0 ? predicates : [],
                       nonRevoked: hasNonRevoked ? { to: '$now' } : undefined,
@@ -367,6 +369,18 @@ export function CreateConnectionAndProofScreensModal({
                 onUploadIcon={() => {
                   setImageUploadModalCredentialId(Array.from(selectedCredentials)[currentCredentialIdx])
                   setIsImageUploadModalOpen(true)
+                }}
+                onSetIcon={(iconPath: string) => {
+                  const credentialId = Array.from(selectedCredentials)[currentCredentialIdx]
+                  const newRequests = new Map(credentialRequests)
+                  const currentRequest = newRequests.get(credentialId)
+                  if (currentRequest) {
+                    newRequests.set(credentialId, {
+                      ...currentRequest,
+                      icon: iconPath,
+                    })
+                    setCredentialRequests(newRequests)
+                  }
                 }}
                 onPrevious={() => setCurrentCredentialIdx(currentCredentialIdx - 1)}
                 onNext={() => setCurrentCredentialIdx(currentCredentialIdx + 1)}

--- a/frontend/src/admin/components/showcase/modals/steps/DefineCredentialValuesStep.tsx
+++ b/frontend/src/admin/components/showcase/modals/steps/DefineCredentialValuesStep.tsx
@@ -10,7 +10,7 @@ import { ImageUploadModal } from '../ImageUploadModal'
 interface DefineCredentialValuesStepProps {
   selectedSchema: Schema | null
   onBack: () => void
-  onSelectCredential: (values: Record<string, string>, icon: string) => void
+  onSelectCredential: (values: Record<string, string>, icon: string, name: string) => void
   error?: string | null
   initialValues?: Record<string, string>
   initialIcon?: string
@@ -38,6 +38,8 @@ export function DefineCredentialValuesStep({
   const [icon, setIcon] = useState<string>(initialIcon ?? '')
   const [dateOptions, setDateOptions] = useState<Record<string, 'custom' | 'issuance'>>({})
   const [yearOffsets, setYearOffsets] = useState<Record<string, number>>({})
+  const [isEditingName, setIsEditingName] = useState(false)
+  const [editedName, setEditedName] = useState(selectedSchema?.name ?? '')
   const [isImageUploadModalOpen, setIsImageUploadModalOpen] = useState(false)
   const [credentialImageModalOpen, setCredentialImageModalOpen] = useState(false)
   const [currentImageAttribute, setCurrentImageAttribute] = useState<string | null>(null)
@@ -55,6 +57,13 @@ export function DefineCredentialValuesStep({
       setValues(newValues)
     }
   }, [selectedSchema, initialValues])
+
+  // Update edited name when schema changes
+  useEffect(() => {
+    if (selectedSchema) {
+      setEditedName(selectedSchema.name)
+    }
+  }, [selectedSchema])
 
   // Initialize date options based on initial values
   useEffect(() => {
@@ -169,15 +178,43 @@ export function DefineCredentialValuesStep({
           }
         }
       })
-      onSelectCredential(finalValues, icon)
+      onSelectCredential(finalValues, icon, editedName)
     }
   }
 
   return (
     <div className="space-y-6">
       <div className="bg-gray-50 rounded-lg p-6">
-        <h3 className="text-2xl font-semibold text-bcgov-black mb-1">{selectedSchema.name}</h3>
-        <p className="text-gray-600">v{selectedSchema.version}</p>
+        <div className="flex items-center gap-3">
+          {isEditingName ? (
+            <input
+              type="text"
+              value={editedName}
+              onChange={(e) => setEditedName(e.target.value)}
+              onBlur={() => setIsEditingName(false)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') setIsEditingName(false)
+                if (e.key === 'Escape') {
+                  setEditedName(selectedSchema.name)
+                  setIsEditingName(false)
+                }
+              }}
+              autoFocus
+              className="text-2xl font-semibold text-bcgov-black border-2 border-bcgov-blue rounded-lg px-3 py-1 focus:outline-none"
+            />
+          ) : (
+            <>
+              <h3 className="text-2xl font-semibold text-bcgov-black">{editedName}</h3>
+              <button
+                onClick={() => setIsEditingName(true)}
+                className="text-sm font-medium text-bcgov-blue hover:text-bcgov-blue-dark transition-colors"
+              >
+                Edit
+              </button>
+            </>
+          )}
+        </div>
+        <p className="text-gray-600 mt-2">v{selectedSchema.version}</p>
 
         <div className="mt-6">
           <div className="flex items-start gap-6">
@@ -196,12 +233,14 @@ export function DefineCredentialValuesStep({
                 className="mt-3 px-3 py-1.5 text-sm font-medium text-white bg-bcgov-blue hover:bg-bcgov-blue-dark rounded-lg transition-colors flex items-center gap-1"
               >
                 <ArrowUpTrayIcon className="w-4 h-4" />
-                Upload Icon
+                Change Icon
               </button>
             </div>
             <div className="flex-1">
               <p className="text-sm text-gray-600 mb-1">Credential Icon</p>
-              <p className="text-xs text-gray-500">Upload an SVG or image file to display as the credential icon</p>
+              <p className="text-xs text-gray-500">
+                Upload or select a SVG or image file to display as the credential icon
+              </p>
             </div>
           </div>
         </div>

--- a/frontend/src/admin/components/showcase/modals/steps/DefineCredentialValuesStep.tsx
+++ b/frontend/src/admin/components/showcase/modals/steps/DefineCredentialValuesStep.tsx
@@ -191,9 +191,15 @@ export function DefineCredentialValuesStep({
               type="text"
               value={editedName}
               onChange={(e) => setEditedName(e.target.value)}
-              onBlur={() => setIsEditingName(false)}
+              onBlur={() => {
+                if (!editedName.trim()) setEditedName(selectedSchema.name)
+                setIsEditingName(false)
+              }}
               onKeyDown={(e) => {
-                if (e.key === 'Enter') setIsEditingName(false)
+                if (e.key === 'Enter') {
+                  if (!editedName.trim()) setEditedName(selectedSchema.name)
+                  setIsEditingName(false)
+                }
                 if (e.key === 'Escape') {
                   setEditedName(selectedSchema.name)
                   setIsEditingName(false)

--- a/frontend/src/admin/components/showcase/modals/steps/DefiningProofRequestStep.tsx
+++ b/frontend/src/admin/components/showcase/modals/steps/DefiningProofRequestStep.tsx
@@ -10,6 +10,7 @@ interface DefiningProofRequestStepProps {
   currentIndex: number
   totalCredentials: number
   onUploadIcon: () => void
+  onSetIcon: (icon: string) => void
   onPrevious: () => void
   onNext: () => void
   onFinish: () => void
@@ -21,13 +22,12 @@ export function DefiningProofRequestStep({
   currentIndex,
   totalCredentials,
   onUploadIcon,
+  onSetIcon,
   onPrevious,
   onNext,
   onFinish,
 }: DefiningProofRequestStepProps) {
   if (!currentCredential || !currentRequest) return null
-
-  const isIconSelected = !!currentRequest.icon
 
   return (
     <div className="space-y-6">
@@ -51,6 +51,10 @@ export function DefiningProofRequestStep({
       <div className="space-y-4">
         <div>
           <label className="block text-sm font-medium text-bcgov-black mb-2">Icon</label>
+          <p className="text-sm text-gray-600 mb-3">
+            This icon is shown to the user during the presentation request. It represents the credential. You can change
+            it to another image during the presentation step if you wish.
+          </p>
           <div className="relative group w-fit">
             {currentRequest.icon ? (
               <div className="w-24 h-24 border border-gray-300 rounded-lg overflow-hidden bg-gray-100">
@@ -62,6 +66,17 @@ export function DefiningProofRequestStep({
                 <PencilIcon
                   onClick={onUploadIcon}
                   className="absolute -top-2 -right-2 w-5 h-5 bg-bcgov-blue text-white p-1 rounded-full opacity-0 group-hover:opacity-100 transition-opacity cursor-pointer"
+                />
+              </div>
+            ) : currentCredential.icon ? (
+              <div
+                className="w-24 h-24 border-2 border-dashed border-gray-300 rounded-lg overflow-hidden bg-gray-50 flex items-center justify-center opacity-60 hover:opacity-100 transition-opacity cursor-pointer"
+                onClick={() => onSetIcon(currentCredential.icon)}
+              >
+                <img
+                  src={`${publicBaseUrl}${currentCredential.icon}`}
+                  alt="Credential icon preview"
+                  className="w-full h-full object-contain p-2"
                 />
               </div>
             ) : (
@@ -162,30 +177,13 @@ export function DefiningProofRequestStep({
           {currentIndex === totalCredentials - 1 && (
             <button
               onClick={onFinish}
-              disabled={!isIconSelected}
-              className={`px-4 py-2 rounded-lg font-medium transition-colors ${
-                isIconSelected
-                  ? 'text-white bg-bcgov-blue hover:bg-bcgov-blue-dark cursor-pointer'
-                  : 'text-white bg-gray-400 cursor-not-allowed'
-              }`}
+              className={`px-4 py-2 rounded-lg font-medium transition-colors text-white bg-bcgov-blue hover:bg-bcgov-blue-dark cursor-pointer`}
             >
               Finish
             </button>
           )}
         </div>
       </div>
-
-      {!isIconSelected && (
-        <div className="bg-red-50 border border-red-200 rounded-lg p-4">
-          <p className="text-sm font-semibold text-red-800 mb-2">Please complete the following:</p>
-          <ul className="text-sm text-red-700 space-y-1">
-            <li className="flex items-center gap-2">
-              <span className="w-1 h-1 bg-red-700 rounded-full" />
-              Presentation request icon is required
-            </li>
-          </ul>
-        </div>
-      )}
     </div>
   )
 }

--- a/frontend/src/admin/components/showcase/modals/steps/EnteringNameStep.tsx
+++ b/frontend/src/admin/components/showcase/modals/steps/EnteringNameStep.tsx
@@ -70,7 +70,11 @@ export function EnteringNameStep({
               </button>
             )}
           </div>
-          {!icon && <p className="text-red-600 text-sm mt-2">Icon is required</p>}
+          {!icon && (
+            <p className="text-red-600 text-sm mt-2">
+              Icon is required. This is the image that will represent the verifier when connecting and verifying.
+            </p>
+          )}
         </div>
       )}
       <div className="flex justify-end gap-3 pt-4 border-t border-gray-200">

--- a/frontend/src/admin/components/showcase/scenarios/ScenarioScreenRow.tsx
+++ b/frontend/src/admin/components/showcase/scenarios/ScenarioScreenRow.tsx
@@ -136,21 +136,24 @@ export function ScenarioScreenRow({
 
   const handleVerifierIconSelect = async (imagePath: string) => {
     try {
-      const updatedScenarios = showcase.scenarios.map((scenario) => ({
-        ...scenario,
-        screens: scenario.screens.map((s) => {
-          if (s.screenId === screen.screenId && s.verifier) {
-            return {
-              ...s,
-              verifier: {
-                ...s.verifier,
-                icon: imagePath,
-              },
+      const updatedScenarios = showcase.scenarios.map((scenario) => {
+        if (scenario.id !== scenarioId) return scenario
+        return {
+          ...scenario,
+          screens: scenario.screens.map((s) => {
+            if (s.screenId === screen.screenId && s.verifier) {
+              return {
+                ...s,
+                verifier: {
+                  ...s.verifier,
+                  icon: imagePath,
+                },
+              }
             }
-          }
-          return s
-        }),
-      }))
+            return s
+          }),
+        }
+      })
 
       await updateShowcase(auth, showcase.name, {
         scenarios: updatedScenarios,
@@ -231,17 +234,26 @@ export function ScenarioScreenRow({
           screen.screenId === 'CONNECTION' && screen.verifier?.name ? (
             <div className="mb-3 px-2">
               <div className="flex items-center gap-3">
-                {screen.verifier.icon && (
+                {screen.verifier.icon && canEdit && (
+                  <button
+                    onClick={() => setIsVerifierIconEditOpen(true)}
+                    className="flex items-center justify-center hover:opacity-75 transition-opacity p-0 border-none bg-transparent cursor-pointer"
+                    title="Click to edit icon. This icon is used as an image for the verifier when connecting and verifying."
+                    aria-label={`Change icon for ${screen.verifier.name}`}
+                  >
+                    <img
+                      src={`${publicBaseUrl}${screen.verifier.icon}`}
+                      alt={screen.verifier.name}
+                      className="w-8 h-8 object-contain"
+                    />
+                  </button>
+                )}
+                {screen.verifier.icon && !canEdit && (
                   <img
                     src={`${publicBaseUrl}${screen.verifier.icon}`}
                     alt={screen.verifier.name}
-                    className="w-8 h-8 object-contain cursor-pointer hover:opacity-75 transition-opacity"
-                    onClick={() => canEdit && setIsVerifierIconEditOpen(true)}
-                    title={
-                      canEdit
-                        ? 'Click to edit icon. This icon is used as an image for the verifier when connecting and verifying.'
-                        : 'Verifier icon'
-                    }
+                    className="w-8 h-8 object-contain"
+                    title="Verifier icon"
                   />
                 )}
                 {!screen.verifier.icon && canEdit && (
@@ -273,19 +285,29 @@ export function ScenarioScreenRow({
                         <div key={credIdx} className="bg-white rounded p-3 flex items-start justify-between gap-3">
                           <div className="flex-1">
                             <div className="flex items-center gap-2 mb-2">
-                              {cred.icon && (
+                              {cred.icon && canEdit && (
+                                <button
+                                  onClick={() => {
+                                    setEditingCredentialIconIdx(credIdx)
+                                    setIsCredentialIconEditOpen(true)
+                                  }}
+                                  className="flex items-center justify-center hover:opacity-75 transition-opacity p-0 border-none bg-transparent cursor-pointer"
+                                  title="Click to change icon. This icon represents the credential during the presentation steps. It defaults to the same icon as during issuance."
+                                  aria-label={`Change icon for ${getCredentialDisplayName(cred)}`}
+                                >
+                                  <img
+                                    src={`${publicBaseUrl}${cred.icon}`}
+                                    alt={cred.name}
+                                    className="w-8 h-8 object-contain"
+                                  />
+                                </button>
+                              )}
+                              {cred.icon && !canEdit && (
                                 <img
                                   src={`${publicBaseUrl}${cred.icon}`}
                                   alt={cred.name}
-                                  className="w-8 h-8 object-contain cursor-pointer hover:opacity-75 transition-opacity"
-                                  onClick={() =>
-                                    canEdit && (setEditingCredentialIconIdx(credIdx), setIsCredentialIconEditOpen(true))
-                                  }
-                                  title={
-                                    canEdit
-                                      ? 'Click to change icon. This icon represents the credential during the presentation steps. It defaults to the same icon as during issuance.'
-                                      : 'Credential icon'
-                                  }
+                                  className="w-8 h-8 object-contain"
+                                  title="Credential icon"
                                 />
                               )}
                               <span className="text-sm font-medium text-bcgov-black">

--- a/frontend/src/admin/components/showcase/scenarios/ScenarioScreenRow.tsx
+++ b/frontend/src/admin/components/showcase/scenarios/ScenarioScreenRow.tsx
@@ -9,6 +9,7 @@ import { useHasRole } from '../../../hooks/useUserRole'
 import { formatCustomDateStampValue } from '../../../utils/formatters'
 import logger from '../../../utils/logger'
 import { ScreenRowBase } from '../ScreenRowBase'
+import { ImageUploadModal } from '../modals/ImageUploadModal'
 import { SelectingAttributesStep } from '../modals/steps/SelectingAttributesStep'
 
 interface ScenarioScreenRowProps {
@@ -61,6 +62,9 @@ export function ScenarioScreenRow({
   const [editingCredIdx, setEditingCredIdx] = useState<number | null>(null)
   const [selectedAttributes, setSelectedAttributes] = useState<Map<string, any>>(new Map())
   const [editingCredential, setEditingCredential] = useState<Credential | null>(null)
+  const [isVerifierIconEditOpen, setIsVerifierIconEditOpen] = useState(false)
+  const [isCredentialIconEditOpen, setIsCredentialIconEditOpen] = useState(false)
+  const [editingCredentialIconIdx, setEditingCredentialIconIdx] = useState<number | null>(null)
 
   useEffect(() => {
     const fetchCredential = async () => {
@@ -120,6 +124,101 @@ export function ScenarioScreenRow({
     fetchCredential()
   }, [editingCredIdx, showcase, nextScreen])
 
+  const getCredentialDisplayName = (cred: CredentialRequest): string => {
+    const showcaseCredential = showcase.credentials.find(
+      (c) =>
+        (cred.cred_id && c.id === cred.cred_id) ||
+        (cred.schema_id && c.schema_id === cred.schema_id) ||
+        (cred.cred_def_id && c.cred_def_id === cred.cred_def_id),
+    )
+    return showcaseCredential ? showcaseCredential.name : cred.name
+  }
+
+  const handleVerifierIconSelect = async (imagePath: string) => {
+    try {
+      const updatedScenarios = showcase.scenarios.map((scenario) => ({
+        ...scenario,
+        screens: scenario.screens.map((s) => {
+          if (s.screenId === screen.screenId && s.verifier) {
+            return {
+              ...s,
+              verifier: {
+                ...s.verifier,
+                icon: imagePath,
+              },
+            }
+          }
+          return s
+        }),
+      }))
+
+      await updateShowcase(auth, showcase.name, {
+        scenarios: updatedScenarios,
+      })
+
+      logger.info('Verifier icon updated successfully')
+
+      if (onRefreshShowcase) {
+        await onRefreshShowcase()
+      }
+
+      setIsVerifierIconEditOpen(false)
+    } catch (error) {
+      logger.error('Error updating verifier icon:', error)
+    }
+  }
+
+  const handleCredentialIconSelect = async (imagePath: string) => {
+    try {
+      if (editingCredentialIconIdx === null) return
+
+      const updatedScenarios = showcase.scenarios.map((scenario) => {
+        if (scenario.id === scenarioId) {
+          return {
+            ...scenario,
+            screens: scenario.screens.map((scenarioScreen) => {
+              if (scenarioScreen.screenId === nextScreen?.screenId && scenarioScreen.requestOptions) {
+                const updatedCredentials = scenarioScreen.requestOptions.requestedCredentials.map((cred, credIdx) => {
+                  if (credIdx === editingCredentialIconIdx) {
+                    return {
+                      ...cred,
+                      icon: imagePath,
+                    }
+                  }
+                  return cred
+                })
+                return {
+                  ...scenarioScreen,
+                  requestOptions: {
+                    ...scenarioScreen.requestOptions,
+                    requestedCredentials: updatedCredentials,
+                  },
+                }
+              }
+              return scenarioScreen
+            }),
+          }
+        }
+        return scenario
+      })
+
+      await updateShowcase(auth, showcase.name, {
+        scenarios: updatedScenarios,
+      })
+
+      logger.info('Credential icon updated successfully')
+
+      if (onRefreshShowcase) {
+        await onRefreshShowcase()
+      }
+
+      setIsCredentialIconEditOpen(false)
+      setEditingCredentialIconIdx(null)
+    } catch (error) {
+      logger.error('Error updating credential icon:', error)
+    }
+  }
+
   return (
     <>
       <ScreenRowBase<ScenarioScreen>
@@ -131,7 +230,31 @@ export function ScenarioScreenRow({
         headerContent={
           screen.screenId === 'CONNECTION' && screen.verifier?.name ? (
             <div className="mb-3 px-2">
-              <p className="text-sm font-semibold text-bcgov-black">{screen.verifier.name}</p>
+              <div className="flex items-center gap-3">
+                {screen.verifier.icon && (
+                  <img
+                    src={`${publicBaseUrl}${screen.verifier.icon}`}
+                    alt={screen.verifier.name}
+                    className="w-8 h-8 object-contain cursor-pointer hover:opacity-75 transition-opacity"
+                    onClick={() => canEdit && setIsVerifierIconEditOpen(true)}
+                    title={
+                      canEdit
+                        ? 'Click to edit icon. This icon is used as an image for the verifier when connecting and verifying.'
+                        : 'Verifier icon'
+                    }
+                  />
+                )}
+                {!screen.verifier.icon && canEdit && (
+                  <button
+                    onClick={() => setIsVerifierIconEditOpen(true)}
+                    className="w-8 h-8 border-2 border-dashed border-gray-300 rounded flex items-center justify-center text-gray-400 hover:border-bcgov-blue hover:text-bcgov-blue transition-colors"
+                    title="Add icon"
+                  >
+                    +
+                  </button>
+                )}
+                <p className="text-sm font-semibold text-bcgov-black">{screen.verifier.name}</p>
+              </div>
             </div>
           ) : null
         }
@@ -154,10 +277,20 @@ export function ScenarioScreenRow({
                                 <img
                                   src={`${publicBaseUrl}${cred.icon}`}
                                   alt={cred.name}
-                                  className="w-8 h-8 object-contain"
+                                  className="w-8 h-8 object-contain cursor-pointer hover:opacity-75 transition-opacity"
+                                  onClick={() =>
+                                    canEdit && (setEditingCredentialIconIdx(credIdx), setIsCredentialIconEditOpen(true))
+                                  }
+                                  title={
+                                    canEdit
+                                      ? 'Click to change icon. This icon represents the credential during the presentation steps. It defaults to the same icon as during issuance.'
+                                      : 'Credential icon'
+                                  }
                                 />
                               )}
-                              <span className="text-sm font-medium text-bcgov-black">{cred.name}</span>
+                              <span className="text-sm font-medium text-bcgov-black">
+                                {getCredentialDisplayName(cred)}
+                              </span>
                             </div>
                             {cred.schema_id && (
                               <p className="text-xs text-gray-500 mb-2 font-mono break-all">{cred.schema_id}</p>
@@ -201,7 +334,7 @@ export function ScenarioScreenRow({
                               onClick={() => setEditingCredIdx(credIdx)}
                               className="flex-shrink-0 p-2 text-gray-600 hover:text-bcgov-blue hover:bg-blue-50 rounded transition-colors"
                               title="Edit proof request"
-                              aria-label={`Edit proof request for ${cred.name}`}
+                              aria-label={`Edit proof request for ${getCredentialDisplayName(cred)}`}
                             >
                               <Cog6ToothIcon className="w-5 h-5" />
                             </button>
@@ -346,6 +479,23 @@ export function ScenarioScreenRow({
             </div>
           </div>
         )}
+
+      <ImageUploadModal
+        isOpen={isVerifierIconEditOpen}
+        onClose={() => setIsVerifierIconEditOpen(false)}
+        onSelectImage={handleVerifierIconSelect}
+        type="icon"
+      />
+
+      <ImageUploadModal
+        isOpen={isCredentialIconEditOpen}
+        onClose={() => {
+          setIsCredentialIconEditOpen(false)
+          setEditingCredentialIconIdx(null)
+        }}
+        onSelectImage={handleCredentialIconSelect}
+        type="icon"
+      />
     </>
   )
 }

--- a/frontend/src/client/pages/dashboard/components/ScenarioContainer.tsx
+++ b/frontend/src/client/pages/dashboard/components/ScenarioContainer.tsx
@@ -27,8 +27,15 @@ export const ScenarioContainer: React.FC<Props> = ({ currentShowcase, completedS
     // item.screens.forEach(screen => requiredCredentials.push(...(screen.requestOptions?.requestedCredentials.map(item => item.name) ?? [])))
     item.screens.forEach((screen) =>
       screen.requestOptions?.requestedCredentials.forEach((cred) => {
+        const actualCredential = currentShowcase.credentials.find(
+          (c) =>
+            c.id === cred.cred_id ||
+            c.schema_id === cred.schema_id ||
+            c.cred_def_id === cred.cred_def_id ||
+            c.name === cred.name,
+        )
         if (!requiredCredentials.includes(cred.name)) {
-          requiredCredentials.push(cred.name)
+          requiredCredentials.push(actualCredential?.name ?? cred.name)
         }
       }),
     )

--- a/frontend/src/client/pages/dashboard/components/ScenarioItem.tsx
+++ b/frontend/src/client/pages/dashboard/components/ScenarioItem.tsx
@@ -26,7 +26,11 @@ const getCredIcon = (currShowcase: Showcase, credName: string) => {
     scenario.screens.forEach((screen) => {
       if (screen) {
         screen.requestOptions?.requestedCredentials.forEach((cred) => {
-          if (cred.name === credName) {
+          // Try to match by cred_id first, then fall back to name
+          if (
+            (cred.cred_id && currShowcase.credentials.some((c) => c.id === cred.cred_id && c.name === credName)) ||
+            cred.name === credName
+          ) {
             icon = cred.icon ?? ''
           }
         })

--- a/frontend/src/client/pages/preview/ScenarioPreviewPage.tsx
+++ b/frontend/src/client/pages/preview/ScenarioPreviewPage.tsx
@@ -40,8 +40,16 @@ export const ScenarioPreviewPage: React.FC = () => {
     const requiredCredentials: string[] = []
     item.screens.forEach((screen) =>
       screen.requestOptions?.requestedCredentials.forEach((cred) => {
-        if (!requiredCredentials.includes(cred.name)) {
-          requiredCredentials.push(cred.name)
+        const actualCredential = previewShowcase.credentials.find(
+          (c) =>
+            c.id === cred.cred_id ||
+            c.schema_id === cred.schema_id ||
+            c.cred_def_id === cred.cred_def_id ||
+            c.name === cred.name,
+        )
+        const credentialName = actualCredential?.name ?? cred.name
+        if (!requiredCredentials.includes(credentialName)) {
+          requiredCredentials.push(credentialName)
         }
       }),
     )

--- a/frontend/src/client/pages/scenario/Section.tsx
+++ b/frontend/src/client/pages/scenario/Section.tsx
@@ -79,9 +79,9 @@ export const Section: React.FC<Props> = ({
   const verifier = section.find((x) => x.verifier !== undefined)?.verifier ?? { name: 'Unkown' }
   const currentShowcase = useCurrentShowcase()
 
-  const overrideCredentialNames = (requestedCredentials: any[] | undefined): any[] => {
+  const overrideCredentialNames = (requestedCredentials: any[] | undefined): any[] | undefined => {
     if (!requestedCredentials || !currentShowcase?.credentials) {
-      return requestedCredentials ?? []
+      return requestedCredentials
     }
     return requestedCredentials.map((cred) => {
       const showcaseCredential = currentShowcase.credentials.find(

--- a/frontend/src/client/pages/scenario/Section.tsx
+++ b/frontend/src/client/pages/scenario/Section.tsx
@@ -79,6 +79,21 @@ export const Section: React.FC<Props> = ({
   const verifier = section.find((x) => x.verifier !== undefined)?.verifier ?? { name: 'Unkown' }
   const currentShowcase = useCurrentShowcase()
 
+  const overrideCredentialNames = (requestedCredentials: any[] | undefined): any[] => {
+    if (!requestedCredentials || !currentShowcase?.credentials) {
+      return requestedCredentials ?? []
+    }
+    return requestedCredentials.map((cred) => {
+      const showcaseCredential = currentShowcase.credentials.find(
+        (c) =>
+          (cred.cred_id && c.id === cred.cred_id) ||
+          (cred.schema_id && c.schema_id === cred.schema_id) ||
+          (cred.cred_def_id && c.cred_def_id === cred.cred_def_id),
+      )
+      return showcaseCredential ? { ...cred, name: showcaseCredential.name } : cred
+    })
+  }
+
   const leave = () => {
     trackSelfDescribingEvent({
       event: {
@@ -180,7 +195,7 @@ export const Section: React.FC<Props> = ({
           characterType={currentShowcase?.persona?.type?.toLowerCase()}
           step={step}
           entity={verifier}
-          requestedCredentials={step.requestOptions?.requestedCredentials}
+          requestedCredentials={overrideCredentialNames(step.requestOptions?.requestedCredentials)}
         />
       )
     }
@@ -196,6 +211,7 @@ export const Section: React.FC<Props> = ({
               currentStep={step.screenId}
               entity={verifier}
               showLeaveModal={showLeaveModal}
+              currentShowcase={currentShowcase}
             />
             <motion.div
               key={'mainContentDiv'}
@@ -232,6 +248,7 @@ export const Section: React.FC<Props> = ({
                       step={step}
                       connectionId={connection.id}
                       requestedCredentials={step.requestOptions.requestedCredentials}
+                      currentShowcase={currentShowcase}
                     />
                   )}
                 {step.screenId.startsWith('STEP_END') && <StepEnd key={step.screenId} step={step} />}

--- a/frontend/src/client/pages/scenario/SideView.tsx
+++ b/frontend/src/client/pages/scenario/SideView.tsx
@@ -1,4 +1,4 @@
-import type { ScenarioScreen } from '../../slices/types'
+import type { ScenarioScreen, Showcase } from '../../slices/types'
 
 import { motion } from 'framer-motion'
 import React from 'react'
@@ -16,11 +16,24 @@ export interface Props {
   currentStep: string
   entity: { name: string; icon?: string }
   showLeaveModal(): void
+  currentShowcase?: Showcase
 }
 
-export const SideView: React.FC<Props> = ({ steps, currentStep, entity, showLeaveModal }) => {
+export const SideView: React.FC<Props> = ({ steps, currentStep, entity, showLeaveModal, currentShowcase }) => {
   const requestedCredentials = steps.find((step) => step.requestOptions?.requestedCredentials)?.requestOptions
     ?.requestedCredentials
+
+  const overriddenCredentials = requestedCredentials
+    ? requestedCredentials.map((cred) => {
+        const showcaseCredential = currentShowcase?.credentials.find(
+          (c) =>
+            (cred.cred_id && c.id === cred.cred_id) ||
+            (cred.schema_id && c.schema_id === cred.schema_id) ||
+            (cred.cred_def_id && c.cred_def_id === cred.cred_def_id),
+        )
+        return showcaseCredential ? { ...cred, name: showcaseCredential.name } : cred
+      })
+    : undefined
 
   return (
     <motion.div
@@ -52,7 +65,7 @@ export const SideView: React.FC<Props> = ({ steps, currentStep, entity, showLeav
       className="flex flex-col lg:mx-6 dark:text-white w-auto lg:w-1/3"
     >
       <ConnectionCard icon={entity.icon} entity={entity.name} />
-      {requestedCredentials && <ProofCard requestedItems={requestedCredentials} />}
+      {overriddenCredentials && <ProofCard requestedItems={overriddenCredentials} />}
       <StepperCard steps={steps} currentStep={currentStep} />
       <motion.button
         onClick={showLeaveModal}

--- a/frontend/src/client/pages/scenario/steps/StepProof.tsx
+++ b/frontend/src/client/pages/scenario/steps/StepProof.tsx
@@ -4,6 +4,7 @@ import type {
   ProofPredicateRequest,
   ProofRestriction,
   ScenarioScreen,
+  Showcase,
 } from '../../../slices/types'
 
 import { trackSelfDescribingEvent } from '@snowplow/browser-tracker'
@@ -28,6 +29,7 @@ export interface Props {
   connectionId: string
   requestedCredentials: CredentialRequest[]
   entityName: string
+  currentShowcase?: Showcase
 }
 
 /**
@@ -75,12 +77,24 @@ export const StepProof: React.FC<Props> = ({
   requestedCredentials,
   entityName,
   characterType,
+  currentShowcase,
 }) => {
   const dispatch = useAppDispatch()
   const proofRequestCreatedRef = useRef(false)
   const proofDone = (proof?.state as string) === 'verified' || proof?.state === 'done'
   const proofReceived = proofDone && proof?.verified !== 'false'
   const proofFailed = proofDone && proof?.verified === 'false'
+
+  // Override credential names for display purposes while keeping originals for proof request
+  const displayCredentials = requestedCredentials.map((cred) => {
+    const showcaseCredential = currentShowcase?.credentials.find(
+      (c) =>
+        (cred.cred_id && c.id === cred.cred_id) ||
+        (cred.schema_id && c.schema_id === cred.schema_id) ||
+        (cred.cred_def_id && c.cred_def_id === cred.cred_def_id),
+    )
+    return showcaseCredential ? { ...cred, name: showcaseCredential.name } : cred
+  })
 
   const [isFailedRequestModalOpen, setIsFailedRequestModalOpen] = useState(false)
   const showFailedRequestModal = () => setIsFailedRequestModalOpen(true)
@@ -195,7 +209,7 @@ export const StepProof: React.FC<Props> = ({
           {proof && (
             <ProofAttributesCard
               entityName={entityName}
-              requestedCredentials={requestedCredentials}
+              requestedCredentials={displayCredentials}
               proof={proof}
               proofReceived={proofReceived}
             />

--- a/frontend/src/client/pages/scenario/steps/StepProof.tsx
+++ b/frontend/src/client/pages/scenario/steps/StepProof.tsx
@@ -109,9 +109,7 @@ export const StepProof: React.FC<Props> = ({
     const predicates: Record<string, ProofPredicateRequest> = {}
 
     requestedCredentials?.forEach((item) => {
-      const restriction: ProofRestriction = {
-        schema_name: item.name,
-      }
+      const restriction: ProofRestriction = {}
       if (item.schema_id) {
         restriction.schema_id = item.schema_id
       }

--- a/frontend/src/client/slices/types.ts
+++ b/frontend/src/client/slices/types.ts
@@ -78,6 +78,7 @@ export interface CredentialRequest {
   predicates?: Predicate[]
   properties?: string[]
   nonRevoked?: { to: number | '$now'; from?: number | '$now' }
+  cred_id?: string
 }
 
 export interface CustomRequestOptions {

--- a/server/migrations/values/lawyerShowcase.json
+++ b/server/migrations/values/lawyerShowcase.json
@@ -147,6 +147,7 @@
               {
                 "icon": "/public/common/screen/bc-logo.png",
                 "name": "Person",
+                "cred_id": "lawyer-person",
                 "properties": ["given_names", "family_name"]
               }
             ]

--- a/server/src/controllers/admin/AdminCredentialController.ts
+++ b/server/src/controllers/admin/AdminCredentialController.ts
@@ -8,7 +8,7 @@ import logger from '../../utils/logger'
 
 // Fields that are locked once a credential is registered on the ledger.
 // Only showcase-specific fields (icon, attributes values, status) remain editable.
-const LEDGER_LOCKED_FIELDS = ['name', 'version', 'schema_id', 'cred_def_id'] as const
+const LEDGER_LOCKED_FIELDS = ['version', 'schema_id', 'cred_def_id'] as const
 
 @JsonController('/admin/credentials')
 @Service()


### PR DESCRIPTION
 - Allows credential name to be changed in all user facing views except in the wallet. Where the OCA bundle will have the new name.
 - Removes schema name restriction because it will fail if name changes. Instead just continue using the schema_id and cred_def_id restrictions.
 - Allows the scenario icons to be changed by clicking on them. Use the issuance credential icon as the default for the presentation credential icon. Also add more description messaging around what the icon is for.