### PR TITLE
Update chart image version, renaming, CI tweaks

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -84,8 +84,8 @@ Images are pushed to **GitHub Container Registry** (`ghcr.io`):
 
 | Variable in workflow      | Image                                         |
 | ------------------------- | --------------------------------------------- |
-| `SHOWCASE_SERVER_IMAGE`   | `ghcr.io/<owner>/bc-wallet-showcase-server`   |
-| `SHOWCASE_FRONTEND_IMAGE` | `ghcr.io/<owner>/bc-wallet-showcase-frontend` |
+| `SHOWCASE_SERVER_IMAGE`   | `ghcr.io/<owner>/digital-trust-showcase-server`   |
+| `SHOWCASE_FRONTEND_IMAGE` | `ghcr.io/<owner>/digital-trust-showcase-frontend` |
 
 Jobs use `docker/login-action@v3`, `docker/setup-buildx-action@v3`, `docker/metadata-action@v5`, and `docker/build-push-action@v7` with **minimal provenance** and **SBOM** attestations (`provenance: mode=min`, `sbom: true`). Image build jobs set **`permissions: id-token: write`** (with `packages: write`) so attestation upload to GHCR is supported.
 
@@ -103,7 +103,7 @@ To approximate CI locally for the showcase web image:
 docker build -f frontend/Dockerfile \
   --build-arg REACT_APP_INSIGHTS_PROJECT_ID="..." \
   --build-arg REACT_APP_HOST_BACKEND="..." \
-  -t bc-wallet-showcase-frontend:local .
+  -t digital-trust-showcase-frontend:local .
 ```
 
 ---
@@ -132,9 +132,9 @@ Runs **chart-releaser** when **`charts/showcase/Chart.yaml`** **`version`** is n
 **Install:**
 
 ```bash
-helm repo add bc-wallet-showcase https://bcgov.github.io/BC-Wallet-Demo
+helm repo add digital-trust-showcase https://bcgov.github.io/BC-Wallet-Demo
 helm repo update
-helm install my-showcase bc-wallet-showcase/showcase --version <chart-version>
+helm install my-showcase digital-trust-showcase/showcase --version <chart-version>
 ```
 
 ---

--- a/.github/README.md
+++ b/.github/README.md
@@ -82,8 +82,8 @@ This folder defines automation for the BC Digital Trust Showcase monorepo (`fron
 
 Images are pushed to **GitHub Container Registry** (`ghcr.io`):
 
-| Variable in workflow      | Image                                         |
-| ------------------------- | --------------------------------------------- |
+| Variable in workflow      | Image                                             |
+| ------------------------- | ------------------------------------------------- |
 | `SHOWCASE_SERVER_IMAGE`   | `ghcr.io/<owner>/digital-trust-showcase-server`   |
 | `SHOWCASE_FRONTEND_IMAGE` | `ghcr.io/<owner>/digital-trust-showcase-frontend` |
 

--- a/.github/actions/showcase-build-frontend/action.yml
+++ b/.github/actions/showcase-build-frontend/action.yml
@@ -1,8 +1,8 @@
 name: Showcase build frontend image
-description: Build and push bc-wallet-showcase-frontend to GHCR (Vite build-args, provenance + SBOM)
+description: Build and push digital-trust-showcase-frontend to GHCR (Vite build-args, provenance + SBOM)
 inputs:
   image:
-    description: Full image reference without tag (e.g. ghcr.io/bcgov/bc-wallet-showcase-frontend)
+    description: Full image reference without tag (e.g. ghcr.io/bcgov/digital-trust-showcase-frontend)
     required: true
   tag:
     description: Image tag (e.g. main or pr-42)

--- a/.github/actions/showcase-build-server/action.yml
+++ b/.github/actions/showcase-build-server/action.yml
@@ -1,8 +1,8 @@
 name: Showcase build server image
-description: Build and push bc-wallet-showcase-server to GHCR (provenance + SBOM)
+description: Build and push digital-trust-showcase-server to GHCR (provenance + SBOM)
 inputs:
   image:
-    description: Full image reference without tag (e.g. ghcr.io/bcgov/bc-wallet-showcase-server)
+    description: Full image reference without tag (e.g. ghcr.io/bcgov/digital-trust-showcase-server)
     required: true
   tag:
     description: Image tag (e.g. main or pr-42)

--- a/.github/workflows/build_packages.yml
+++ b/.github/workflows/build_packages.yml
@@ -106,6 +106,11 @@ jobs:
         uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
         with:
           images: ${{ env.SHOWCASE_SERVER_IMAGE }}
+          # Release tag `vX.Y.Z` -> images `X.Y.Z`, `X.Y`, and `latest` (latest=auto on semver). Branch runs -> branch name only.
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=ref,event=branch
 
       - name: Build and push Docker image
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
@@ -154,6 +159,11 @@ jobs:
         uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
         with:
           images: ${{ env.SHOWCASE_FRONTEND_IMAGE }}
+          # Release tag `vX.Y.Z` -> images `X.Y.Z`, `X.Y`, and `latest` (latest=auto on semver). Branch runs -> branch name only.
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=ref,event=branch
 
       - name: Build and push Docker image
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0

--- a/.github/workflows/build_packages.yml
+++ b/.github/workflows/build_packages.yml
@@ -17,8 +17,8 @@ permissions:
 env:
   HUSKY: '0'
   REGISTRY: ghcr.io
-  SHOWCASE_FRONTEND_IMAGE: ghcr.io/${{ github.repository_owner }}/bc-wallet-showcase-frontend
-  SHOWCASE_SERVER_IMAGE: ghcr.io/${{ github.repository_owner }}/bc-wallet-showcase-server
+  SHOWCASE_FRONTEND_IMAGE: ghcr.io/${{ github.repository_owner }}/digital-trust-showcase-frontend
+  SHOWCASE_SERVER_IMAGE: ghcr.io/${{ github.repository_owner }}/digital-trust-showcase-server
 
 jobs:
   cypress-run:

--- a/.github/workflows/delete_images.yml
+++ b/.github/workflows/delete_images.yml
@@ -19,7 +19,7 @@ jobs:
         uses: snok/container-retention-policy@d3bdcf5ce9b05f685154e4a16c39233b245e3d53 # v3.1.0
         with:
           account: bcgov
-          image-names: bc-wallet-showcase-frontend, bc-wallet-showcase-server
+          image-names: digital-trust-showcase-frontend, digital-trust-showcase-server
           cut-off: 1month
           tag-selection: untagged
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy-showcase-dev.yaml
+++ b/.github/workflows/deploy-showcase-dev.yaml
@@ -53,8 +53,8 @@ permissions:
 env:
   HUSKY: '0'
   REGISTRY: ghcr.io
-  SHOWCASE_SERVER_IMAGE: ghcr.io/${{ github.repository_owner }}/bc-wallet-showcase-server
-  SHOWCASE_FRONTEND_IMAGE: ghcr.io/${{ github.repository_owner }}/bc-wallet-showcase-frontend
+  SHOWCASE_SERVER_IMAGE: ghcr.io/${{ github.repository_owner }}/digital-trust-showcase-server
+  SHOWCASE_FRONTEND_IMAGE: ghcr.io/${{ github.repository_owner }}/digital-trust-showcase-frontend
 
 jobs:
   build-server:

--- a/.github/workflows/deploy-showcase-dev.yaml
+++ b/.github/workflows/deploy-showcase-dev.yaml
@@ -148,6 +148,8 @@ jobs:
           fi
           helm upgrade --install "${release}" . \
             -f ../../deploy/showcase/values-dev.yaml \
+            --set showcase.server.image.tag=main \
+            --set showcase.frontend.image.tag=main \
             --namespace "${ns}" \
             --wait \
             --timeout 15m \

--- a/.github/workflows/deploy-showcase-pr.yaml
+++ b/.github/workflows/deploy-showcase-pr.yaml
@@ -51,11 +51,11 @@ permissions:
 env:
   HUSKY: '0'
   REGISTRY: ghcr.io
-  SHOWCASE_SERVER_IMAGE: ghcr.io/${{ github.repository_owner }}/bc-wallet-showcase-server
-  SHOWCASE_FRONTEND_IMAGE: ghcr.io/${{ github.repository_owner }}/bc-wallet-showcase-frontend
+  SHOWCASE_SERVER_IMAGE: ghcr.io/${{ github.repository_owner }}/digital-trust-showcase-server
+  SHOWCASE_FRONTEND_IMAGE: ghcr.io/${{ github.repository_owner }}/digital-trust-showcase-frontend
   # PR Route host fragment (no scheme): https://pr-<N>-<SHOWCASE_PR_HOST_SUFFIX>/…
   # Override per-repo with Actions variable SHOWCASE_PR_HOST_SUFFIX if your cluster DNS differs.
-  SHOWCASE_PR_HOST_SUFFIX: ${{ vars.SHOWCASE_PR_HOST_SUFFIX != '' && vars.SHOWCASE_PR_HOST_SUFFIX || 'bc-wallet-showcase-dev.apps.silver.devops.gov.bc.ca' }}
+  SHOWCASE_PR_HOST_SUFFIX: ${{ vars.SHOWCASE_PR_HOST_SUFFIX != '' && vars.SHOWCASE_PR_HOST_SUFFIX || 'digital-trust-showcase-dev.apps.silver.devops.gov.bc.ca' }}
   # Traction tenant proxy for PR webhook registration (matches deploy/showcase/values-pr.yaml).
   TRACTION_URL: 'https://traction-tenant-proxy-dev.apps.silver.devops.gov.bc.ca'
 
@@ -188,9 +188,9 @@ jobs:
             -f ../../deploy/showcase/values-pr.yaml
             --namespace "${ns}"
             --set-string "showcase.publicOrigin=${origin}"
-            --set "showcase.server.image.repository=${owner_lc}/bc-wallet-showcase-server"
+            --set "showcase.server.image.repository=${owner_lc}/digital-trust-showcase-server"
             --set "showcase.server.image.tag=pr-${PR_NUM}"
-            --set "showcase.frontend.image.repository=${owner_lc}/bc-wallet-showcase-frontend"
+            --set "showcase.frontend.image.repository=${owner_lc}/digital-trust-showcase-frontend"
             --set "showcase.frontend.image.tag=pr-${PR_NUM}"
             --wait
             --timeout 10m

--- a/.github/workflows/helm-release-showcase.yaml
+++ b/.github/workflows/helm-release-showcase.yaml
@@ -94,8 +94,8 @@ jobs:
             echo "**Helm repo:** \`https://bcgov.github.io/BC-Wallet-Demo\`"
             echo ""
             echo '```bash'
-            echo "helm repo add bc-wallet-showcase https://bcgov.github.io/BC-Wallet-Demo"
+            echo "helm repo add digital-trust-showcase https://bcgov.github.io/BC-Wallet-Demo"
             echo "helm repo update"
-            echo "helm search repo bc-wallet-showcase"
+            echo "helm search repo digital-trust-showcase"
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/undeploy-showcase-pr.yaml
+++ b/.github/workflows/undeploy-showcase-pr.yaml
@@ -15,7 +15,7 @@ permissions:
   packages: write
 
 env:
-  SHOWCASE_PR_HOST_SUFFIX: ${{ vars.SHOWCASE_PR_HOST_SUFFIX != '' && vars.SHOWCASE_PR_HOST_SUFFIX || 'bc-wallet-showcase-dev.apps.silver.devops.gov.bc.ca' }}
+  SHOWCASE_PR_HOST_SUFFIX: ${{ vars.SHOWCASE_PR_HOST_SUFFIX != '' && vars.SHOWCASE_PR_HOST_SUFFIX || 'digital-trust-showcase-dev.apps.silver.devops.gov.bc.ca' }}
   TRACTION_URL: 'https://traction-tenant-proxy-dev.apps.silver.devops.gov.bc.ca'
 
 jobs:
@@ -117,7 +117,7 @@ jobs:
         with:
           account: ${{ github.repository_owner }}
           token: ${{ secrets.GITHUB_TOKEN }}
-          image-names: bc-wallet-showcase-server bc-wallet-showcase-frontend
+          image-names: digital-trust-showcase-server digital-trust-showcase-frontend
           image-tags: pr-${{ github.event.pull_request.number }}
           cut-off: 1s
           tag-selection: tagged

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -16,8 +16,9 @@ Both versions follow [Semantic Versioning](https://semver.org/) (`MAJOR.MINOR.PA
 When you create a GitHub Release:
 
 - **Docker Images** → Published to GitHub Container Registry (GHCR)
-  - `ghcr.io/bcgov/digital-trust-showcase-server:<version>`
-  - `ghcr.io/bcgov/digital-trust-showcase-frontend:<version>`
+  - `ghcr.io/bcgov/digital-trust-showcase-server`
+  - `ghcr.io/bcgov/digital-trust-showcase-frontend`
+  - Tags for release `vX.Y.Z`: `X.Y.Z`, `X.Y`, and `latest` (the leading `v` is stripped)
   - Multi-platform: linux/amd64, linux/arm64
 
 - **Helm Chart** → Published to GitHub Pages
@@ -58,11 +59,11 @@ Update both version files to the new version:
 apiVersion: v2
 name: showcase
 version: 0.5.0
-appVersion: '1.0.0'
+appVersion: '0.2.0'
 ...
 ```
 
-> **Note:** `Chart.yaml` version and `package.json` version are independent. You may update them at different rates depending on your release strategy.
+> **Note:** `Chart.yaml` `version` (chart) and `package.json` `version` (app) are independent. Set `Chart.yaml` `appVersion` to the released app version (no leading `v`) — it is the default image tag the chart pulls, so it must match a published image tag (e.g. release `v0.2.0` publishes `:0.2.0`).
 
 ### 3. Commit Changes
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -16,8 +16,8 @@ Both versions follow [Semantic Versioning](https://semver.org/) (`MAJOR.MINOR.PA
 When you create a GitHub Release:
 
 - **Docker Images** → Published to GitHub Container Registry (GHCR)
-  - `ghcr.io/bcgov/bc-wallet-showcase-server:<version>`
-  - `ghcr.io/bcgov/bc-wallet-showcase-frontend:<version>`
+  - `ghcr.io/bcgov/digital-trust-showcase-server:<version>`
+  - `ghcr.io/bcgov/digital-trust-showcase-frontend:<version>`
   - Multi-platform: linux/amd64, linux/arm64
 
 - **Helm Chart** → Published to GitHub Pages
@@ -103,16 +103,16 @@ Both workflows should trigger automatically:
 #### a. Verify Docker Images
 
 - Go to [GHCR packages](https://github.com/bcgov/bc-wallet-demo/pkgs/container)
-- Check `bc-wallet-showcase-server` and `bc-wallet-showcase-frontend` have new tags with the version
+- Check `digital-trust-showcase-server` and `digital-trust-showcase-frontend` have new tags with the version
 
 #### b. Verify Helm Chart Published
 
 - Go to [GitHub Pages Helm repo](https://bcgov.github.io/BC-Wallet-Demo)
 - Add the repo and search:
   ```bash
-  helm repo add bc-wallet-showcase https://bcgov.github.io/BC-Wallet-Demo
+  helm repo add digital-trust-showcase https://bcgov.github.io/BC-Wallet-Demo
   helm repo update
-  helm search repo bc-wallet-showcase
+  helm search repo digital-trust-showcase
   ```
 - Confirm the new chart version appears
 

--- a/charts/showcase/Chart.yaml
+++ b/charts/showcase/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: showcase
 description: Helm chart for the BC Digital Trust Showcase (frontend + server API + MongoDB by default)
 type: application
-version: 0.5.3
-appVersion: '0.2.4'
+version: 0.6.0
+appVersion: '0.2.5'
 dependencies:
   - name: mongodb
     version: 0.15.0

--- a/charts/showcase/README.md
+++ b/charts/showcase/README.md
@@ -22,11 +22,11 @@ helm dependency update
 Publishing a **GitHub Release** runs **chart-releaser** and updates the **`gh-pages`** index (see **`.github/workflows/helm-release-showcase.yaml`**). Bump **`charts/showcase/Chart.yaml`** **`version`** before cutting the release. Enable **GitHub Pages** on the repository (**Settings → Pages → Deploy from branch `gh-pages` / root**) before the first release.
 
 ```bash
-helm repo add bc-wallet-showcase https://bcgov.github.io/BC-Wallet-Demo
+helm repo add digital-trust-showcase https://bcgov.github.io/BC-Wallet-Demo
 helm repo update
-helm search repo bc-wallet-showcase
+helm search repo digital-trust-showcase
 
-helm upgrade --install my-showcase bc-wallet-showcase/showcase \
+helm upgrade --install my-showcase digital-trust-showcase/showcase \
   --version <chart-version> \
   -f deploy/showcase/values-dev.yaml \
   --namespace <namespace> \
@@ -59,7 +59,7 @@ helm upgrade --install my-showcase . \
 
 Create the referenced **`Secret`** first (keys as env names; see **`server/.env.example`** in the app repo).
 
-Default images: **`ghcr.io/bcgov/bc-wallet-showcase-server:main`**, **`ghcr.io/bcgov/bc-wallet-showcase-frontend:main`**. Override **`showcase.server.image`** / **`showcase.frontend.image`** if needed.
+Default images: **`ghcr.io/bcgov/digital-trust-showcase-server:main`**, **`ghcr.io/bcgov/digital-trust-showcase-frontend:main`**. Override **`showcase.server.image`** / **`showcase.frontend.image`** if needed.
 
 ## Applying chart changes
 
@@ -140,4 +140,4 @@ Quick **public** checks (replace host with yours): **`curl -i`** to **`…/serve
 
 PRs touching **`charts/showcase/**`** or **`deploy/showcase/**`** run **`helm dependency update`**, **`helm lint`** (default values, **`deploy/showcase/values-dev.yaml`**, and **`deploy/showcase/values-pr.yaml`**), and **`helm template`** (see **`.github/workflows/helm-lint-showcase.yaml`**). Publishing a **GitHub Release** runs **chart-releaser** to **GitHub Pages** (**`.github/workflows/helm-release-showcase.yaml`**). Merges to **`main`** can run **`Deploy showcase (dev)`** when repository variables and a token secret are configured (see **`.github/workflows/deploy-showcase-dev.yaml`**).
 
-**PR environments** (bcgov repo only): **`.github/workflows/deploy-showcase-pr.yaml`** builds and pushes **`ghcr.io/bcgov/bc-wallet-showcase-{server,frontend}:pr-<N>`**, then **`helm upgrade --install pr-<N>-showcase`** with **`deploy/showcase/values-pr.yaml`**. Public URL uses workflow default host suffix **`bc-wallet-showcase-dev.apps.silver.devops.gov.bc.ca`** (override with repository variable **`SHOWCASE_PR_HOST_SUFFIX`** if needed). Requires OpenShift secrets **`OPENSHIFT_SERVER`**, **`OPENSHIFT_TOKEN`**, **`OPENSHIFT_DEV_NAMESPACE`**. **`.github/workflows/undeploy-showcase-pr.yaml`** runs on PR close to **`helm uninstall`** and delete labeled **`Secret`**/**`PVC`**.
+**PR environments** (bcgov repo only): **`.github/workflows/deploy-showcase-pr.yaml`** builds and pushes **`ghcr.io/bcgov/digital-trust-showcase-{server,frontend}:pr-<N>`**, then **`helm upgrade --install pr-<N>-showcase`** with **`deploy/showcase/values-pr.yaml`**. Public URL uses workflow default host suffix **`digital-trust-showcase-dev.apps.silver.devops.gov.bc.ca`** (override with repository variable **`SHOWCASE_PR_HOST_SUFFIX`** if needed). Requires OpenShift secrets **`OPENSHIFT_SERVER`**, **`OPENSHIFT_TOKEN`**, **`OPENSHIFT_DEV_NAMESPACE`**. **`.github/workflows/undeploy-showcase-pr.yaml`** runs on PR close to **`helm uninstall`** and delete labeled **`Secret`**/**`PVC`**.

--- a/charts/showcase/templates/_helpers.tpl
+++ b/charts/showcase/templates/_helpers.tpl
@@ -66,7 +66,7 @@ Container image reference (registry + repository + tag or digest).
 {{- $global := .global -}}
 {{- $reg := coalesce $img.registry $global.imageRegistry "" -}}
 {{- $repo := $img.repository -}}
-{{- $tag := default "latest" $img.tag -}}
+{{- $tag := default (default "latest" .defaultTag) $img.tag -}}
 {{- $dig := $img.digest -}}
 {{- if $dig -}}
 {{- if $reg -}}
@@ -110,14 +110,14 @@ Frontend (Caddy + static SPA) resource name prefix.
 Server container image.
 */}}
 {{- define "showcase.server.image" -}}
-{{ include "showcase.image" (dict "image" .Values.showcase.server.image "global" .Values.global) }}
+{{ include "showcase.image" (dict "image" .Values.showcase.server.image "global" .Values.global "defaultTag" .Chart.AppVersion) }}
 {{- end }}
 
 {{/*
 Frontend container image.
 */}}
 {{- define "showcase.frontend.image" -}}
-{{ include "showcase.image" (dict "image" .Values.showcase.frontend.image "global" .Values.global) }}
+{{ include "showcase.image" (dict "image" .Values.showcase.frontend.image "global" .Values.global "defaultTag" .Chart.AppVersion) }}
 {{- end }}
 
 {{/*

--- a/charts/showcase/values.yaml
+++ b/charts/showcase/values.yaml
@@ -86,9 +86,9 @@ showcase:
     ## HTTP listen port for the server container and Service.
     containerPort: 5000
     image:
-      ## ghcr.io/bcgov/bc-wallet-showcase-server:main (see https://github.com/orgs/bcgov/packages?repo_name=BC-Wallet-Demo)
+      ## ghcr.io/bcgov/digital-trust-showcase-server:main (see https://github.com/orgs/bcgov/packages?repo_name=BC-Wallet-Demo)
       registry: ghcr.io
-      repository: bcgov/bc-wallet-showcase-server
+      repository: bcgov/digital-trust-showcase-server
       ## Defaults to the chart appVersion when empty. CI overrides to `main` for dev.
       tag: ''
       digest: ''
@@ -171,9 +171,9 @@ showcase:
     ## (same behaviour as before); set this to override without a new chart version.
     caddyfile: ''
     image:
-      ## ghcr.io/bcgov/bc-wallet-showcase-frontend:main
+      ## ghcr.io/bcgov/digital-trust-showcase-frontend:main
       registry: ghcr.io
-      repository: bcgov/bc-wallet-showcase-frontend
+      repository: bcgov/digital-trust-showcase-frontend
       ## Defaults to the chart appVersion when empty. CI overrides to `main` for dev.
       tag: ''
       digest: ''

--- a/charts/showcase/values.yaml
+++ b/charts/showcase/values.yaml
@@ -89,7 +89,8 @@ showcase:
       ## ghcr.io/bcgov/bc-wallet-showcase-server:main (see https://github.com/orgs/bcgov/packages?repo_name=BC-Wallet-Demo)
       registry: ghcr.io
       repository: bcgov/bc-wallet-showcase-server
-      tag: main
+      ## Defaults to the chart appVersion when empty. CI overrides to `main` for dev.
+      tag: ''
       digest: ''
       pullPolicy: IfNotPresent
     ## Database seeding. When enabled, runs as an init container before the server starts.
@@ -173,7 +174,8 @@ showcase:
       ## ghcr.io/bcgov/bc-wallet-showcase-frontend:main
       registry: ghcr.io
       repository: bcgov/bc-wallet-showcase-frontend
-      tag: main
+      ## Defaults to the chart appVersion when empty. CI overrides to `main` for dev.
+      tag: ''
       digest: ''
       pullPolicy: IfNotPresent
     resources: {}

--- a/deploy/showcase/values-dev.yaml
+++ b/deploy/showcase/values-dev.yaml
@@ -17,7 +17,7 @@ ingress:
     tls: false
 
 showcase:
-  publicOrigin: 'https://bc-wallet-showcase-dev.apps.silver.devops.gov.bc.ca'
+  publicOrigin: 'https://digital-trust-showcase-dev.apps.silver.devops.gov.bc.ca'
   networkPolicy:
     enabled: true
   ## Force pod rollout on every helm upgrade so that Always-pull picks up rebuilt images behind the same tag.

--- a/deploy/showcase/values-pr.yaml
+++ b/deploy/showcase/values-pr.yaml
@@ -19,7 +19,7 @@ ingress:
 showcase:
   autoProvisionSecrets: true
   ## Overridden in CI; placeholder keeps helm lint/template valid locally.
-  publicOrigin: 'https://bc-wallet-showcase-pr-0.apps.silver.devops.gov.bc.ca'
+  publicOrigin: 'https://digital-trust-showcase-pr-0.apps.silver.devops.gov.bc.ca'
   networkPolicy:
     enabled: true
   server:

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "0.1.0",
+  "version": "0.2.5",
   "private": true,
   "license": "Apache-2.0",
   "description": "BC Digital Trust Showcase - A showcase of how to use the BC Services Card app to prove things about yourself, in a way that's safe and secure.",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bc-wallet-demo",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "private": true,
   "license": "Apache-2.0",
   "description": "BC Digital Trust Showcase - Verifiable Credential Demo",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "server",
-  "version": "1.0.0",
+  "version": "0.2.5",
   "private": true,
   "description": "",
   "main": "build/src/index.js",


### PR DESCRIPTION
- Renames chart and components to `digital-trust-showcase`
- Updates chart to use `appImage` as default image version for deployments
- Updates CI to improve image tagging