### PR TITLE
ci: speed up frontend Docker build caching and parallelize CI checks

### DIFF
--- a/.github/actions/showcase-build-frontend/action.yml
+++ b/.github/actions/showcase-build-frontend/action.yml
@@ -17,6 +17,10 @@ inputs:
   github_token:
     description: Token with packages write (typically secrets.GITHUB_TOKEN)
     required: true
+  sbom:
+    description: Generate an SBOM (enable for released images; skip for ephemeral PR/dev builds to save time)
+    required: false
+    default: 'false'
 
 runs:
   using: composite
@@ -51,7 +55,7 @@ runs:
         labels: ${{ steps.meta.outputs.labels }}
         annotations: ${{ steps.meta.outputs.annotations }}
         provenance: mode=min
-        sbom: true
+        sbom: ${{ inputs.sbom }}
         cache-from: type=gha
         cache-to: type=gha,mode=max
         build-args: |

--- a/.github/actions/showcase-build-server/action.yml
+++ b/.github/actions/showcase-build-server/action.yml
@@ -10,6 +10,10 @@ inputs:
   github_token:
     description: Token with packages write (typically secrets.GITHUB_TOKEN)
     required: true
+  sbom:
+    description: Generate an SBOM (enable for released images; skip for ephemeral PR/dev builds to save time)
+    required: false
+    default: 'false'
 
 runs:
   using: composite
@@ -45,6 +49,6 @@ runs:
         labels: ${{ steps.meta.outputs.labels }}
         annotations: ${{ steps.meta.outputs.annotations }}
         provenance: mode=min
-        sbom: true
+        sbom: ${{ inputs.sbom }}
         cache-from: type=gha
         cache-to: type=gha,mode=max

--- a/.github/workflows/build_packages.yml
+++ b/.github/workflows/build_packages.yml
@@ -123,7 +123,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           annotations: ${{ steps.meta.outputs.annotations }}
           provenance: mode=min
-          sbom: true
+          sbom: ${{ github.event_name == 'release' }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -176,7 +176,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           annotations: ${{ steps.meta.outputs.annotations }}
           provenance: mode=min
-          sbom: true
+          sbom: ${{ github.event_name == 'release' }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           build-args: |

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -53,10 +53,10 @@ jobs:
       - name: Run frontend unit tests
         run: yarn workspace frontend test:unit
 
-  cypress-run:
-    name: Cypress E2E Tests
+  static-checks:
+    name: Lint, Format & Types
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -77,6 +77,22 @@ jobs:
 
       - name: Compile
         run: yarn check-types
+
+  cypress-run:
+    name: Cypress E2E Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Setup NodeJS
+        uses: ./.github/actions/setup-node
+        with:
+          node-version: 22
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
 
       # Cypress: only the Vite dev server is started. cypress.config.ts sets apiUrl to :5000 for
       # specs that hit the API—if CI runs those, also start the server (e.g. concurrently) or align with build_packages.yml (yarn dev).

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,17 +1,30 @@
+# syntax=docker/dockerfile:1
 ARG build_image=node:22-alpine
 ARG runtime_image=caddy:alpine
 
 # build stage
 FROM ${build_image} AS build-stage
 WORKDIR /app
-ENV HUSKY=0
-COPY . .
+ENV HUSKY=0 \
+    YARN_NETWORK_CONCURRENCY=8
+
+# Install deps first so this layer stays cached unless a manifest/lockfile changes.
+# The whole workspace is resolved against the root lockfile, so every member
+# package.json must be present for `--frozen-lockfile` to succeed.
+COPY package.json yarn.lock ./
+COPY frontend/package.json ./frontend/
+COPY server/package.json ./server/
+RUN --mount=type=cache,target=/root/.cache/yarn \
+    yarn install --frozen-lockfile --network-timeout 600000 --non-interactive
+
 # CI passes legacy secret names (REACT_APP_*). Map them to Vite env for `vite build`.
 ARG REACT_APP_INSIGHTS_PROJECT_ID
 ARG REACT_APP_HOST_BACKEND
 ENV VITE_INSIGHTS_PROJECT_ID=$REACT_APP_INSIGHTS_PROJECT_ID
 ENV VITE_HOST_BACKEND=$REACT_APP_HOST_BACKEND
-RUN yarn install --frozen-lockfile --network-timeout 600000 --non-interactive
+
+# Copy source last so edits don't invalidate the dependency layer above.
+COPY frontend ./frontend
 RUN yarn workspace frontend build
 
 # production stage


### PR DESCRIPTION
- frontend/Dockerfile: install deps from manifests before copying source and add a BuildKit yarn cache mount so the dependency layer stays cached across source changes (mirrors server/Dockerfile)
- continuous-integration.yml: split lint/format/type-check into a parallel static-checks job so failures surface without waiting on Cypress setup
- restrict SBOM generation to release builds; PR/dev image builds skip it via a new opt-in 'sbom' input on the showcase-build-* actions