### PR TITLE
feat(proof-requests): support external credential requests

### DIFF
--- a/frontend/src/admin/components/showcase/modals/CreateConnectionAndProofScreensModal.tsx
+++ b/frontend/src/admin/components/showcase/modals/CreateConnectionAndProofScreensModal.tsx
@@ -196,11 +196,14 @@ export function CreateConnectionAndProofScreensModal({
                         ...(scenario.screens?.slice(0, insertIdx) ?? []),
                         connectionScreenData,
                         externalCredentials.size > 0
-                          ? { ...proofScreenData, requestOptions: {
-                              name: verifierName,
-                              text: "Review and confirm the information you're sharing",
-                              requestedCredentials: Array.from(externalCredentials.values()),
-                            } }
+                          ? {
+                              ...proofScreenData,
+                              requestOptions: {
+                                name: verifierName,
+                                text: "Review and confirm the information you're sharing",
+                                requestedCredentials: Array.from(externalCredentials.values()),
+                              },
+                            }
                           : proofScreenData,
                         ...(scenario.screens?.slice(insertIdx) ?? []),
                       ]

--- a/frontend/src/admin/components/showcase/modals/CreateConnectionAndProofScreensModal.tsx
+++ b/frontend/src/admin/components/showcase/modals/CreateConnectionAndProofScreensModal.tsx
@@ -5,6 +5,7 @@ import { useState, useEffect } from 'react'
 import { useAuth } from 'react-oidc-context'
 
 import { updateShowcase } from '../../../api/adminApi'
+import { ExternalCredentialRequestModal } from './ExternalCredentialRequestModal'
 
 import { CreateOrEditScreenModal } from './CreateOrEditScreenModal'
 import { ImageUploadModal } from './ImageUploadModal'
@@ -43,6 +44,9 @@ export function CreateConnectionAndProofScreensModal({
   const [currentCredentialIdx, setCurrentCredentialIdx] = useState(0)
   const [selectedAttributes, setSelectedAttributes] = useState<Map<string, Map<string, AttributeRequest>>>(new Map())
   const [credentialRequests, setCredentialRequests] = useState<Map<string, CredentialRequest>>(new Map())
+  const [externalCredentials, setExternalCredentials] = useState<Map<string, CredentialRequest>>(new Map())
+  const [editingExternalKey, setEditingExternalKey] = useState<string | null>(null)
+  const [editingExternalIconKey, setEditingExternalIconKey] = useState<string | null>(null)
   const [isImageUploadModalOpen, setIsImageUploadModalOpen] = useState(false)
   const [imageUploadModalCredentialId, setImageUploadModalCredentialId] = useState<string | null>(null)
   const [isVerifierIconUploadOpen, setIsVerifierIconUploadOpen] = useState(false)
@@ -75,6 +79,9 @@ export function CreateConnectionAndProofScreensModal({
     setCurrentCredentialIdx(0)
     setSelectedAttributes(new Map())
     setCredentialRequests(new Map())
+    setExternalCredentials(new Map())
+    setEditingExternalKey(null)
+    setEditingExternalIconKey(null)
     setIsImageUploadModalOpen(false)
     setImageUploadModalCredentialId(null)
     setIsVerifierIconUploadOpen(false)
@@ -154,8 +161,19 @@ export function CreateConnectionAndProofScreensModal({
                   setSelectedCredentials(newSelected)
                 }}
                 onBack={() => setStep({ type: 'EDITING_PROOF_SCREEN' })}
+                externalCredentials={externalCredentials}
+                onAddExternal={() => {
+                  const key = `external:${Date.now()}-${Math.random()}`
+                  setExternalCredentials(new Map(externalCredentials).set(key, { name: '' }))
+                  setEditingExternalKey(key)
+                }}
+                onEditExternal={(key) => setEditingExternalKey(key)}
+                onRemoveExternal={(key) => {
+                  const next = new Map(externalCredentials)
+                  next.delete(key)
+                  setExternalCredentials(next)
+                }}
                 onContinue={async () => {
-                  // If credentials are selected, go to attribute selection
                   if (selectedCredentials.size > 0) {
                     setStep({ type: 'SELECTING_ATTRIBUTES' })
                     setCurrentCredentialIdx(0)
@@ -177,7 +195,13 @@ export function CreateConnectionAndProofScreensModal({
                       const updatedScreens = [
                         ...(scenario.screens?.slice(0, insertIdx) ?? []),
                         connectionScreenData,
-                        proofScreenData,
+                        externalCredentials.size > 0
+                          ? { ...proofScreenData, requestOptions: {
+                              name: verifierName,
+                              text: "Review and confirm the information you're sharing",
+                              requestedCredentials: Array.from(externalCredentials.values()),
+                            } }
+                          : proofScreenData,
                         ...(scenario.screens?.slice(insertIdx) ?? []),
                       ]
 
@@ -406,6 +430,7 @@ export function CreateConnectionAndProofScreensModal({
                           nonRevoked: req.nonRevoked,
                         }
                       })
+                      proofRequests.push(...Array.from(externalCredentials.values()))
                       const requestOptions = {
                         name: verifierName,
                         text: "Review and confirm the information you're sharing",
@@ -448,6 +473,8 @@ export function CreateConnectionAndProofScreensModal({
                       setSelectedCredentials(new Set())
                       setSelectedAttributes(new Map())
                       setCredentialRequests(new Map())
+                      setExternalCredentials(new Map())
+                      setEditingExternalKey(null)
                       setCurrentCredentialIdx(0)
 
                       onComplete?.()
@@ -480,7 +507,14 @@ export function CreateConnectionAndProofScreensModal({
         onClose={() => setIsImageUploadModalOpen(false)}
         type="icon"
         onSelectImage={(imagePath) => {
-          if (imageUploadModalCredentialId) {
+          if (editingExternalIconKey) {
+            const next = new Map(externalCredentials)
+            const currentRequest = next.get(editingExternalIconKey)
+            if (currentRequest) next.set(editingExternalIconKey, { ...currentRequest, icon: imagePath })
+            setExternalCredentials(next)
+            setEditingExternalIconKey(null)
+            setIsImageUploadModalOpen(false)
+          } else if (imageUploadModalCredentialId) {
             const newRequests = new Map(credentialRequests)
             const currentRequest = newRequests.get(imageUploadModalCredentialId)
             if (currentRequest) {
@@ -493,6 +527,23 @@ export function CreateConnectionAndProofScreensModal({
             setIsImageUploadModalOpen(false)
             setImageUploadModalCredentialId(null)
           }
+        }}
+      />
+
+      <ExternalCredentialRequestModal
+        isOpen={editingExternalKey !== null}
+        initialValue={editingExternalKey ? externalCredentials.get(editingExternalKey) : null}
+        onClose={() => setEditingExternalKey(null)}
+        onRequestIconUpload={() => {
+          setEditingExternalIconKey(editingExternalKey)
+          setIsImageUploadModalOpen(true)
+        }}
+        onSave={(request) => {
+          if (!editingExternalKey) return
+          const next = new Map(externalCredentials)
+          next.set(editingExternalKey, request)
+          setExternalCredentials(next)
+          setEditingExternalKey(null)
         }}
       />
 

--- a/frontend/src/admin/components/showcase/modals/CreateConnectionAndProofScreensModal.tsx
+++ b/frontend/src/admin/components/showcase/modals/CreateConnectionAndProofScreensModal.tsx
@@ -420,20 +420,25 @@ export function CreateConnectionAndProofScreensModal({
                       if (!scenario) return
 
                       // Build the requestOptions from credentialRequests
-                      const proofRequests = Array.from(credentialRequests.entries()).map(([credentialId, req]) => {
-                        const credential = showcase?.credentials?.find((c) => c.id === credentialId)
-                        return {
-                          name: credential?.name || req.name,
-                          schema_id: credential?.schema_id,
-                          cred_def_id: credential?.cred_def_id,
-                          cred_id: credential?.id,
-                          icon: req.icon,
-                          properties: req.properties,
-                          ...(req.predicates && req.predicates.length > 0 && { predicates: req.predicates }),
-                          nonRevoked: req.nonRevoked,
-                        }
-                      })
-                      proofRequests.push(...Array.from(externalCredentials.values()))
+                      const proofRequests: CredentialRequest[] = [
+                        ...Array.from(credentialRequests.entries()).map(([credentialId, req]) => {
+                          const credential = showcase?.credentials?.find((c) => c.id === credentialId)
+                          return {
+                            name: credential?.name || req.name,
+                            schema_id: credential?.schema_id,
+                            cred_def_id: credential?.cred_def_id,
+                            cred_id: credential?.id,
+                            icon: req.icon,
+                            properties: req.properties,
+                            ...(req.predicates && req.predicates.length > 0 && { predicates: req.predicates }),
+                            nonRevoked: req.nonRevoked,
+                          }
+                        }),
+                        ...Array.from(externalCredentials.values()).map((request) => ({
+                          ...request,
+                          nonRevoked: request.nonRevoked,
+                        })),
+                      ]
                       const requestOptions = {
                         name: verifierName,
                         text: "Review and confirm the information you're sharing",

--- a/frontend/src/admin/components/showcase/modals/CreateConnectionAndProofScreensModal.tsx
+++ b/frontend/src/admin/components/showcase/modals/CreateConnectionAndProofScreensModal.tsx
@@ -5,9 +5,9 @@ import { useState, useEffect } from 'react'
 import { useAuth } from 'react-oidc-context'
 
 import { updateShowcase } from '../../../api/adminApi'
-import { ExternalCredentialRequestModal } from './ExternalCredentialRequestModal'
 
 import { CreateOrEditScreenModal } from './CreateOrEditScreenModal'
+import { ExternalCredentialRequestModal } from './ExternalCredentialRequestModal'
 import { ImageUploadModal } from './ImageUploadModal'
 import { EnteringNameStep, SelectingCredentialsStep, SelectingAttributesStep, DefiningProofRequestStep } from './steps'
 

--- a/frontend/src/admin/components/showcase/modals/ExternalCredentialRequestModal.tsx
+++ b/frontend/src/admin/components/showcase/modals/ExternalCredentialRequestModal.tsx
@@ -1,0 +1,176 @@
+import type { CredentialRequest } from '../../../types'
+
+import { XMarkIcon } from '@heroicons/react/24/outline'
+import { useEffect, useState } from 'react'
+
+import { publicBaseUrl } from '../../../api/adminApi'
+import {
+  EXTERNAL_CREDENTIAL_JSON_TEMPLATE,
+  buildExternalCredentialRequest,
+  parseExternalCredentialJson,
+} from '../../../utils/externalCredentialRequest'
+
+interface ExternalCredentialRequestModalProps {
+  isOpen: boolean
+  initialValue?: CredentialRequest | null
+  onSave: (request: CredentialRequest) => void
+  onClose: () => void
+  onRequestIconUpload: () => void
+}
+
+const fieldsFromRequest = (request?: CredentialRequest | null) =>
+  request
+    ? JSON.stringify(
+        {
+          ...(request.schema_id ? { schema_id: request.schema_id } : {}),
+          ...(request.cred_def_id ? { cred_def_id: request.cred_def_id } : {}),
+          ...(request.properties?.length ? { properties: request.properties } : {}),
+          ...(request.predicates?.length ? { predicates: request.predicates } : {}),
+          ...(request.nonRevoked ? { nonRevoked: request.nonRevoked } : {}),
+        },
+        null,
+        2,
+      )
+    : EXTERNAL_CREDENTIAL_JSON_TEMPLATE
+
+export function ExternalCredentialRequestModal({
+  isOpen,
+  initialValue,
+  onSave,
+  onClose,
+  onRequestIconUpload,
+}: ExternalCredentialRequestModalProps) {
+  const [name, setName] = useState('')
+  const [icon, setIcon] = useState<string | undefined>()
+  const [json, setJson] = useState(EXTERNAL_CREDENTIAL_JSON_TEMPLATE)
+  const [touched, setTouched] = useState(false)
+
+  const parsed = parseExternalCredentialJson(json)
+
+  useEffect(() => {
+    if (!isOpen) return
+    setName(initialValue?.name || '')
+    setIcon(initialValue?.icon)
+    setJson(fieldsFromRequest(initialValue))
+    setTouched(false)
+  }, [isOpen, initialValue])
+
+  if (!isOpen) return null
+
+  const save = () => {
+    setTouched(true)
+    if (!name.trim() || parsed.errors.length > 0 || !parsed.value) return
+    onSave(buildExternalCredentialRequest(name, icon, parsed.value))
+  }
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-40">
+      <div className="bg-white rounded-lg shadow-lg max-w-2xl w-full mx-4 max-h-[90vh] overflow-y-auto">
+        <div className="flex items-center justify-between border-b border-gray-200 p-6">
+          <h2 className="text-lg font-semibold text-bcgov-black">External Credential (Advanced)</h2>
+          <button onClick={onClose} className="text-gray-500 hover:text-gray-700" aria-label="Close">
+            <XMarkIcon className="w-6 h-6" />
+          </button>
+        </div>
+        <div className="p-6 space-y-5">
+          <div className="rounded-lg border border-amber-200 bg-amber-50 p-4 text-sm text-amber-900">
+            Use this for a credential issued outside this showcase. The schema or credential definition must be available
+            to the verifier agent on the ledger it uses.
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-bcgov-black mb-2" htmlFor="external-credential-name">
+              Credential name
+            </label>
+            <input
+              id="external-credential-name"
+              value={name}
+              onChange={(event) => setName(event.target.value)}
+              className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm"
+              placeholder="e.g., University Degree"
+            />
+          </div>
+
+          <div>
+            <p className="block text-sm font-medium text-bcgov-black mb-2">Icon</p>
+            <div className="flex items-center gap-3">
+              {icon ? (
+                <img src={`${publicBaseUrl}${icon}`} alt="Credential icon" className="w-12 h-12 object-contain" />
+              ) : (
+                <div className="w-12 h-12 border border-dashed border-gray-300 rounded-lg" />
+              )}
+              <button onClick={onRequestIconUpload} className="px-3 py-2 border border-gray-300 rounded-lg text-sm">
+                Change icon
+              </button>
+            </div>
+          </div>
+
+          <div>
+            <div className="flex items-center justify-between mb-2">
+              <label className="text-sm font-medium text-bcgov-black" htmlFor="external-credential-json">
+                Credential identifiers and attributes
+              </label>
+              <button
+                onClick={() => parsed.value && setJson(JSON.stringify(parsed.value, null, 2))}
+                disabled={parsed.errors.length > 0}
+                className="text-xs text-bcgov-blue disabled:text-gray-400"
+              >
+                Format JSON
+              </button>
+            </div>
+            <textarea
+              id="external-credential-json"
+              value={json}
+              onChange={(event) => {
+                setJson(event.target.value)
+                setTouched(true)
+              }}
+              rows={14}
+              spellCheck={false}
+              className="w-full border border-gray-300 rounded-lg p-3 font-mono text-xs"
+            />
+          </div>
+
+          {(touched || parsed.errors.length > 0) && parsed.errors.length > 0 && (
+            <div className="rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-800">
+              {parsed.errors.map((error) => (
+                <p key={error}>{error}</p>
+              ))}
+            </div>
+          )}
+          {parsed.warnings.length > 0 && (
+            <div className="rounded-lg border border-amber-200 bg-amber-50 p-3 text-sm text-amber-800">
+              {parsed.warnings.map((warning) => (
+                <p key={warning}>{warning}</p>
+              ))}
+            </div>
+          )}
+
+          {parsed.value && (
+            <div className="rounded-lg bg-gray-50 p-4 text-sm">
+              <p className="font-semibold text-bcgov-black mb-2">Request preview</p>
+              <p className="text-gray-600">Properties: {parsed.value.properties?.join(', ') || 'None'}</p>
+              <p className="text-gray-600">
+                Predicates:{' '}
+                {parsed.value.predicates?.map((predicate) => `${predicate.name} ${predicate.type} ${predicate.value}`).join(', ') || 'None'}
+              </p>
+              {parsed.value.nonRevoked && <p className="text-green-700">Non-revoked credential required</p>}
+            </div>
+          )}
+        </div>
+        <div className="flex justify-end gap-3 border-t border-gray-200 p-6">
+          <button onClick={onClose} className="px-4 py-2 text-gray-700 bg-gray-100 rounded-lg">
+            Cancel
+          </button>
+          <button
+            onClick={save}
+            disabled={!name.trim() || parsed.errors.length > 0 || !parsed.value}
+            className="px-4 py-2 text-white bg-bcgov-blue rounded-lg disabled:bg-gray-300"
+          >
+            Save credential
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/admin/components/showcase/modals/ExternalCredentialRequestModal.tsx
+++ b/frontend/src/admin/components/showcase/modals/ExternalCredentialRequestModal.tsx
@@ -15,7 +15,7 @@ interface ExternalCredentialRequestModalProps {
   initialValue?: CredentialRequest | null
   onSave: (request: CredentialRequest) => void
   onClose: () => void
-  onRequestIconUpload: () => void
+  onRequestIconUpload?: () => void
 }
 
 const fieldsFromRequest = (request?: CredentialRequest | null) =>
@@ -99,9 +99,11 @@ export function ExternalCredentialRequestModal({
               ) : (
                 <div className="w-12 h-12 border border-dashed border-gray-300 rounded-lg" />
               )}
-              <button onClick={onRequestIconUpload} className="px-3 py-2 border border-gray-300 rounded-lg text-sm">
-                Change icon
-              </button>
+              {onRequestIconUpload && (
+                <button onClick={onRequestIconUpload} className="px-3 py-2 border border-gray-300 rounded-lg text-sm">
+                  Change icon
+                </button>
+              )}
             </div>
           </div>
 

--- a/frontend/src/admin/components/showcase/modals/ExternalCredentialRequestModal.tsx
+++ b/frontend/src/admin/components/showcase/modals/ExternalCredentialRequestModal.tsx
@@ -3,12 +3,12 @@ import type { CredentialRequest } from '../../../types'
 import { XMarkIcon } from '@heroicons/react/24/outline'
 import { useEffect, useState } from 'react'
 
-import { publicBaseUrl } from '../../../api/adminApi'
 import {
   EXTERNAL_CREDENTIAL_JSON_TEMPLATE,
   buildExternalCredentialRequest,
   parseExternalCredentialJson,
 } from '../../../utils/externalCredentialRequest'
+import { getPublicAssetUrl } from '../../../utils/publicAssetUrl'
 
 interface ExternalCredentialRequestModalProps {
   isOpen: boolean
@@ -74,8 +74,8 @@ export function ExternalCredentialRequestModal({
         </div>
         <div className="p-6 space-y-5">
           <div className="rounded-lg border border-amber-200 bg-amber-50 p-4 text-sm text-amber-900">
-            Use this for a credential issued outside this showcase. The schema or credential definition must be available
-            to the verifier agent on the ledger it uses.
+            Use this for a credential issued outside this showcase. The schema or credential definition must be
+            available to the verifier agent on the ledger it uses.
           </div>
 
           <div>
@@ -95,7 +95,7 @@ export function ExternalCredentialRequestModal({
             <p className="block text-sm font-medium text-bcgov-black mb-2">Icon</p>
             <div className="flex items-center gap-3">
               {icon ? (
-                <img src={`${publicBaseUrl}${icon}`} alt="Credential icon" className="w-12 h-12 object-contain" />
+                <img src={getPublicAssetUrl(icon)} alt="Credential icon" className="w-12 h-12 object-contain" />
               ) : (
                 <div className="w-12 h-12 border border-dashed border-gray-300 rounded-lg" />
               )}
@@ -152,7 +152,9 @@ export function ExternalCredentialRequestModal({
               <p className="text-gray-600">Properties: {parsed.value.properties?.join(', ') || 'None'}</p>
               <p className="text-gray-600">
                 Predicates:{' '}
-                {parsed.value.predicates?.map((predicate) => `${predicate.name} ${predicate.type} ${predicate.value}`).join(', ') || 'None'}
+                {parsed.value.predicates
+                  ?.map((predicate) => `${predicate.name} ${predicate.type} ${predicate.value}`)
+                  .join(', ') || 'None'}
               </p>
               {parsed.value.nonRevoked && <p className="text-green-700">Non-revoked credential required</p>}
             </div>

--- a/frontend/src/admin/components/showcase/modals/ExternalCredentialRequestModal.tsx
+++ b/frontend/src/admin/components/showcase/modals/ExternalCredentialRequestModal.tsx
@@ -19,7 +19,12 @@ interface ExternalCredentialRequestModalProps {
 }
 
 const fieldsFromRequest = (request?: CredentialRequest | null) =>
-  request
+  request &&
+  (request.schema_id ||
+    request.cred_def_id ||
+    request.properties?.length ||
+    request.predicates?.length ||
+    request.nonRevoked)
     ? JSON.stringify(
         {
           ...(request.schema_id ? { schema_id: request.schema_id } : {}),

--- a/frontend/src/admin/components/showcase/modals/ExternalCredentialRequestModal.tsx
+++ b/frontend/src/admin/components/showcase/modals/ExternalCredentialRequestModal.tsx
@@ -1,7 +1,7 @@
 import type { CredentialRequest } from '../../../types'
 
 import { XMarkIcon } from '@heroicons/react/24/outline'
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 import {
   EXTERNAL_CREDENTIAL_JSON_TEMPLATE,
@@ -49,15 +49,24 @@ export function ExternalCredentialRequestModal({
   const [icon, setIcon] = useState<string | undefined>()
   const [json, setJson] = useState(EXTERNAL_CREDENTIAL_JSON_TEMPLATE)
   const [touched, setTouched] = useState(false)
+  const wasOpenRef = useRef(false)
 
   const parsed = parseExternalCredentialJson(json)
 
   useEffect(() => {
-    if (!isOpen) return
-    setName(initialValue?.name || '')
+    if (!isOpen) {
+      wasOpenRef.current = false
+      return
+    }
+    // Only reset name/json on the open transition so picking an icon (which updates
+    // initialValue via the parent) doesn't discard unsaved edits still being typed.
+    if (!wasOpenRef.current) {
+      setName(initialValue?.name || '')
+      setJson(fieldsFromRequest(initialValue))
+      setTouched(false)
+    }
     setIcon(initialValue?.icon)
-    setJson(fieldsFromRequest(initialValue))
-    setTouched(false)
+    wasOpenRef.current = true
   }, [isOpen, initialValue])
 
   if (!isOpen) return null

--- a/frontend/src/admin/components/showcase/modals/ExternalCredentialRequestModal.tsx
+++ b/frontend/src/admin/components/showcase/modals/ExternalCredentialRequestModal.tsx
@@ -80,7 +80,8 @@ export function ExternalCredentialRequestModal({
         <div className="p-6 space-y-5">
           <div className="rounded-lg border border-amber-200 bg-amber-50 p-4 text-sm text-amber-900">
             Use this for a credential issued outside this showcase. The schema or credential definition must be
-            available to the verifier agent on the ledger it uses.
+            available to the verifier agent on the ledger it uses. Provide an array of values for schema_id or
+            cred_def_id to accept any one of them (OR condition).
           </div>
 
           <div>

--- a/frontend/src/admin/components/showcase/modals/steps/CreateCredentialStep.tsx
+++ b/frontend/src/admin/components/showcase/modals/steps/CreateCredentialStep.tsx
@@ -1,4 +1,4 @@
-import type { Credential, Showcase } from '../../../../types'
+import type { Credential, CredentialRequest, Showcase } from '../../../../types'
 
 import { publicBaseUrl } from '../../../../api/adminApi'
 
@@ -8,6 +8,10 @@ interface CreateCredentialStepProps {
   onSelectCredential: (credentialId: string, checked: boolean) => void
   onBack: () => void
   onContinue: () => void
+  externalCredentials: Map<string, CredentialRequest>
+  onAddExternal: () => void
+  onEditExternal: (key: string) => void
+  onRemoveExternal: (key: string) => void
 }
 
 export function CreateCredentialStep({
@@ -16,7 +20,13 @@ export function CreateCredentialStep({
   onSelectCredential,
   onBack,
   onContinue,
+  externalCredentials,
+  onAddExternal,
+  onEditExternal,
+  onRemoveExternal,
 }: CreateCredentialStepProps) {
+  const hasCredentials = selectedCredentials.size > 0 || externalCredentials.size > 0
+
   return (
     <div className="space-y-4">
       <div>
@@ -59,6 +69,31 @@ export function CreateCredentialStep({
         <p className="text-xs text-gray-500 italic">No credentials available in this showcase</p>
       )}
 
+      <div className="border-t border-gray-200 pt-4 space-y-3">
+        <div>
+          <h3 className="text-sm font-semibold text-bcgov-black">External credentials (advanced)</h3>
+          <p className="text-xs text-gray-500">Request a credential issued outside this showcase using its ledger identifiers.</p>
+        </div>
+        {Array.from(externalCredentials.entries()).map(([key, credential]) => (
+          <div key={key} className="border border-amber-200 bg-amber-50 rounded-lg p-3 flex items-start justify-between gap-3">
+            <div className="min-w-0">
+              <p className="text-sm font-medium text-bcgov-black">{credential.name}</p>
+              <p className="text-xs font-mono text-gray-600 break-all">{credential.cred_def_id || credential.schema_id}</p>
+            </div>
+            <div className="flex gap-2 shrink-0">
+              <button onClick={() => onEditExternal(key)} className="text-xs text-bcgov-blue">Edit</button>
+              <button onClick={() => onRemoveExternal(key)} className="text-xs text-red-700">Remove</button>
+            </div>
+          </div>
+        ))}
+        <button
+          onClick={onAddExternal}
+          className="w-full px-4 py-2 text-sm text-bcgov-blue border border-bcgov-blue rounded-lg hover:bg-blue-50"
+        >
+          Add external credential (advanced)
+        </button>
+      </div>
+
       <div className="flex justify-end gap-3 pt-4 border-t border-gray-200">
         <button
           onClick={onBack}
@@ -68,7 +103,8 @@ export function CreateCredentialStep({
         </button>
         <button
           onClick={onContinue}
-          className="px-4 py-2 text-white bg-bcgov-blue hover:bg-bcgov-blue-dark rounded-lg font-medium transition-colors"
+          disabled={!hasCredentials}
+          className="px-4 py-2 text-white bg-bcgov-blue hover:bg-bcgov-blue-dark rounded-lg font-medium transition-colors disabled:bg-gray-300"
         >
           Continue
         </button>

--- a/frontend/src/admin/components/showcase/modals/steps/CreateCredentialStep.tsx
+++ b/frontend/src/admin/components/showcase/modals/steps/CreateCredentialStep.tsx
@@ -2,6 +2,16 @@ import type { Credential, CredentialRequest, Showcase } from '../../../../types'
 
 import { publicBaseUrl } from '../../../../api/adminApi'
 
+const hasIdentifier = (value?: string | string[]): boolean => {
+  if (Array.isArray(value)) return value.some((entry) => entry.trim().length > 0)
+  return typeof value === 'string' && value.trim().length > 0
+}
+
+const isMinimallyValidExternalCredential = (credential: CredentialRequest): boolean =>
+  credential.name.trim().length > 0 &&
+  (hasIdentifier(credential.schema_id) || hasIdentifier(credential.cred_def_id)) &&
+  Boolean(credential.properties?.length || credential.predicates?.length)
+
 interface CreateCredentialStepProps {
   showcase: Showcase | null | undefined
   selectedCredentials: Set<string>
@@ -25,6 +35,7 @@ export function CreateCredentialStep({
   onEditExternal,
   onRemoveExternal,
 }: CreateCredentialStepProps) {
+  const hasValidExternalCredentials = Array.from(externalCredentials.values()).every(isMinimallyValidExternalCredential)
   const hasCredentials = selectedCredentials.size > 0 || externalCredentials.size > 0
 
   return (
@@ -114,7 +125,7 @@ export function CreateCredentialStep({
         </button>
         <button
           onClick={onContinue}
-          disabled={!hasCredentials}
+          disabled={!hasCredentials || !hasValidExternalCredentials}
           className="px-4 py-2 text-white bg-bcgov-blue hover:bg-bcgov-blue-dark rounded-lg font-medium transition-colors disabled:bg-gray-300"
         >
           Continue

--- a/frontend/src/admin/components/showcase/modals/steps/CreateCredentialStep.tsx
+++ b/frontend/src/admin/components/showcase/modals/steps/CreateCredentialStep.tsx
@@ -72,17 +72,28 @@ export function CreateCredentialStep({
       <div className="border-t border-gray-200 pt-4 space-y-3">
         <div>
           <h3 className="text-sm font-semibold text-bcgov-black">External credentials (advanced)</h3>
-          <p className="text-xs text-gray-500">Request a credential issued outside this showcase using its ledger identifiers.</p>
+          <p className="text-xs text-gray-500">
+            Request a credential issued outside this showcase using its ledger identifiers.
+          </p>
         </div>
         {Array.from(externalCredentials.entries()).map(([key, credential]) => (
-          <div key={key} className="border border-amber-200 bg-amber-50 rounded-lg p-3 flex items-start justify-between gap-3">
+          <div
+            key={key}
+            className="border border-amber-200 bg-amber-50 rounded-lg p-3 flex items-start justify-between gap-3"
+          >
             <div className="min-w-0">
               <p className="text-sm font-medium text-bcgov-black">{credential.name}</p>
-              <p className="text-xs font-mono text-gray-600 break-all">{credential.cred_def_id || credential.schema_id}</p>
+              <p className="text-xs font-mono text-gray-600 break-all">
+                {credential.cred_def_id || credential.schema_id}
+              </p>
             </div>
             <div className="flex gap-2 shrink-0">
-              <button onClick={() => onEditExternal(key)} className="text-xs text-bcgov-blue">Edit</button>
-              <button onClick={() => onRemoveExternal(key)} className="text-xs text-red-700">Remove</button>
+              <button onClick={() => onEditExternal(key)} className="text-xs text-bcgov-blue">
+                Edit
+              </button>
+              <button onClick={() => onRemoveExternal(key)} className="text-xs text-red-700">
+                Remove
+              </button>
             </div>
           </div>
         ))}

--- a/frontend/src/admin/components/showcase/scenarios/ScenarioScreenRow.tsx
+++ b/frontend/src/admin/components/showcase/scenarios/ScenarioScreenRow.tsx
@@ -63,6 +63,7 @@ export function ScenarioScreenRow({
   const canEdit = useHasRole('creator')
   const [editingCredIdx, setEditingCredIdx] = useState<number | null>(null)
   const [editingExternalIdx, setEditingExternalIdx] = useState<number | null>(null)
+  const [isAddingExternalCredential, setIsAddingExternalCredential] = useState(false)
   const [selectedAttributes, setSelectedAttributes] = useState<Map<string, any>>(new Map())
   const [editingCredential, setEditingCredential] = useState<Credential | null>(null)
   const [isVerifierIconEditOpen, setIsVerifierIconEditOpen] = useState(false)
@@ -379,6 +380,14 @@ export function ScenarioScreenRow({
                       ))}
                     </div>
                   )}
+                {canEdit && (
+                  <button
+                    onClick={() => setIsAddingExternalCredential(true)}
+                    className="mt-3 w-full px-3 py-2 text-sm text-bcgov-blue border border-bcgov-blue rounded-lg hover:bg-blue-50"
+                  >
+                    Add external credential (advanced)
+                  </button>
+                )}
               </div>
             </div>
           ) : null
@@ -403,6 +412,39 @@ export function ScenarioScreenRow({
       />
 
       {/* Edit Proof Request Modal */}
+      {isAddingExternalCredential && (
+        <ExternalCredentialRequestModal
+          isOpen={true}
+          onClose={() => setIsAddingExternalCredential(false)}
+          onSave={async (request) => {
+            try {
+              const updatedScenarios = showcase.scenarios.map((scenario) => {
+                if (scenario.id !== scenarioId) return scenario
+                return {
+                  ...scenario,
+                  screens: scenario.screens.map((scenarioScreen) => {
+                    if (scenarioScreen.screenId !== nextScreen?.screenId || !scenarioScreen.requestOptions) {
+                      return scenarioScreen
+                    }
+                    return {
+                      ...scenarioScreen,
+                      requestOptions: {
+                        ...scenarioScreen.requestOptions,
+                        requestedCredentials: [...scenarioScreen.requestOptions.requestedCredentials, request],
+                      },
+                    }
+                  }),
+                }
+              })
+              await updateShowcase(auth, showcase.name, { scenarios: updatedScenarios })
+              await onRefreshShowcase?.()
+              setIsAddingExternalCredential(false)
+            } catch (error) {
+              logger.error('Error adding external proof request:', error)
+            }
+          }}
+        />
+      )}
       {editingExternalIdx !== null && nextScreen?.requestOptions?.requestedCredentials?.[editingExternalIdx] && (
         <ExternalCredentialRequestModal
           isOpen={true}

--- a/frontend/src/admin/components/showcase/scenarios/ScenarioScreenRow.tsx
+++ b/frontend/src/admin/components/showcase/scenarios/ScenarioScreenRow.tsx
@@ -6,7 +6,7 @@ import { useAuth } from 'react-oidc-context'
 
 import { publicBaseUrl, updateShowcase } from '../../../api/adminApi'
 import { useHasRole } from '../../../hooks/useUserRole'
-import { isExternalCredentialRequest } from '../../../utils/externalCredentialRequest'
+import { isExternalCredentialRequest, toIdList } from '../../../utils/externalCredentialRequest'
 import { formatCustomDateStampValue } from '../../../utils/formatters'
 import logger from '../../../utils/logger'
 import { ScreenRowBase } from '../ScreenRowBase'
@@ -77,7 +77,7 @@ export function ScenarioScreenRow({
         try {
           const cred =
             showcase.credentials.find((c) => c.id === proofRequest.cred_id) ||
-            showcase.credentials.find((c) => c.schema_id === proofRequest.schema_id) ||
+            showcase.credentials.find((c) => c.schema_id && toIdList(proofRequest.schema_id).includes(c.schema_id)) ||
             null
 
           if (!cred) {
@@ -135,8 +135,8 @@ export function ScenarioScreenRow({
     const showcaseCredential = showcase.credentials.find(
       (c) =>
         (cred.cred_id && c.id === cred.cred_id) ||
-        (cred.schema_id && c.schema_id === cred.schema_id) ||
-        (cred.cred_def_id && c.cred_def_id === cred.cred_def_id),
+        (c.schema_id && toIdList(cred.schema_id).includes(c.schema_id)) ||
+        (c.cred_def_id && toIdList(cred.cred_def_id).includes(c.cred_def_id)),
     )
     return showcaseCredential ? showcaseCredential.name : cred.name
   }
@@ -327,10 +327,14 @@ export function ScenarioScreenRow({
                               )}
                             </div>
                             {cred.schema_id && (
-                              <p className="text-xs text-gray-500 mb-2 font-mono break-all">{cred.schema_id}</p>
+                              <p className="text-xs text-gray-500 mb-2 font-mono break-all">
+                                {toIdList(cred.schema_id).join(', ')}
+                              </p>
                             )}
                             {cred.cred_def_id && (
-                              <p className="text-xs text-gray-500 mb-2 font-mono break-all">{cred.cred_def_id}</p>
+                              <p className="text-xs text-gray-500 mb-2 font-mono break-all">
+                                {toIdList(cred.cred_def_id).join(', ')}
+                              </p>
                             )}
                             {cred.properties && cred.properties.length > 0 && (
                               <div className="text-xs space-y-1 ml-2">

--- a/frontend/src/admin/components/showcase/scenarios/ScenarioScreenRow.tsx
+++ b/frontend/src/admin/components/showcase/scenarios/ScenarioScreenRow.tsx
@@ -63,7 +63,6 @@ export function ScenarioScreenRow({
   const canEdit = useHasRole('creator')
   const [editingCredIdx, setEditingCredIdx] = useState<number | null>(null)
   const [editingExternalIdx, setEditingExternalIdx] = useState<number | null>(null)
-  const [isAddingExternalCredential, setIsAddingExternalCredential] = useState(false)
   const [selectedAttributes, setSelectedAttributes] = useState<Map<string, any>>(new Map())
   const [editingCredential, setEditingCredential] = useState<Credential | null>(null)
   const [isVerifierIconEditOpen, setIsVerifierIconEditOpen] = useState(false)
@@ -387,14 +386,6 @@ export function ScenarioScreenRow({
                       ))}
                     </div>
                   )}
-                {canEdit && (
-                  <button
-                    onClick={() => setIsAddingExternalCredential(true)}
-                    className="mt-3 w-full px-3 py-2 text-sm text-bcgov-blue border border-bcgov-blue rounded-lg hover:bg-blue-50"
-                  >
-                    Add external credential (advanced)
-                  </button>
-                )}
               </div>
             </div>
           ) : null
@@ -419,39 +410,6 @@ export function ScenarioScreenRow({
       />
 
       {/* Edit Proof Request Modal */}
-      {isAddingExternalCredential && (
-        <ExternalCredentialRequestModal
-          isOpen={true}
-          onClose={() => setIsAddingExternalCredential(false)}
-          onSave={async (request) => {
-            try {
-              const updatedScenarios = showcase.scenarios.map((scenario) => {
-                if (scenario.id !== scenarioId) return scenario
-                return {
-                  ...scenario,
-                  screens: scenario.screens.map((scenarioScreen) => {
-                    if (scenarioScreen.screenId !== nextScreen?.screenId || !scenarioScreen.requestOptions) {
-                      return scenarioScreen
-                    }
-                    return {
-                      ...scenarioScreen,
-                      requestOptions: {
-                        ...scenarioScreen.requestOptions,
-                        requestedCredentials: [...scenarioScreen.requestOptions.requestedCredentials, request],
-                      },
-                    }
-                  }),
-                }
-              })
-              await updateShowcase(auth, showcase.name, { scenarios: updatedScenarios })
-              await onRefreshShowcase?.()
-              setIsAddingExternalCredential(false)
-            } catch (error) {
-              logger.error('Error adding external proof request:', error)
-            }
-          }}
-        />
-      )}
       {editingExternalIdx !== null && nextScreen?.requestOptions?.requestedCredentials?.[editingExternalIdx] && (
         <ExternalCredentialRequestModal
           isOpen={true}

--- a/frontend/src/admin/components/showcase/scenarios/ScenarioScreenRow.tsx
+++ b/frontend/src/admin/components/showcase/scenarios/ScenarioScreenRow.tsx
@@ -6,12 +6,12 @@ import { useAuth } from 'react-oidc-context'
 
 import { publicBaseUrl, updateShowcase } from '../../../api/adminApi'
 import { useHasRole } from '../../../hooks/useUserRole'
-import { formatCustomDateStampValue } from '../../../utils/formatters'
 import { isExternalCredentialRequest } from '../../../utils/externalCredentialRequest'
+import { formatCustomDateStampValue } from '../../../utils/formatters'
 import logger from '../../../utils/logger'
 import { ScreenRowBase } from '../ScreenRowBase'
-import { ImageUploadModal } from '../modals/ImageUploadModal'
 import { ExternalCredentialRequestModal } from '../modals/ExternalCredentialRequestModal'
+import { ImageUploadModal } from '../modals/ImageUploadModal'
 import { SelectingAttributesStep } from '../modals/steps/SelectingAttributesStep'
 
 interface ScenarioScreenRowProps {

--- a/frontend/src/admin/components/showcase/scenarios/ScenarioScreenRow.tsx
+++ b/frontend/src/admin/components/showcase/scenarios/ScenarioScreenRow.tsx
@@ -7,9 +7,11 @@ import { useAuth } from 'react-oidc-context'
 import { publicBaseUrl, updateShowcase } from '../../../api/adminApi'
 import { useHasRole } from '../../../hooks/useUserRole'
 import { formatCustomDateStampValue } from '../../../utils/formatters'
+import { isExternalCredentialRequest } from '../../../utils/externalCredentialRequest'
 import logger from '../../../utils/logger'
 import { ScreenRowBase } from '../ScreenRowBase'
 import { ImageUploadModal } from '../modals/ImageUploadModal'
+import { ExternalCredentialRequestModal } from '../modals/ExternalCredentialRequestModal'
 import { SelectingAttributesStep } from '../modals/steps/SelectingAttributesStep'
 
 interface ScenarioScreenRowProps {
@@ -60,6 +62,7 @@ export function ScenarioScreenRow({
   const auth = useAuth()
   const canEdit = useHasRole('creator')
   const [editingCredIdx, setEditingCredIdx] = useState<number | null>(null)
+  const [editingExternalIdx, setEditingExternalIdx] = useState<number | null>(null)
   const [selectedAttributes, setSelectedAttributes] = useState<Map<string, any>>(new Map())
   const [editingCredential, setEditingCredential] = useState<Credential | null>(null)
   const [isVerifierIconEditOpen, setIsVerifierIconEditOpen] = useState(false)
@@ -77,7 +80,10 @@ export function ScenarioScreenRow({
             null
 
           if (!cred) {
-            logger.error('Credential not found for proof request', proofRequest)
+            if (isExternalCredentialRequest(proofRequest, showcase)) {
+              setEditingExternalIdx(editingCredIdx)
+              setEditingCredIdx(null)
+            }
             setEditingCredential(null)
             return
           }
@@ -313,9 +319,17 @@ export function ScenarioScreenRow({
                               <span className="text-sm font-medium text-bcgov-black">
                                 {getCredentialDisplayName(cred)}
                               </span>
+                              {isExternalCredentialRequest(cred, showcase) && (
+                                <span className="text-[10px] uppercase tracking-wide text-amber-800 bg-amber-100 px-1.5 py-0.5 rounded">
+                                  External
+                                </span>
+                              )}
                             </div>
                             {cred.schema_id && (
                               <p className="text-xs text-gray-500 mb-2 font-mono break-all">{cred.schema_id}</p>
+                            )}
+                            {cred.cred_def_id && (
+                              <p className="text-xs text-gray-500 mb-2 font-mono break-all">{cred.cred_def_id}</p>
                             )}
                             {cred.properties && cred.properties.length > 0 && (
                               <div className="text-xs space-y-1 ml-2">
@@ -389,6 +403,46 @@ export function ScenarioScreenRow({
       />
 
       {/* Edit Proof Request Modal */}
+      {editingExternalIdx !== null && nextScreen?.requestOptions?.requestedCredentials?.[editingExternalIdx] && (
+        <ExternalCredentialRequestModal
+          isOpen={true}
+          initialValue={nextScreen.requestOptions.requestedCredentials[editingExternalIdx]}
+          onClose={() => setEditingExternalIdx(null)}
+          onRequestIconUpload={() => {
+            setEditingCredentialIconIdx(editingExternalIdx)
+            setIsCredentialIconEditOpen(true)
+          }}
+          onSave={async (request) => {
+            try {
+              const updatedScenarios = showcase.scenarios.map((scenario) => {
+                if (scenario.id !== scenarioId) return scenario
+                return {
+                  ...scenario,
+                  screens: scenario.screens.map((scenarioScreen) => {
+                    if (scenarioScreen.screenId !== nextScreen?.screenId || !scenarioScreen.requestOptions) {
+                      return scenarioScreen
+                    }
+                    return {
+                      ...scenarioScreen,
+                      requestOptions: {
+                        ...scenarioScreen.requestOptions,
+                        requestedCredentials: scenarioScreen.requestOptions.requestedCredentials.map((cred, index) =>
+                          index === editingExternalIdx ? request : cred,
+                        ),
+                      },
+                    }
+                  }),
+                }
+              })
+              await updateShowcase(auth, showcase.name, { scenarios: updatedScenarios })
+              await onRefreshShowcase?.()
+              setEditingExternalIdx(null)
+            } catch (error) {
+              logger.error('Error updating external proof request:', error)
+            }
+          }}
+        />
+      )}
       {editingCredIdx !== null &&
         editingCredential &&
         nextScreen?.requestOptions?.requestedCredentials?.[editingCredIdx] && (

--- a/frontend/src/admin/components/showcase/scenarios/ScenarioScreenRow.tsx
+++ b/frontend/src/admin/components/showcase/scenarios/ScenarioScreenRow.tsx
@@ -78,6 +78,9 @@ export function ScenarioScreenRow({
           const cred =
             showcase.credentials.find((c) => c.id === proofRequest.cred_id) ||
             showcase.credentials.find((c) => c.schema_id && toIdList(proofRequest.schema_id).includes(c.schema_id)) ||
+            showcase.credentials.find(
+              (c) => c.cred_def_id && toIdList(proofRequest.cred_def_id).includes(c.cred_def_id),
+            ) ||
             null
 
           if (!cred) {

--- a/frontend/src/admin/types/index.ts
+++ b/frontend/src/admin/types/index.ts
@@ -45,8 +45,9 @@ export interface NonRevokedInterval {
 export interface CredentialRequest {
   name: string
   icon?: string
-  schema_id?: string
-  cred_def_id?: string
+  // A single value restricts to one schema/creddef; an array is an OR of alternatives
+  schema_id?: string | string[]
+  cred_def_id?: string | string[]
   cred_id?: string
   predicates?: Predicate[]
   properties?: string[]

--- a/frontend/src/admin/types/index.ts
+++ b/frontend/src/admin/types/index.ts
@@ -21,7 +21,7 @@ export interface IntroductionStep {
   credentials?: Credential[]
 }
 
-type DateIntMarker = `$dateint:${number}`
+export type DateIntMarker = `$dateint:${number}`
 
 export interface Predicate {
   name: string
@@ -37,6 +37,11 @@ export interface AttributeRequest {
   nonRevoked?: boolean
 }
 
+export interface NonRevokedInterval {
+  to: number | '$now'
+  from?: number | '$now'
+}
+
 export interface CredentialRequest {
   name: string
   icon?: string
@@ -45,7 +50,7 @@ export interface CredentialRequest {
   cred_id?: string
   predicates?: Predicate[]
   properties?: string[]
-  nonRevoked?: { to: number | '$now'; from?: number | '$now' }
+  nonRevoked?: NonRevokedInterval
 }
 
 export interface CustomRequestOptions {

--- a/frontend/src/admin/utils/__tests__/externalCredentialRequest.test.ts
+++ b/frontend/src/admin/utils/__tests__/externalCredentialRequest.test.ts
@@ -12,8 +12,11 @@ describe('external credential request parsing', () => {
 
     expect(result.errors).toEqual([])
     expect(result.value).toMatchObject({
+      schema_id: 'did:sov:example:2:university_degree:1.0',
       cred_def_id: 'did:sov:example:3:CL:12345:1.0',
-      properties: ['attribute_name'],
+      properties: ['degree', 'institution'],
+      predicates: [{ name: 'graduation_year', type: '>=', value: 2010 }],
+      nonRevoked: { to: '$now' },
     })
   })
 

--- a/frontend/src/admin/utils/__tests__/externalCredentialRequest.test.ts
+++ b/frontend/src/admin/utils/__tests__/externalCredentialRequest.test.ts
@@ -77,6 +77,10 @@ describe('external credential request parsing', () => {
       JSON.stringify({ schema_id: 'schema', cred_def_id: 'creddef', properties: ['name'] }),
     )
     expect(result.errors).toEqual([])
-    expect(result.warnings).toHaveLength(2)
+    expect(result.warnings).toEqual([
+      'schema_id does not match a recognized AnonCreds identifier format.',
+      'cred_def_id does not match a recognized AnonCreds identifier format.',
+      'schema_id and cred_def_id appear to use different issuer prefixes.',
+    ])
   })
 })

--- a/frontend/src/admin/utils/__tests__/externalCredentialRequest.test.ts
+++ b/frontend/src/admin/utils/__tests__/externalCredentialRequest.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  EXTERNAL_CREDENTIAL_JSON_TEMPLATE,
+  buildExternalCredentialRequest,
+  parseExternalCredentialJson,
+} from '../externalCredentialRequest'
+
+describe('external credential request parsing', () => {
+  it('accepts a valid credential definition request', () => {
+    const result = parseExternalCredentialJson(EXTERNAL_CREDENTIAL_JSON_TEMPLATE)
+
+    expect(result.errors).toEqual([])
+    expect(result.value).toMatchObject({
+      cred_def_id: 'did:sov:example:3:CL:12345:1.0',
+      properties: ['attribute_name'],
+    })
+  })
+
+  it('rejects invalid JSON and unsupported fields', () => {
+    expect(parseExternalCredentialJson('{').errors).toContain('Enter valid JSON.')
+    expect(parseExternalCredentialJson('{"name":"outside"}').errors).toContain(
+      '"name" is not supported here. Use the name and icon fields above.',
+    )
+  })
+
+  it('requires an identifier and an attribute or predicate', () => {
+    expect(parseExternalCredentialJson('{"properties":["name"]}').errors).toContain(
+      'Provide at least one of schema_id or cred_def_id.',
+    )
+    expect(parseExternalCredentialJson('{"cred_def_id":"abc"}').errors).toContain(
+      'Provide at least one property or predicate.',
+    )
+  })
+
+  it('validates properties, predicates, and non-revocation', () => {
+    const result = parseExternalCredentialJson(
+      JSON.stringify({
+        cred_def_id: 'abc',
+        properties: ['name', 'name'],
+        predicates: [{ name: 'age', type: '==', value: 18 }],
+        nonRevoked: { to: 'tomorrow' },
+      }),
+    )
+
+    expect(result.errors).toEqual(
+      expect.arrayContaining([
+        'properties must not contain duplicates.',
+        'predicates[0].type must be one of >=, >, <=, <.',
+        'nonRevoked.to must be a finite number or "$now".',
+      ]),
+    )
+  })
+
+  it('accepts date markers and emits non-empty request fields', () => {
+    const result = parseExternalCredentialJson(
+      JSON.stringify({
+        schema_id: 'did:sov:example:2:degree:1.0',
+        properties: ['name'],
+        predicates: [{ name: 'graduation_year', type: '>=', value: '$dateint:-5' }],
+        nonRevoked: { to: '$now' },
+      }),
+    )
+    expect(result.errors).toEqual([])
+    expect(buildExternalCredentialRequest('Degree', '/icon.svg', result.value!)).toEqual({
+      name: 'Degree',
+      icon: '/icon.svg',
+      schema_id: 'did:sov:example:2:degree:1.0',
+      properties: ['name'],
+      predicates: [{ name: 'graduation_year', type: '>=', value: '$dateint:-5' }],
+      nonRevoked: { to: '$now' },
+    })
+  })
+
+  it('reports identifier warnings without blocking a valid request', () => {
+    const result = parseExternalCredentialJson(
+      JSON.stringify({ schema_id: 'schema', cred_def_id: 'creddef', properties: ['name'] }),
+    )
+    expect(result.errors).toEqual([])
+    expect(result.warnings).toHaveLength(2)
+  })
+})

--- a/frontend/src/admin/utils/__tests__/externalCredentialRequest.test.ts
+++ b/frontend/src/admin/utils/__tests__/externalCredentialRequest.test.ts
@@ -86,4 +86,24 @@ describe('external credential request parsing', () => {
       'schema_id and cred_def_id appear to use different issuer prefixes.',
     ])
   })
+
+  it('accepts an array of cred_def_id alternatives to define an OR condition', () => {
+    const result = parseExternalCredentialJson(
+      JSON.stringify({
+        cred_def_id: ['did:sov:example:3:CL:111:1.0', 'did:sov:example:3:CL:222:1.0'],
+        properties: ['name'],
+      }),
+    )
+
+    expect(result.errors).toEqual([])
+    expect(result.value).toMatchObject({
+      cred_def_id: ['did:sov:example:3:CL:111:1.0', 'did:sov:example:3:CL:222:1.0'],
+    })
+  })
+
+  it('rejects an array containing an empty or non-string entry', () => {
+    const result = parseExternalCredentialJson(JSON.stringify({ cred_def_id: ['abc', ''], properties: ['name'] }))
+
+    expect(result.errors).toContain('cred_def_id must be a non-empty string or an array of non-empty strings.')
+  })
 })

--- a/frontend/src/admin/utils/__tests__/externalCredentialRequest.test.ts
+++ b/frontend/src/admin/utils/__tests__/externalCredentialRequest.test.ts
@@ -1,10 +1,23 @@
+import type { CredentialRequest, Showcase } from '../../types'
+
 import { describe, expect, it } from 'vitest'
 
 import {
   EXTERNAL_CREDENTIAL_JSON_TEMPLATE,
   buildExternalCredentialRequest,
+  isExternalCredentialRequest,
   parseExternalCredentialJson,
 } from '../externalCredentialRequest'
+
+const showcase: Showcase = {
+  name: 'Test showcase',
+  progressBar: [],
+  introduction: [],
+  scenarios: [],
+  credentials: [
+    { id: 'cred-1', name: 'Student Card', icon: '', version: '1.0', attributes: [], schema_id: 'schema-1' },
+  ],
+}
 
 describe('external credential request parsing', () => {
   it('accepts a valid credential definition request', () => {
@@ -105,5 +118,25 @@ describe('external credential request parsing', () => {
     const result = parseExternalCredentialJson(JSON.stringify({ cred_def_id: ['abc', ''], properties: ['name'] }))
 
     expect(result.errors).toContain('cred_def_id must be a non-empty string or an array of non-empty strings.')
+  })
+})
+
+describe('isExternalCredentialRequest', () => {
+  const request: CredentialRequest = { name: 'Student Card' }
+
+  it('returns false when the request matches a showcase credential by cred_id', () => {
+    expect(isExternalCredentialRequest({ ...request, cred_id: 'cred-1' }, showcase)).toBe(false)
+  })
+
+  it('returns false when the request matches a showcase credential by schema_id', () => {
+    expect(isExternalCredentialRequest({ ...request, schema_id: 'schema-1' }, showcase)).toBe(false)
+  })
+
+  it('returns true when cred_id is set but does not match any showcase credential', () => {
+    expect(isExternalCredentialRequest({ ...request, cred_id: 'stale-id' }, showcase)).toBe(true)
+  })
+
+  it('returns true when neither cred_id, schema_id, nor cred_def_id match', () => {
+    expect(isExternalCredentialRequest({ ...request, schema_id: 'unmatched-schema' }, showcase)).toBe(true)
   })
 })

--- a/frontend/src/admin/utils/__tests__/externalCredentialRequest.test.ts
+++ b/frontend/src/admin/utils/__tests__/externalCredentialRequest.test.ts
@@ -25,8 +25,8 @@ describe('external credential request parsing', () => {
 
     expect(result.errors).toEqual([])
     expect(result.value).toMatchObject({
-      schema_id: 'did:sov:example:2:university_degree:1.0',
-      cred_def_id: 'did:sov:example:3:CL:12345:1.0',
+      schema_id: ['did:sov:example:2:university_degree:1.0'],
+      cred_def_id: ['did:sov:example:3:CL:12345:1.0'],
       properties: ['degree', 'institution'],
       predicates: [{ name: 'graduation_year', type: '>=', value: 2010 }],
       nonRevoked: { to: '$now' },
@@ -71,7 +71,7 @@ describe('external credential request parsing', () => {
   it('accepts date markers and emits non-empty request fields', () => {
     const result = parseExternalCredentialJson(
       JSON.stringify({
-        schema_id: 'did:sov:example:2:degree:1.0',
+        schema_id: ['did:sov:example:2:degree:1.0'],
         properties: ['name'],
         predicates: [{ name: 'graduation_year', type: '>=', value: '$dateint:-5' }],
         nonRevoked: { to: '$now' },
@@ -81,7 +81,7 @@ describe('external credential request parsing', () => {
     expect(buildExternalCredentialRequest('Degree', '/icon.svg', result.value!)).toEqual({
       name: 'Degree',
       icon: '/icon.svg',
-      schema_id: 'did:sov:example:2:degree:1.0',
+      schema_id: ['did:sov:example:2:degree:1.0'],
       properties: ['name'],
       predicates: [{ name: 'graduation_year', type: '>=', value: '$dateint:-5' }],
       nonRevoked: { to: '$now' },

--- a/frontend/src/admin/utils/externalCredentialRequest.ts
+++ b/frontend/src/admin/utils/externalCredentialRequest.ts
@@ -36,6 +36,27 @@ const issuerPrefix = (value: string): string | undefined => {
 
 const isQualifiedIdentifier = (value: string): boolean => value.startsWith('did:')
 
+// Normalizes a single id or an OR-list of ids into an array
+export const toIdList = (value?: string | string[]): string[] => {
+  if (!value) return []
+  return Array.isArray(value) ? value : [value]
+}
+
+// Accepts a single identifier or an array of alternatives (OR); rejects any other shape
+const parseIdField = (value: unknown, fieldName: string, errors: string[]): string | string[] | undefined => {
+  if (value === undefined) return undefined
+  if (typeof value === 'string') {
+    const trimmed = value.trim()
+    if (!trimmed) errors.push(`${fieldName} must be a non-empty string.`)
+    return trimmed || undefined
+  }
+  if (Array.isArray(value) && value.length > 0 && value.every((entry) => typeof entry === 'string' && entry.trim())) {
+    return value.map((entry) => (entry as string).trim())
+  }
+  errors.push(`${fieldName} must be a non-empty string or an array of non-empty strings.`)
+  return undefined
+}
+
 export function parseExternalCredentialJson(raw: string): {
   value?: ExternalCredentialFields
   errors: string[]
@@ -57,19 +78,24 @@ export function parseExternalCredentialJson(raw: string): {
     if (!allowedKeys.has(key)) errors.push(`"${key}" is not supported here. Use the name and icon fields above.`)
   })
 
-  const schemaId = typeof parsed.schema_id === 'string' ? parsed.schema_id.trim() : undefined
-  const credDefId = typeof parsed.cred_def_id === 'string' ? parsed.cred_def_id.trim() : undefined
-  if (parsed.schema_id !== undefined && !schemaId) errors.push('schema_id must be a non-empty string.')
-  if (parsed.cred_def_id !== undefined && !credDefId) errors.push('cred_def_id must be a non-empty string.')
-  if (!schemaId && !credDefId) errors.push('Provide at least one of schema_id or cred_def_id.')
+  const schemaId = parseIdField(parsed.schema_id, 'schema_id', errors)
+  const credDefId = parseIdField(parsed.cred_def_id, 'cred_def_id', errors)
+  const schemaIds = toIdList(schemaId)
+  const credDefIds = toIdList(credDefId)
+  if (schemaIds.length === 0 && credDefIds.length === 0)
+    errors.push('Provide at least one of schema_id or cred_def_id.')
 
-  if (schemaId && !isQualifiedIdentifier(schemaId) && !/^.+:2:.+:.+$/.test(schemaId)) {
+  if (schemaIds.some((id) => !isQualifiedIdentifier(id) && !/^.+:2:.+:.+$/.test(id))) {
     warnings.push('schema_id does not match a recognized AnonCreds identifier format.')
   }
-  if (credDefId && !isQualifiedIdentifier(credDefId) && !/^.+:3:CL:.+:.+$/.test(credDefId)) {
+  if (credDefIds.some((id) => !isQualifiedIdentifier(id) && !/^.+:3:CL:.+:.+$/.test(id))) {
     warnings.push('cred_def_id does not match a recognized AnonCreds identifier format.')
   }
-  if (schemaId && credDefId && issuerPrefix(schemaId) !== issuerPrefix(credDefId)) {
+  if (
+    schemaIds.length > 0 &&
+    credDefIds.length > 0 &&
+    schemaIds.some((s) => credDefIds.some((c) => issuerPrefix(s) !== issuerPrefix(c)))
+  ) {
     warnings.push('schema_id and cred_def_id appear to use different issuer prefixes.')
   }
 
@@ -162,7 +188,7 @@ export function isExternalCredentialRequest(request: CredentialRequest, showcase
   if (request.cred_id) return false
   return !showcase.credentials.some(
     (credential) =>
-      (request.schema_id && credential.schema_id === request.schema_id) ||
-      (request.cred_def_id && credential.cred_def_id === request.cred_def_id),
+      (credential.schema_id && toIdList(request.schema_id).includes(credential.schema_id)) ||
+      (credential.cred_def_id && toIdList(request.cred_def_id).includes(credential.cred_def_id)),
   )
 }

--- a/frontend/src/admin/utils/externalCredentialRequest.ts
+++ b/frontend/src/admin/utils/externalCredentialRequest.ts
@@ -1,0 +1,150 @@
+import type { CredentialRequest, NonRevokedInterval, Predicate, Showcase } from '../types'
+
+export type ExternalCredentialFields = Pick<
+  CredentialRequest,
+  'schema_id' | 'cred_def_id' | 'properties' | 'predicates' | 'nonRevoked'
+>
+
+export const EXTERNAL_CREDENTIAL_JSON_TEMPLATE = JSON.stringify(
+  {
+    cred_def_id: 'did:sov:example:3:CL:12345:1.0',
+    properties: ['attribute_name'],
+  },
+  null,
+  2,
+)
+
+const predicateTypes = new Set(['>=', '>', '<=', '<'])
+const allowedKeys = new Set(['schema_id', 'cred_def_id', 'properties', 'predicates', 'nonRevoked'])
+
+const isObject = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+
+const isDateInt = (value: unknown): value is `$dateint:${number}` =>
+  typeof value === 'string' && /^\$dateint:-?\d+$/.test(value)
+
+const isDateOrNow = (value: unknown): value is number | '$now' =>
+  (typeof value === 'number' && Number.isFinite(value)) || value === '$now'
+
+const issuerPrefix = (value: string): string | undefined => {
+  if (value.startsWith('did:')) return value.split(':').slice(0, 3).join(':')
+  return value.split(':')[0]
+}
+
+const isQualifiedIdentifier = (value: string): boolean => value.startsWith('did:')
+
+export function parseExternalCredentialJson(raw: string): {
+  value?: ExternalCredentialFields
+  errors: string[]
+  warnings: string[]
+} {
+  const errors: string[] = []
+  const warnings: string[] = []
+  let parsed: unknown
+
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    return { errors: ['Enter valid JSON.'], warnings: [] }
+  }
+
+  if (!isObject(parsed)) return { errors: ['The JSON value must be an object.'], warnings: [] }
+
+  Object.keys(parsed).forEach((key) => {
+    if (!allowedKeys.has(key)) errors.push(`"${key}" is not supported here. Use the name and icon fields above.`)
+  })
+
+  const schemaId = typeof parsed.schema_id === 'string' ? parsed.schema_id.trim() : undefined
+  const credDefId = typeof parsed.cred_def_id === 'string' ? parsed.cred_def_id.trim() : undefined
+  if (parsed.schema_id !== undefined && !schemaId) errors.push('schema_id must be a non-empty string.')
+  if (parsed.cred_def_id !== undefined && !credDefId) errors.push('cred_def_id must be a non-empty string.')
+  if (!schemaId && !credDefId) errors.push('Provide at least one of schema_id or cred_def_id.')
+
+  if (schemaId && !isQualifiedIdentifier(schemaId) && !/^.+:2:.+:.+$/.test(schemaId)) {
+    warnings.push('schema_id does not match a recognized AnonCreds identifier format.')
+  }
+  if (credDefId && !isQualifiedIdentifier(credDefId) && !/^.+:3:CL:.+:.+$/.test(credDefId)) {
+    warnings.push('cred_def_id does not match a recognized AnonCreds identifier format.')
+  }
+  if (schemaId && credDefId && issuerPrefix(schemaId) !== issuerPrefix(credDefId)) {
+    warnings.push('schema_id and cred_def_id appear to use different issuer prefixes.')
+  }
+
+  let properties: string[] | undefined
+  if (parsed.properties !== undefined) {
+    if (!Array.isArray(parsed.properties) || parsed.properties.some((property) => typeof property !== 'string' || !property.trim())) {
+      errors.push('properties must be an array of non-empty strings.')
+    } else {
+      properties = parsed.properties.map((property) => property.trim())
+      if (new Set(properties).size !== properties.length) errors.push('properties must not contain duplicates.')
+    }
+  }
+
+  let predicates: Predicate[] | undefined
+  if (parsed.predicates !== undefined) {
+    if (!Array.isArray(parsed.predicates)) {
+      errors.push('predicates must be an array.')
+    } else {
+      predicates = []
+      parsed.predicates.forEach((predicate, index) => {
+        if (!isObject(predicate) || typeof predicate.name !== 'string' || !predicate.name.trim()) {
+          errors.push(`predicates[${index}].name must be a non-empty string.`)
+          return
+        }
+        if (typeof predicate.type !== 'string' || !predicateTypes.has(predicate.type)) {
+          errors.push(`predicates[${index}].type must be one of >=, >, <=, <.`)
+          return
+        }
+        if (!((typeof predicate.value === 'number' && Number.isFinite(predicate.value)) || isDateInt(predicate.value))) {
+          errors.push(`predicates[${index}].value must be a number or $dateint marker.`)
+          return
+        }
+        predicates.push({ name: predicate.name.trim(), type: predicate.type, value: predicate.value })
+      })
+    }
+  }
+
+  let nonRevoked: NonRevokedInterval | undefined
+  if (parsed.nonRevoked !== undefined) {
+    if (!isObject(parsed.nonRevoked) || !isDateOrNow(parsed.nonRevoked.to)) {
+      errors.push('nonRevoked.to must be a finite number or "$now".')
+    } else if (parsed.nonRevoked.from !== undefined && !isDateOrNow(parsed.nonRevoked.from)) {
+      errors.push('nonRevoked.from must be a finite number or "$now".')
+    } else {
+      nonRevoked = { to: parsed.nonRevoked.to }
+      if (parsed.nonRevoked.from !== undefined) nonRevoked.from = parsed.nonRevoked.from
+    }
+  }
+
+  if ((!properties || properties.length === 0) && (!predicates || predicates.length === 0)) {
+    errors.push('Provide at least one property or predicate.')
+  }
+
+  if (errors.length > 0) return { errors, warnings }
+  return { value: { schema_id: schemaId, cred_def_id: credDefId, properties, predicates, nonRevoked }, errors, warnings }
+}
+
+export function buildExternalCredentialRequest(
+  name: string,
+  icon: string | undefined,
+  fields: ExternalCredentialFields,
+): CredentialRequest {
+  return {
+    name: name.trim(),
+    ...(icon ? { icon } : {}),
+    ...(fields.schema_id ? { schema_id: fields.schema_id } : {}),
+    ...(fields.cred_def_id ? { cred_def_id: fields.cred_def_id } : {}),
+    ...(fields.properties?.length ? { properties: fields.properties } : {}),
+    ...(fields.predicates?.length ? { predicates: fields.predicates } : {}),
+    ...(fields.nonRevoked ? { nonRevoked: fields.nonRevoked } : {}),
+  }
+}
+
+export function isExternalCredentialRequest(request: CredentialRequest, showcase: Showcase): boolean {
+  if (request.cred_id) return false
+  return !showcase.credentials.some(
+    (credential) =>
+      (request.schema_id && credential.schema_id === request.schema_id) ||
+      (request.cred_def_id && credential.cred_def_id === request.cred_def_id),
+  )
+}

--- a/frontend/src/admin/utils/externalCredentialRequest.ts
+++ b/frontend/src/admin/utils/externalCredentialRequest.ts
@@ -185,10 +185,10 @@ export function buildExternalCredentialRequest(
 }
 
 export function isExternalCredentialRequest(request: CredentialRequest, showcase: Showcase): boolean {
-  if (request.cred_id) return false
   return !showcase.credentials.some(
     (credential) =>
-      (credential.schema_id && toIdList(request.schema_id).includes(credential.schema_id)) ||
-      (credential.cred_def_id && toIdList(request.cred_def_id).includes(credential.cred_def_id)),
+      (!!request.cred_id && credential.id === request.cred_id) ||
+      (!!credential.schema_id && toIdList(request.schema_id).includes(credential.schema_id)) ||
+      (!!credential.cred_def_id && toIdList(request.cred_def_id).includes(credential.cred_def_id)),
   )
 }

--- a/frontend/src/admin/utils/externalCredentialRequest.ts
+++ b/frontend/src/admin/utils/externalCredentialRequest.ts
@@ -7,8 +7,8 @@ export type ExternalCredentialFields = Pick<
 
 export const EXTERNAL_CREDENTIAL_JSON_TEMPLATE = JSON.stringify(
   {
-    schema_id: 'did:sov:example:2:university_degree:1.0',
-    cred_def_id: 'did:sov:example:3:CL:12345:1.0',
+    schema_id: ['did:sov:example:2:university_degree:1.0'],
+    cred_def_id: ['did:sov:example:3:CL:12345:1.0'],
     properties: ['degree', 'institution'],
     predicates: [{ name: 'graduation_year', type: '>=', value: 2010 }],
     nonRevoked: { to: '$now' },

--- a/frontend/src/admin/utils/externalCredentialRequest.ts
+++ b/frontend/src/admin/utils/externalCredentialRequest.ts
@@ -72,7 +72,10 @@ export function parseExternalCredentialJson(raw: string): {
 
   let properties: string[] | undefined
   if (parsed.properties !== undefined) {
-    if (!Array.isArray(parsed.properties) || parsed.properties.some((property) => typeof property !== 'string' || !property.trim())) {
+    if (
+      !Array.isArray(parsed.properties) ||
+      parsed.properties.some((property) => typeof property !== 'string' || !property.trim())
+    ) {
       errors.push('properties must be an array of non-empty strings.')
     } else {
       properties = parsed.properties.map((property) => property.trim())
@@ -95,7 +98,10 @@ export function parseExternalCredentialJson(raw: string): {
           errors.push(`predicates[${index}].type must be one of >=, >, <=, <.`)
           return
         }
-        if (!((typeof predicate.value === 'number' && Number.isFinite(predicate.value)) || isDateInt(predicate.value))) {
+        if (!(
+          (typeof predicate.value === 'number' && Number.isFinite(predicate.value)) ||
+          isDateInt(predicate.value)
+        )) {
           errors.push(`predicates[${index}].value must be a number or $dateint marker.`)
           return
         }
@@ -121,7 +127,11 @@ export function parseExternalCredentialJson(raw: string): {
   }
 
   if (errors.length > 0) return { errors, warnings }
-  return { value: { schema_id: schemaId, cred_def_id: credDefId, properties, predicates, nonRevoked }, errors, warnings }
+  return {
+    value: { schema_id: schemaId, cred_def_id: credDefId, properties, predicates, nonRevoked },
+    errors,
+    warnings,
+  }
 }
 
 export function buildExternalCredentialRequest(

--- a/frontend/src/admin/utils/externalCredentialRequest.ts
+++ b/frontend/src/admin/utils/externalCredentialRequest.ts
@@ -86,12 +86,11 @@ export function parseExternalCredentialJson(raw: string): {
     }
   }
 
-  let predicates: Predicate[] | undefined
+  const predicates: Predicate[] = []
   if (parsed.predicates !== undefined) {
     if (!Array.isArray(parsed.predicates)) {
       errors.push('predicates must be an array.')
     } else {
-      predicates = []
       parsed.predicates.forEach((predicate, index) => {
         if (!isObject(predicate) || typeof predicate.name !== 'string' || !predicate.name.trim()) {
           errors.push(`predicates[${index}].name must be a non-empty string.`)
@@ -131,7 +130,13 @@ export function parseExternalCredentialJson(raw: string): {
 
   if (errors.length > 0) return { errors, warnings }
   return {
-    value: { schema_id: schemaId, cred_def_id: credDefId, properties, predicates, nonRevoked },
+    value: {
+      schema_id: schemaId,
+      cred_def_id: credDefId,
+      properties,
+      predicates: predicates.length > 0 ? predicates : undefined,
+      nonRevoked,
+    },
     errors,
     warnings,
   }

--- a/frontend/src/admin/utils/externalCredentialRequest.ts
+++ b/frontend/src/admin/utils/externalCredentialRequest.ts
@@ -7,8 +7,11 @@ export type ExternalCredentialFields = Pick<
 
 export const EXTERNAL_CREDENTIAL_JSON_TEMPLATE = JSON.stringify(
   {
+    schema_id: 'did:sov:example:2:university_degree:1.0',
     cred_def_id: 'did:sov:example:3:CL:12345:1.0',
-    properties: ['attribute_name'],
+    properties: ['degree', 'institution'],
+    predicates: [{ name: 'graduation_year', type: '>=', value: 2010 }],
+    nonRevoked: { to: '$now' },
   },
   null,
   2,

--- a/frontend/src/admin/utils/publicAssetUrl.ts
+++ b/frontend/src/admin/utils/publicAssetUrl.ts
@@ -1,0 +1,14 @@
+import { publicBaseUrl } from '../api/adminApi'
+
+export function getPublicAssetUrl(assetPath?: string): string | undefined {
+  if (!assetPath) return undefined
+
+  const hasControlCharacter = Array.from(assetPath).some((character) => {
+    const codePoint = character.charCodeAt(0)
+    return codePoint <= 31 || codePoint === 127
+  })
+  if (hasControlCharacter) return undefined
+
+  const normalizedPath = assetPath.startsWith('/') ? assetPath : `/${assetPath}`
+  return `${publicBaseUrl}${encodeURI(normalizedPath)}`
+}

--- a/frontend/src/client/pages/dashboard/components/ScenarioContainer.tsx
+++ b/frontend/src/client/pages/dashboard/components/ScenarioContainer.tsx
@@ -6,6 +6,7 @@ import { useNavigate } from 'react-router-dom'
 
 import { dashboardTitle, rowContainer } from '../../../FramerAnimations'
 import { basePath } from '../../../utils/BasePath'
+import { toIdList } from '../../../utils/proofRequest'
 
 import { ScenarioItem } from './ScenarioItem'
 
@@ -30,8 +31,8 @@ export const ScenarioContainer: React.FC<Props> = ({ currentShowcase, completedS
         const actualCredential = currentShowcase.credentials.find(
           (c) =>
             c.id === cred.cred_id ||
-            c.schema_id === cred.schema_id ||
-            c.cred_def_id === cred.cred_def_id ||
+            (!!c.schema_id && toIdList(cred.schema_id).includes(c.schema_id)) ||
+            (!!c.cred_def_id && toIdList(cred.cred_def_id).includes(c.cred_def_id)) ||
             c.name === cred.name,
         )
         if (!requiredCredentials.includes(cred.name)) {

--- a/frontend/src/client/pages/preview/ScenarioPreviewPage.tsx
+++ b/frontend/src/client/pages/preview/ScenarioPreviewPage.tsx
@@ -6,6 +6,7 @@ import { dashboardTitle, page, rowContainer } from '../../FramerAnimations'
 import { useAppDispatch } from '../../hooks/hooks'
 import { useShowcases } from '../../slices/showcases/showcasesSelectors'
 import { fetchAllShowcases } from '../../slices/showcases/showcasesThunks'
+import { toIdList } from '../../utils/proofRequest'
 import { ProfileCard } from '../dashboard/components/ProfileCard'
 import { ScenarioItem } from '../dashboard/components/ScenarioItem'
 import { NavBar } from '../landing/components/Navbar'
@@ -43,8 +44,8 @@ export const ScenarioPreviewPage: React.FC = () => {
         const actualCredential = previewShowcase.credentials.find(
           (c) =>
             c.id === cred.cred_id ||
-            c.schema_id === cred.schema_id ||
-            c.cred_def_id === cred.cred_def_id ||
+            (!!c.schema_id && toIdList(cred.schema_id).includes(c.schema_id)) ||
+            (!!c.cred_def_id && toIdList(cred.cred_def_id).includes(c.cred_def_id)) ||
             c.name === cred.name,
         )
         const credentialName = actualCredential?.name ?? cred.name

--- a/frontend/src/client/pages/scenario/Section.tsx
+++ b/frontend/src/client/pages/scenario/Section.tsx
@@ -18,6 +18,7 @@ import { nextStep, prevStep, resetStep } from '../../slices/scenarios/scenariosS
 import { useCurrentShowcase } from '../../slices/showcases/showcasesSelectors'
 import { basePath } from '../../utils/BasePath'
 import { isConnected, isCredIssued } from '../../utils/Helpers'
+import { toIdList } from '../../utils/proofRequest'
 
 import { SideView } from './SideView'
 import { EndContainer } from './components/EndContainer'
@@ -87,8 +88,8 @@ export const Section: React.FC<Props> = ({
       const showcaseCredential = currentShowcase.credentials.find(
         (c) =>
           (cred.cred_id && c.id === cred.cred_id) ||
-          (cred.schema_id && c.schema_id === cred.schema_id) ||
-          (cred.cred_def_id && c.cred_def_id === cred.cred_def_id),
+          (c.schema_id && toIdList(cred.schema_id).includes(c.schema_id)) ||
+          (c.cred_def_id && toIdList(cred.cred_def_id).includes(c.cred_def_id)),
       )
       return showcaseCredential ? { ...cred, name: showcaseCredential.name } : cred
     })

--- a/frontend/src/client/pages/scenario/SideView.tsx
+++ b/frontend/src/client/pages/scenario/SideView.tsx
@@ -6,6 +6,7 @@ import { isMobile } from 'react-device-detect'
 import { FiLogOut } from 'react-icons/fi'
 
 import { fadeDelay } from '../../FramerAnimations'
+import { toIdList } from '../../utils/proofRequest'
 
 import { ConnectionCard } from './components/ConnectionCard'
 import { ProofCard } from './components/ProofCard'
@@ -28,8 +29,8 @@ export const SideView: React.FC<Props> = ({ steps, currentStep, entity, showLeav
         const showcaseCredential = currentShowcase?.credentials.find(
           (c) =>
             (cred.cred_id && c.id === cred.cred_id) ||
-            (cred.schema_id && c.schema_id === cred.schema_id) ||
-            (cred.cred_def_id && c.cred_def_id === cred.cred_def_id),
+            (c.schema_id && toIdList(cred.schema_id).includes(c.schema_id)) ||
+            (c.cred_def_id && toIdList(cred.cred_def_id).includes(c.cred_def_id)),
         )
         return showcaseCredential ? { ...cred, name: showcaseCredential.name } : cred
       })

--- a/frontend/src/client/pages/scenario/steps/StepProof.tsx
+++ b/frontend/src/client/pages/scenario/steps/StepProof.tsx
@@ -2,7 +2,6 @@ import type {
   CredentialRequest,
   ProofAttributeRequest,
   ProofPredicateRequest,
-  ProofRestriction,
   ScenarioScreen,
   Showcase,
 } from '../../../slices/types'
@@ -18,6 +17,7 @@ import { useConnection } from '../../../slices/connection/connectionSelectors'
 import { createProof, deleteProofById, createDeepProof, fetchProofById } from '../../../slices/proof/proofThunks'
 import { useSocket } from '../../../slices/socket/socketSelector'
 import log from '../../../utils/logger'
+import { buildRestrictions } from '../../../utils/proofRequest'
 import { FailedRequestModal } from '../../introduction/components/FailedRequestModal'
 import { ProofAttributesCard } from '../components/ProofAttributesCard'
 import { StepInfo } from '../components/StepInfo'
@@ -109,14 +109,7 @@ export const StepProof: React.FC<Props> = ({
     const predicates: Record<string, ProofPredicateRequest> = {}
 
     requestedCredentials?.forEach((item) => {
-      const restriction: ProofRestriction = {}
-      if (item.schema_id) {
-        restriction.schema_id = item.schema_id
-      }
-      if (item.cred_def_id) {
-        restriction.cred_def_id = item.cred_def_id
-      }
-      const restrictions: ProofRestriction[] = [restriction]
+      const restrictions = buildRestrictions(item)
       if (item.properties?.length) {
         proofs[item.name] = {
           restrictions,

--- a/frontend/src/client/pages/scenario/steps/StepProof.tsx
+++ b/frontend/src/client/pages/scenario/steps/StepProof.tsx
@@ -17,7 +17,7 @@ import { useConnection } from '../../../slices/connection/connectionSelectors'
 import { createProof, deleteProofById, createDeepProof, fetchProofById } from '../../../slices/proof/proofThunks'
 import { useSocket } from '../../../slices/socket/socketSelector'
 import log from '../../../utils/logger'
-import { buildRestrictions } from '../../../utils/proofRequest'
+import { buildRestrictions, toIdList } from '../../../utils/proofRequest'
 import { FailedRequestModal } from '../../introduction/components/FailedRequestModal'
 import { ProofAttributesCard } from '../components/ProofAttributesCard'
 import { StepInfo } from '../components/StepInfo'
@@ -90,8 +90,8 @@ export const StepProof: React.FC<Props> = ({
     const showcaseCredential = currentShowcase?.credentials.find(
       (c) =>
         (cred.cred_id && c.id === cred.cred_id) ||
-        (cred.schema_id && c.schema_id === cred.schema_id) ||
-        (cred.cred_def_id && c.cred_def_id === cred.cred_def_id),
+        (c.schema_id && toIdList(cred.schema_id).includes(c.schema_id)) ||
+        (c.cred_def_id && toIdList(cred.cred_def_id).includes(c.cred_def_id)),
     )
     return showcaseCredential ? { ...cred, name: showcaseCredential.name } : cred
   })

--- a/frontend/src/client/pages/scenario/steps/StepProofOOB.tsx
+++ b/frontend/src/client/pages/scenario/steps/StepProofOOB.tsx
@@ -2,7 +2,6 @@ import type {
   CredentialRequest,
   ProofAttributeRequest,
   ProofPredicateRequest,
-  ProofRestriction,
   ScenarioScreen,
 } from '../../../slices/types'
 
@@ -18,6 +17,7 @@ import { useProof } from '../../../slices/proof/proofSelectors'
 import { createProofOOB, deleteProofById, fetchProofById } from '../../../slices/proof/proofThunks'
 import { useSocket } from '../../../slices/socket/socketSelector'
 import log from '../../../utils/logger'
+import { buildRestrictions } from '../../../utils/proofRequest'
 import { ProofAttributesCard } from '../components/ProofAttributesCard'
 import { StepInfo } from '../components/StepInfo'
 
@@ -69,10 +69,7 @@ export const StepProofOOB: React.FC<Props> = ({ proof, step, requestedCredential
       const predicates: Record<string, ProofPredicateRequest> = {}
 
       requestedCredentials?.forEach((item) => {
-        const restriction: ProofRestriction = { schema_name: item.name }
-        if (item.schema_id) restriction.schema_id = item.schema_id
-        if (item.cred_def_id) restriction.cred_def_id = item.cred_def_id
-        const restrictions: ProofRestriction[] = [restriction]
+        const restrictions = buildRestrictions(item)
         if (item.properties?.length) {
           proofs[item.name] = {
             restrictions,

--- a/frontend/src/client/slices/types.ts
+++ b/frontend/src/client/slices/types.ts
@@ -72,9 +72,10 @@ export interface Predicate {
 export interface CredentialRequest {
   name: string
   icon?: string
-  schema_id?: string
+  // A single value restricts to one schema/creddef; an array is an OR of alternatives
+  schema_id?: string | string[]
   schema_version?: string
-  cred_def_id?: string
+  cred_def_id?: string | string[]
   predicates?: Predicate[]
   properties?: string[]
   nonRevoked?: { to: number | '$now'; from?: number | '$now' }

--- a/frontend/src/client/utils/__tests__/proofRequest.test.ts
+++ b/frontend/src/client/utils/__tests__/proofRequest.test.ts
@@ -1,0 +1,50 @@
+import type { CredentialRequest } from '../../slices/types'
+
+import { describe, expect, it } from 'vitest'
+
+import { buildRestrictions, toIdList } from '../proofRequest'
+
+describe('toIdList', () => {
+  it('returns an empty array for undefined', () => {
+    expect(toIdList(undefined)).toEqual([])
+  })
+
+  it('wraps a single string in an array', () => {
+    expect(toIdList('abc')).toEqual(['abc'])
+  })
+
+  it('passes an array through, filtering out empty entries', () => {
+    expect(toIdList(['a', '', 'b'])).toEqual(['a', 'b'])
+  })
+})
+
+describe('buildRestrictions', () => {
+  const base: CredentialRequest = { name: 'Card' }
+
+  it('builds a single restriction from a legacy scalar schema_id', () => {
+    expect(buildRestrictions({ ...base, schema_id: 'schema-1' })).toEqual([{ schema_id: 'schema-1' }])
+  })
+
+  it('builds a single restriction from a legacy scalar cred_def_id', () => {
+    expect(buildRestrictions({ ...base, cred_def_id: 'creddef-1' })).toEqual([{ cred_def_id: 'creddef-1' }])
+  })
+
+  it('builds one restriction per entry for an array cred_def_id (OR)', () => {
+    expect(buildRestrictions({ ...base, cred_def_id: ['creddef-1', 'creddef-2'] })).toEqual([
+      { cred_def_id: 'creddef-1' },
+      { cred_def_id: 'creddef-2' },
+    ])
+  })
+
+  it('concatenates schema_id and cred_def_id entries into a union of restrictions', () => {
+    expect(buildRestrictions({ ...base, schema_id: ['schema-1', 'schema-2'], cred_def_id: 'creddef-1' })).toEqual([
+      { schema_id: 'schema-1' },
+      { schema_id: 'schema-2' },
+      { cred_def_id: 'creddef-1' },
+    ])
+  })
+
+  it('falls back to schema_name when neither identifier is present', () => {
+    expect(buildRestrictions(base)).toEqual([{ schema_name: 'Card' }])
+  })
+})

--- a/frontend/src/client/utils/__tests__/proofRequest.test.ts
+++ b/frontend/src/client/utils/__tests__/proofRequest.test.ts
@@ -36,11 +36,10 @@ describe('buildRestrictions', () => {
     ])
   })
 
-  it('concatenates schema_id and cred_def_id entries into a union of restrictions', () => {
+  it('combines schema_id and cred_def_id entries into a cartesian product of restrictions', () => {
     expect(buildRestrictions({ ...base, schema_id: ['schema-1', 'schema-2'], cred_def_id: 'creddef-1' })).toEqual([
-      { schema_id: 'schema-1' },
-      { schema_id: 'schema-2' },
-      { cred_def_id: 'creddef-1' },
+      { schema_id: 'schema-1', cred_def_id: 'creddef-1' },
+      { schema_id: 'schema-2', cred_def_id: 'creddef-1' },
     ])
   })
 

--- a/frontend/src/client/utils/proofRequest.ts
+++ b/frontend/src/client/utils/proofRequest.ts
@@ -1,9 +1,15 @@
 import type { CredentialRequest, ProofRestriction } from '../slices/types'
 
+// Normalizes a single id or an OR-list of ids into an array
+export function toIdList(value?: string | string[]): string[] {
+  if (!value) return []
+  return (Array.isArray(value) ? value : [value]).filter((entry) => !!entry)
+}
+
 export function buildRestrictions(item: CredentialRequest): ProofRestriction[] {
-  const restriction: ProofRestriction = {}
-  if (item.schema_id) restriction.schema_id = item.schema_id
-  if (item.cred_def_id) restriction.cred_def_id = item.cred_def_id
-  if (!item.schema_id && !item.cred_def_id) restriction.schema_name = item.name
-  return [restriction]
+  const restrictions = [
+    ...toIdList(item.schema_id).map((schema_id) => ({ schema_id })),
+    ...toIdList(item.cred_def_id).map((cred_def_id) => ({ cred_def_id })),
+  ]
+  return restrictions.length > 0 ? restrictions : [{ schema_name: item.name }]
 }

--- a/frontend/src/client/utils/proofRequest.ts
+++ b/frontend/src/client/utils/proofRequest.ts
@@ -1,5 +1,4 @@
-import type { CredentialRequest } from '../slices/types'
-import type { ProofRestriction } from '../slices/types'
+import type { CredentialRequest, ProofRestriction } from '../slices/types'
 
 export function buildRestrictions(item: CredentialRequest): ProofRestriction[] {
   const restriction: ProofRestriction = {}

--- a/frontend/src/client/utils/proofRequest.ts
+++ b/frontend/src/client/utils/proofRequest.ts
@@ -1,0 +1,10 @@
+import type { CredentialRequest } from '../slices/types'
+import type { ProofRestriction } from '../slices/types'
+
+export function buildRestrictions(item: CredentialRequest): ProofRestriction[] {
+  const restriction: ProofRestriction = {}
+  if (item.schema_id) restriction.schema_id = item.schema_id
+  if (item.cred_def_id) restriction.cred_def_id = item.cred_def_id
+  if (!item.schema_id && !item.cred_def_id) restriction.schema_name = item.name
+  return [restriction]
+}

--- a/frontend/src/client/utils/proofRequest.ts
+++ b/frontend/src/client/utils/proofRequest.ts
@@ -7,9 +7,11 @@ export function toIdList(value?: string | string[]): string[] {
 }
 
 export function buildRestrictions(item: CredentialRequest): ProofRestriction[] {
-  const restrictions = [
-    ...toIdList(item.schema_id).map((schema_id) => ({ schema_id })),
-    ...toIdList(item.cred_def_id).map((cred_def_id) => ({ cred_def_id })),
-  ]
+  const schemaIds = toIdList(item.schema_id)
+  const credDefIds = toIdList(item.cred_def_id)
+  const restrictions =
+    schemaIds.length > 0 && credDefIds.length > 0
+      ? schemaIds.flatMap((schema_id) => credDefIds.map((cred_def_id) => ({ schema_id, cred_def_id })))
+      : [...schemaIds.map((schema_id) => ({ schema_id })), ...credDefIds.map((cred_def_id) => ({ cred_def_id }))]
   return restrictions.length > 0 ? restrictions : [{ schema_name: item.name }]
 }

--- a/server/migrations/003-add-restrictions-to-presentations.ts
+++ b/server/migrations/003-add-restrictions-to-presentations.ts
@@ -12,6 +12,7 @@ export async function up() {
         for (const screen of scenario.screens || []) {
           if (screen.requestOptions?.requestedCredentials) {
             for (const requestedCredential of screen.requestOptions.requestedCredentials) {
+              if (requestedCredential.schema_id || requestedCredential.cred_def_id) continue
               // Look up the credential by name
               const credential = await CredentialModel.findOne({ name: requestedCredential.name })
               if (credential?.schema_id) {

--- a/server/src/content/types.ts
+++ b/server/src/content/types.ts
@@ -69,8 +69,9 @@ export interface Predicate {
 export interface CredentialRequest {
   name: string
   icon?: string
-  schema_id?: string
-  cred_def_id?: string
+  // A single value restricts to one schema/creddef; an array is an OR of alternatives
+  schema_id?: string | string[]
+  cred_def_id?: string | string[]
   cred_id?: string
   predicates?: Predicate[]
   properties?: string[]

--- a/server/src/db/__tests__/Scenario.test.ts
+++ b/server/src/db/__tests__/Scenario.test.ts
@@ -150,7 +150,7 @@ describe('CredentialRequestSchema', () => {
     expect(cred.cred_def_id).toEqual(['abc:2:3:4:tag'])
   })
 
-  it('rejects an array containing a non-string entry for schema_id', async () => {
+  it('rejects an array containing an empty string entry for schema_id', async () => {
     await expect(
       HostModel.create({
         scenarios: [
@@ -166,6 +166,36 @@ describe('CredentialRequestSchema', () => {
                   name: 'T',
                   text: 'X',
                   requestedCredentials: [{ name: 'Bad', schema_id: ['abc', ''] }],
+                },
+              },
+            ],
+          },
+        ],
+      }),
+    ).rejects.toThrow()
+  })
+
+  it.each([
+    ['an empty schema_id array', { schema_id: [] }],
+    ['an empty cred_def_id array', { cred_def_id: [] }],
+    ['a whitespace-only schema_id', { schema_id: '   ' }],
+    ['a whitespace-only cred_def_id', { cred_def_id: ['  '] }],
+  ])('rejects %s', async (_description, identifier) => {
+    await expect(
+      HostModel.create({
+        scenarios: [
+          {
+            id: 'invalid-identifier',
+            name: 'Invalid identifier',
+            screens: [
+              {
+                screenId: 'PROOF',
+                name: 'T',
+                text: 'X',
+                requestOptions: {
+                  name: 'T',
+                  text: 'X',
+                  requestedCredentials: [{ name: 'Bad', ...identifier }],
                 },
               },
             ],

--- a/server/src/db/__tests__/Scenario.test.ts
+++ b/server/src/db/__tests__/Scenario.test.ts
@@ -117,4 +117,61 @@ describe('CredentialRequestSchema', () => {
       }),
     ).rejects.toThrow()
   })
+
+  it('persists an array of schema_id/cred_def_id alternatives to express an OR condition', async () => {
+    const doc = await HostModel.create({
+      scenarios: [
+        {
+          id: 'uc4',
+          name: 'UC4',
+          screens: [
+            {
+              screenId: 'PROOF',
+              name: 'T',
+              text: 'X',
+              requestOptions: {
+                name: 'Needed',
+                text: 'Provide the following',
+                requestedCredentials: [
+                  {
+                    name: 'Driver Licence',
+                    schema_id: ['abc:1:2:3', 'abc:1:2:4'],
+                    cred_def_id: ['abc:2:3:4:tag'],
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      ],
+    })
+    const cred = doc.toJSON().scenarios[0].screens[0].requestOptions.requestedCredentials[0]
+    expect(cred.schema_id).toEqual(['abc:1:2:3', 'abc:1:2:4'])
+    expect(cred.cred_def_id).toEqual(['abc:2:3:4:tag'])
+  })
+
+  it('rejects an array containing a non-string entry for schema_id', async () => {
+    await expect(
+      HostModel.create({
+        scenarios: [
+          {
+            id: 'uc5',
+            name: 'UC5',
+            screens: [
+              {
+                screenId: 'PROOF',
+                name: 'T',
+                text: 'X',
+                requestOptions: {
+                  name: 'T',
+                  text: 'X',
+                  requestedCredentials: [{ name: 'Bad', schema_id: ['abc', ''] }],
+                },
+              },
+            ],
+          },
+        ],
+      }),
+    ).rejects.toThrow()
+  })
 })

--- a/server/src/db/models/Scenario.ts
+++ b/server/src/db/models/Scenario.ts
@@ -41,8 +41,10 @@ const PredicateSchema = new Schema<PersistedPredicate>(
 const idOrIdListValidator = {
   validator: (value: unknown) =>
     value === undefined ||
-    (typeof value === 'string' && value.length > 0) ||
-    (Array.isArray(value) && value.every((entry) => typeof entry === 'string' && entry.length > 0)),
+    (typeof value === 'string' && value.trim().length > 0) ||
+    (Array.isArray(value) &&
+      value.length > 0 &&
+      value.every((entry) => typeof entry === 'string' && entry.trim().length > 0)),
   message: 'Value must be a non-empty string or an array of non-empty strings',
 }
 

--- a/server/src/db/models/Scenario.ts
+++ b/server/src/db/models/Scenario.ts
@@ -37,12 +37,21 @@ const PredicateSchema = new Schema<PersistedPredicate>(
   embeddedSchemaOptions,
 )
 
+// A single identifier restricts to one schema/creddef; an array expresses an OR of alternatives
+const idOrIdListValidator = {
+  validator: (value: unknown) =>
+    value === undefined ||
+    (typeof value === 'string' && value.length > 0) ||
+    (Array.isArray(value) && value.every((entry) => typeof entry === 'string' && entry.length > 0)),
+  message: 'Value must be a non-empty string or an array of non-empty strings',
+}
+
 const CredentialRequestSchema = new Schema<PersistedCredentialRequest>(
   {
     name: { type: String, required: true },
     icon: String,
-    schema_id: String,
-    cred_def_id: String,
+    schema_id: { type: Schema.Types.Mixed, validate: idOrIdListValidator },
+    cred_def_id: { type: Schema.Types.Mixed, validate: idOrIdListValidator },
     cred_id: String,
     predicates: [PredicateSchema],
     properties: [String],


### PR DESCRIPTION
This PR add support for custom proof-request configurations: an advanced panel with JSON configuration is now available in the builder, allowing users more freedom when defining a proof-request.

The restrictions have also been updated to allow `OR` constraints in the proof request: schema and creddef id now support both a string identifier as well as an array of identifiers that will be joined in an `OR` clause.