### PR TITLE
reset completed preferences

### DIFF
--- a/frontend/src/client/slices/preferences/preferencesSlice.ts
+++ b/frontend/src/client/slices/preferences/preferencesSlice.ts
@@ -73,6 +73,9 @@ const preferencesSlice = createSlice({
       .addCase('demo/RESET', (state) => {
         state.darkMode = localStorage.getItem('theme') === 'dark'
         state.connectionDate = undefined
+        state.completedScenarioSlugs = []
+        state.completeCanceled = false
+        state.demoCompleted = false
       })
       .addCase(fetchLastServerReset.fulfilled, (state, action) => {
         state.lastServerReset = action.payload


### PR DESCRIPTION
There was a regression with the latest hidden scenario feature here https://github.com/bcgov/BC-Wallet-Demo/blob/main/frontend/src/client/slices/index.ts#L49 https://github.com/bcgov/BC-Wallet-Demo/pull/600/changes#diff-528036cac026e69379ebb28f4287ab14f9d83be501c12756be4523939da7eea7

The problem is that the scenario completed slug list didn't get reset so this modal state would be set to true when entering the scenario section if a user previously finished the scenarios and the memory cache was saved.